### PR TITLE
Fix SDK name for macOS

### DIFF
--- a/Sources/ScipioKit/Compiler.swift
+++ b/Sources/ScipioKit/Compiler.swift
@@ -239,7 +239,6 @@ struct Compiler<E: Executor> {
                 ("scheme", context.target.name),
                 ("archivePath", xcArchivePath.pathString),
                 ("destination", context.sdk.destination),
-                ("sdk", context.sdk.name),
             ].map(Pair.init(key:value:))
         }
 


### PR DESCRIPTION
The SDK name for macOS is not correct.
As a result, scipio cannot make xcframewrok for macOS.
I fixed the SDK name in this PR.