### PR TITLE
Support Static Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ All XCFrameworks are generated into `MyAppDependencies/XCFramework` in default.
 |-\-configuration, -c|Build configuration for generated frameworks (debug / release)|release|
 |-\-output, -o|Path indicates a XCFrameworks output directory|$PACKAGE_ROOT/XCFrameworks|
 |-\-embed-debug-symbols|Whether embed debug symbols to frameworks or not|-|
-|-\--static|Whether generated frameworks is a Static Framework or not|-|
+|-\--static|Whether generated frameworks are Static Frameworks or not|-|
 |-\-support-simulators|Whether also building for simulators of each SDKs or not|-|
 |-\-cache-policy|How to reuse built frameworks|project|
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ All XCFrameworks are generated into `MyAppDependencies/XCFramework` in default.
 |-\-configuration, -c|Build configuration for generated frameworks (debug / release)|release|
 |-\-output, -o|Path indicates a XCFrameworks output directory|$PACKAGE_ROOT/XCFrameworks|
 |-\-embed-debug-symbols|Whether embed debug symbols to frameworks or not|-|
+|-\--static|Whether generated frameworks is a Static Framework or not|-|
 |-\-support-simulators|Whether also building for simulators of each SDKs or not|-|
 |-\-cache-policy|How to reuse built frameworks|project|
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ They are stored on `$OUTPUT_DIR/.$FRAMEWORK_NAME.version` as a JSON file.
   "buildOptions" : {
     "buildConfiguration" : "release",
     "isDebugSymbolsEmbedded" : false,
+    "frameworkType" : "dynamic",
     "sdks" : [
       "iOS"
     ],

--- a/Sources/ScipioKit/BuildOptions.swift
+++ b/Sources/ScipioKit/BuildOptions.swift
@@ -4,6 +4,7 @@ struct BuildOptions: Hashable, Codable {
    var buildConfiguration: BuildConfiguration
     var isSimulatorSupported: Bool
     var isDebugSymbolsEmbedded: Bool
+    var frameworkType: FrameworkType
     var sdks: [SDK]
 }
 
@@ -17,6 +18,11 @@ public enum BuildConfiguration: String, Codable {
         case .release: return "Release"
         }
     }
+}
+
+public enum FrameworkType: String, Codable {
+    case dynamic
+    case `static`
 }
 
 enum SDK: String, Codable {

--- a/Sources/ScipioKit/ProjectGenerator.swift
+++ b/Sources/ScipioKit/ProjectGenerator.swift
@@ -16,7 +16,11 @@ struct ProjectGenerator {
     }
 
     @discardableResult
-    func generate(for package: Package, embedDebugSymbols isDebugSymbolsEmbedded: Bool) throws -> Result {
+    func generate(
+        for package: Package,
+        embedDebugSymbols isDebugSymbolsEmbedded: Bool,
+        frameworkType: FrameworkType
+    ) throws -> Result {
         let projectPath = package.projectPath
 
         let project = try pbxproj(

--- a/Sources/ScipioKit/ProjectGenerator.swift
+++ b/Sources/ScipioKit/ProjectGenerator.swift
@@ -67,6 +67,7 @@ struct ProjectGenerator {
         BUILD_LIBRARY_FOR_DISTRIBUTION = YES
         ENABLE_BITCODE = YES
         OTHER_CFLAGS = -fembed-bitcode
+        MACH_O_TYPE = staticlib
         """
         if embedDebugSymbols {
             let debugSymbol = """

--- a/Sources/ScipioKit/ProjectGenerator.swift
+++ b/Sources/ScipioKit/ProjectGenerator.swift
@@ -64,7 +64,7 @@ struct ProjectGenerator {
 
         let isStaticFramework = frameworkType == .static
         let xcConfigData = makeXCConfigData(
-            shouldEmbedDebugSymbols: isDebugSymbolsEmbedded,
+            isDebugSymbolsEmbedded: isDebugSymbolsEmbedded,
             isStaticFramework: isStaticFramework
         )
         try fileSystem.writeFileContents(distributionXCConfigPath,
@@ -100,12 +100,12 @@ struct ProjectGenerator {
         return .init(project: project, projectPath: projectPath)
     }
 
-    private func makeXCConfigData(shouldEmbedDebugSymbols: Bool, isStaticFramework: Bool) -> Data {
+    private func makeXCConfigData(isDebugSymbolsEmbedded: Bool, isStaticFramework: Bool) -> Data {
         var configs: [String: any XCConfigValue] = [
             "BUILD_LIBRARY_FOR_DISTRIBUTION": true,
         ]
 
-        if shouldEmbedDebugSymbols {
+        if isDebugSymbolsEmbedded {
             configs["DEBUG_INFORMATION_FORMAT"] = "dwarf-with-dsym"
         }
 

--- a/Sources/ScipioKit/ProjectGenerator.swift
+++ b/Sources/ScipioKit/ProjectGenerator.swift
@@ -3,28 +3,28 @@ import Xcodeproj
 import TSCBasic
 import Basics
 
-protocol XCConfigValue {
-    var value: String { get }
+struct XCConfigValue {
+    let rawString: String
 }
 
-extension Bool: XCConfigValue {
-    var value: String {
-        self ? "YES" : "NO"
+extension XCConfigValue: ExpressibleByBooleanLiteral {
+    init(booleanLiteral value: BooleanLiteralType) {
+        self.rawString = value ? "YES" : "NO"
     }
 }
 
-extension String: XCConfigValue {
-    var value: String {
-        self
+extension XCConfigValue: ExpressibleByStringLiteral {
+    init(stringLiteral value: StringLiteralType) {
+        self.rawString = value
     }
 }
 
 struct XCConfigEncoder {
-    func generate(configs: [String: any XCConfigValue]) -> Data {
+    func generate(configs: [String: XCConfigValue]) -> Data {
         configs
             .sorted { $0.key < $1.key }
             .map { pair -> String in
-                 "\(pair.key) = \(pair.value.value)"
+                "\(pair.key) = \(pair.value.rawString)"
              }
              .joined(separator: "\n")
              .data(using: .utf8)!
@@ -101,7 +101,7 @@ struct ProjectGenerator {
     }
 
     private func makeXCConfigData(isDebugSymbolsEmbedded: Bool, isStaticFramework: Bool) -> Data {
-        var configs: [String: any XCConfigValue] = [
+        var configs: [String: XCConfigValue] = [
             "BUILD_LIBRARY_FOR_DISTRIBUTION": true,
         ]
 

--- a/Sources/ScipioKit/ProjectGenerator.swift
+++ b/Sources/ScipioKit/ProjectGenerator.swift
@@ -24,10 +24,10 @@ struct XCConfigEncoder {
         configs
             .sorted { $0.key < $1.key }
             .map { pair -> String in
-            "\(pair.key) = \(pair.value.value)"
-        }
-        .joined(separator: "\n")
-        .data(using: .utf8)!
+                 "\(pair.key) = \(pair.value.value)"
+             }
+             .joined(separator: "\n")
+             .data(using: .utf8)!
     }
 }
 

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -33,10 +33,11 @@ public struct Runner {
     }
 
     public struct Options {
-        public init(buildConfiguration: BuildConfiguration, isSimulatorSupported: Bool, isDebugSymbolsEmbedded: Bool, outputDirectory: URL? = nil, cacheMode: CacheMode, verbose: Bool) {
+        public init(buildConfiguration: BuildConfiguration, isSimulatorSupported: Bool, isDebugSymbolsEmbedded: Bool, frameworkType: FrameworkType, outputDirectory: URL? = nil, cacheMode: CacheMode, verbose: Bool) {
             self.buildConfiguration = buildConfiguration
             self.isSimulatorSupported = isSimulatorSupported
             self.isDebugSymbolsEmbedded = isDebugSymbolsEmbedded
+            self.frameworkType = frameworkType
             self.outputDirectory = outputDirectory
             self.cacheMode = cacheMode
             self.verbose = verbose
@@ -45,6 +46,7 @@ public struct Runner {
         public var buildConfiguration: BuildConfiguration
         public var isSimulatorSupported: Bool
         public var isDebugSymbolsEmbedded: Bool
+        public var frameworkType: FrameworkType
         public var outputDirectory: URL?
         public var cacheMode: CacheMode
         public var verbose: Bool

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -121,6 +121,7 @@ public struct Runner {
         let buildOptions = BuildOptions(buildConfiguration: options.buildConfiguration,
                                         isSimulatorSupported: options.isSimulatorSupported,
                                         isDebugSymbolsEmbedded: options.isDebugSymbolsEmbedded,
+                                        frameworkType: .dynamic,
                                         sdks: sdks)
         try fileSystem.createDirectory(package.workspaceDirectory, recursive: true)
 
@@ -128,7 +129,9 @@ public struct Runner {
         try await resolver.resolve()
 
         let generator = ProjectGenerator()
-        try generator.generate(for: package, embedDebugSymbols: buildOptions.isDebugSymbolsEmbedded)
+        try generator.generate(for: package,
+                               embedDebugSymbols: buildOptions.isDebugSymbolsEmbedded,
+                               frameworkType: buildOptions.frameworkType)
 
         let outputDir = frameworkOutputDir.resolve(packageDirectory: packageDirectory)
         

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -123,7 +123,7 @@ public struct Runner {
         let buildOptions = BuildOptions(buildConfiguration: options.buildConfiguration,
                                         isSimulatorSupported: options.isSimulatorSupported,
                                         isDebugSymbolsEmbedded: options.isDebugSymbolsEmbedded,
-                                        frameworkType: .dynamic,
+                                        frameworkType: options.frameworkType,
                                         sdks: sdks)
         try fileSystem.createDirectory(package.workspaceDirectory, recursive: true)
 

--- a/Sources/scipio/Arguments.swift
+++ b/Sources/scipio/Arguments.swift
@@ -20,5 +20,3 @@ extension BuildConfiguration: ExpressibleByArgument {
         }
     }
 }
-
-extension FrameworkType: ExpressibleByArgument { }

--- a/Sources/scipio/Arguments.swift
+++ b/Sources/scipio/Arguments.swift
@@ -20,3 +20,5 @@ extension BuildConfiguration: ExpressibleByArgument {
         }
     }
 }
+
+extension FrameworkType: ExpressibleByArgument { }

--- a/Sources/scipio/CreateCommands.swift
+++ b/Sources/scipio/CreateCommands.swift
@@ -24,6 +24,7 @@ extension Scipio {
                                     buildConfiguration: buildOptions.buildConfiguration,
                                     isSimulatorSupported: buildOptions.supportSimulators,
                                     isDebugSymbolsEmbedded: buildOptions.embedDebugSymbols,
+                                    frameworkType: buildOptions.frameworkType,
                                     cacheMode: .disabled,
                                     verbose: globalOptions.verbose)
             )

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -25,7 +25,7 @@ struct BuildOptionGroup: ParsableArguments {
           help: "Whether also building for simulators of each SDKs or not.")
     var supportSimulators = false
 
-    @Flag(name: [.customLong("--static")],
+    @Flag(name: [.customLong("static")],
           help: "Whether generated frameworks are Static Frameworks or not")
     var shouldBuildStaticFramework = false
 }

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -17,6 +17,10 @@ struct BuildOptionGroup: ParsableArguments {
             help: "Build configuration for generated frameworks. (debug / release)")
     var buildConfiguration: BuildConfiguration = .release
 
+    @Option(name: [.customLong("framework-type"), .customShort("t")],
+            help: "Framework type for generated frameworks. (dynamic / static)")
+    var frameworkType: FrameworkType
+
     @Flag(name: .customLong("embed-debug-symbols"),
           help: "Whether embed debug symbols to frameworks or not.")
     var embedDebugSymbols = false

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -26,7 +26,7 @@ struct BuildOptionGroup: ParsableArguments {
     var supportSimulators = false
 
     @Flag(name: [.customLong("--static")],
-          help: "Whether generated frameworks is a Static Framework or not")
+          help: "Whether generated frameworks are Static Frameworks or not")
     var shouldBuildStaticFramework = false
 }
 

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -17,10 +17,6 @@ struct BuildOptionGroup: ParsableArguments {
             help: "Build configuration for generated frameworks. (debug / release)")
     var buildConfiguration: BuildConfiguration = .release
 
-    @Option(name: [.customLong("framework-type"), .customShort("t")],
-            help: "Framework type for generated frameworks. (dynamic / static)")
-    var frameworkType: FrameworkType
-
     @Flag(name: .customLong("embed-debug-symbols"),
           help: "Whether embed debug symbols to frameworks or not.")
     var embedDebugSymbols = false
@@ -28,4 +24,14 @@ struct BuildOptionGroup: ParsableArguments {
     @Flag(name: .customLong("support-simulators"),
           help: "Whether also building for simulators of each SDKs or not.")
     var supportSimulators = false
+
+    @Flag(name: [.customLong("--static")],
+          help: "Whether generated frameworks is a Static Framework or not")
+    var shouldBuildStaticFramework = false
+}
+
+extension BuildOptionGroup {
+    var frameworkType: FrameworkType {
+        shouldBuildStaticFramework ? .static : .dynamic
+    }
 }

--- a/Sources/scipio/PrepareCommands.swift
+++ b/Sources/scipio/PrepareCommands.swift
@@ -46,6 +46,7 @@ extension Scipio {
                     buildConfiguration: buildOptions.buildConfiguration,
                     isSimulatorSupported: buildOptions.supportSimulators,
                     isDebugSymbolsEmbedded: buildOptions.embedDebugSymbols,
+                    frameworkType: buildOptions.frameworkType,
                     cacheMode: runnerCacheMode,
                     verbose: globalOptions.verbose)
             )

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -27,6 +27,7 @@ InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault
                                 buildOptions: .init(buildConfiguration: .release,
                                                     isSimulatorSupported: false,
                                                     isDebugSymbolsEmbedded: false,
+                                                    frameworkType: .dynamic,
                                                     sdks: [.iOS]),
                                 clangVersion: "clang-1400.0.29.102")
         let encoder = JSONEncoder()
@@ -38,6 +39,7 @@ InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault
   "buildOptions" : {
     "buildConfiguration" : "release",
     "isDebugSymbolsEmbedded" : false,
+    "frameworkType" : "dynamic",
     "sdks" : [
       "iOS"
     ],

--- a/Tests/ScipioKitTests/PrepareTests.swift
+++ b/Tests/ScipioKitTests/PrepareTests.swift
@@ -65,6 +65,7 @@ final class PrepareTests: XCTestCase {
                                       buildOptions: .init(buildConfiguration: .release,
                                                           isSimulatorSupported: false,
                                                           isDebugSymbolsEmbedded: false,
+                                                          frameworkType: .dynamic,
                                                           sdks: [.iOS]),
                                       outputDirectory: frameworkOutputDir,
                                       storage: nil)

--- a/Tests/ScipioKitTests/PrepareTests.swift
+++ b/Tests/ScipioKitTests/PrepareTests.swift
@@ -29,6 +29,7 @@ final class PrepareTests: XCTestCase {
                 buildConfiguration: .release,
                 isSimulatorSupported: false,
                 isDebugSymbolsEmbedded: false,
+                frameworkType: .dynamic,
                 cacheMode: .disabled,
                 verbose: true))
         do {
@@ -88,6 +89,7 @@ final class PrepareTests: XCTestCase {
                 buildConfiguration: .release,
                 isSimulatorSupported: false,
                 isDebugSymbolsEmbedded: false,
+                frameworkType: .dynamic,
                 cacheMode: .project,
                 verbose: false)
         )
@@ -127,6 +129,7 @@ final class PrepareTests: XCTestCase {
                 buildConfiguration: .release,
                 isSimulatorSupported: false,
                 isDebugSymbolsEmbedded: false,
+                frameworkType: .dynamic,
                 cacheMode: .storage(storage),
                 verbose: false)
         )

--- a/Tests/ScipioKitTests/XCConfigEncoderTests.swift
+++ b/Tests/ScipioKitTests/XCConfigEncoderTests.swift
@@ -5,15 +5,15 @@ import XCTest
 final class XCConfigEncoderTests: XCTestCase {
     func testEncode() {
         let encoder = XCConfigEncoder()
-        let configs: [String: any XCConfigValue] = [
+        let configs: [String: XCConfigValue] = [
             "MACH_O_TYPE": "staticlib",
-            "ENABLE_BITCODE": true,
+            "BUILD_LIBRARY_FOR_DISTRIBUTION": true,
         ]
         let data = encoder.generate(configs: configs)
         XCTAssertEqual(
             String(data: data, encoding: .utf8),
             """
-            ENABLE_BITCODE = YES
+            BUILD_LIBRARY_FOR_DISTRIBUTION = YES
             MACH_O_TYPE = staticlib
             """
         )

--- a/Tests/ScipioKitTests/XCConfigEncoderTests.swift
+++ b/Tests/ScipioKitTests/XCConfigEncoderTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+@testable import ScipioKit
+import XCTest
+
+final class XCConfigEncoderTests: XCTestCase {
+    func testEncode() {
+        let encoder = XCConfigEncoder()
+        let configs: [String: any XCConfigValue] = [
+            "MACH_O_TYPE": "staticlib",
+            "ENABLE_BITCODE": true,
+        ]
+        let data = encoder.generate(configs: configs)
+        XCTAssertEqual(
+            String(data: data, encoding: .utf8),
+            """
+            ENABLE_BITCODE = YES
+            MACH_O_TYPE = staticlib
+            """
+        )
+    }
+}


### PR DESCRIPTION
Add `--static` flag to generate Static Frameworks.

```
$ scipio prepare MyDependencies --static
$ file XCFrameworks/MyFramework.xcframework/ios-arm64/MyFramework.framework/MyFramework
XCFrameworks/MyFramework.xcframework/ios-arm64/MyFramework.framework/MyFramework: current ar archive
```