### PR TITLE
Remove swift-support-tools-core

### DIFF
--- a/Sources/ScipioKit/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Cache/CacheSystem.swift
@@ -109,7 +109,7 @@ struct CacheSystem {
     enum Error: LocalizedError {
         case revisionNotDetected(String)
         case compilerVersionNotDetected
-        case couldNotReadVersionFile(Foundation.URL)
+        case couldNotReadVersionFile(URL)
 
         var errorDescription: String? {
             switch self {

--- a/Sources/ScipioKit/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Cache/CacheSystem.swift
@@ -157,7 +157,7 @@ struct CacheSystem {
             let versionFilePath = versionFilePath(for: cacheKey.targetName)
             guard fileSystem.exists(versionFilePath) else { return false }
             let decoder = JSONDecoder()
-            guard let contents = fileSystem.contents(at: versionFilePath) else {
+            guard let contents = fileSystem.contents(of: versionFilePath) else {
                 throw Error.couldNotReadVersionFile(versionFilePath)
             }
             let versionFileKey = try decoder.decode(CacheKey.self, from: contents)

--- a/Sources/ScipioKit/Cache/LocalCacheStorage.swift
+++ b/Sources/ScipioKit/Cache/LocalCacheStorage.swift
@@ -1,10 +1,8 @@
 import Foundation
-import TSCUtility
 import PackageGraph
-import TSCBasic
 
 public struct LocalCacheStorage: CacheStorage {
-    private let fileSystem: any ScipioKit.FileSystem
+    private let fileSystem: any FileSystem
 
     enum Error: Swift.Error {
         case cacheDirectoryIsNotFound
@@ -12,17 +10,17 @@ public struct LocalCacheStorage: CacheStorage {
 
     public enum CacheDirectory {
         case system
-        case custom(AbsolutePath)
+        case custom(URL)
     }
 
     private let cacheDirectroy: CacheDirectory
 
-    public init(cacheDirectory: CacheDirectory = .system, fileSystem: ScipioKit.FileSystem = ScipioKit.localFileSystem) {
+    public init(cacheDirectory: CacheDirectory = .system, fileSystem: FileSystem = localFileSystem) {
         self.cacheDirectroy = cacheDirectory
         self.fileSystem = fileSystem
     }
 
-    private func buildBaseDirectoryPath() throws -> AbsolutePath {
+    private func buildBaseDirectoryPath() throws -> URL {
         let cacheDir: Foundation.URL
         switch cacheDirectroy {
         case .system:
@@ -31,45 +29,48 @@ public struct LocalCacheStorage: CacheStorage {
             }
             cacheDir = systemCacheDir
         case .custom(let customPath):
-            cacheDir = customPath.asURL
+            cacheDir = customPath
         }
-        return AbsolutePath(cacheDir.appendingPathComponent("Scipio").path)
+        return cacheDir.appendingPathComponent("Scipio")
     }
 
     private func xcFrameworkFileName(for cacheKey: CacheKey) -> String {
         "\(cacheKey.targetName.packageNamed()).xcframework"
     }
 
-    private func cacheFrameworkPath(for cacheKey: CacheKey) throws -> AbsolutePath {
+    private func cacheFrameworkPath(for cacheKey: CacheKey) throws -> URL {
         let baseDirectory = try buildBaseDirectoryPath()
         let checksum = try cacheKey.calculateChecksum()
-        return baseDirectory.appending(components: cacheKey.targetName.packageNamed(), checksum, xcFrameworkFileName(for: cacheKey))
+        return baseDirectory
+            .appendingPathComponent(cacheKey.targetName.packageNamed())
+            .appendingPathComponent(checksum)
+            .appendingPathComponent(xcFrameworkFileName(for: cacheKey))
     }
 
     public func existsValidCache(for cacheKey: CacheKey) async -> Bool {
         do {
             let xcFrameworkPath = try cacheFrameworkPath(for: cacheKey)
-            return fileSystem.exists(xcFrameworkPath.asURL)
+            return fileSystem.exists(xcFrameworkPath)
         } catch {
             return false
         }
     }
 
-    public func cacheFramework(_ frameworkPath: TSCBasic.AbsolutePath, for cacheKey: CacheKey) async {
+    public func cacheFramework(_ frameworkPath: URL, for cacheKey: CacheKey) async {
         do {
             let destination = try cacheFrameworkPath(for: cacheKey)
-            let directoryPath = AbsolutePath(destination.dirname)
+            let directoryPath = destination.deletingLastPathComponent()
 
-            try fileSystem.createDirectory(directoryPath.asURL, recursive: true)
-            try fileSystem.copy(at: frameworkPath.asURL, to: destination.asURL)
+            try fileSystem.createDirectory(directoryPath, recursive: true)
+            try fileSystem.copy(at: frameworkPath, to: destination)
         } catch {
             // ignore error
         }
     }
 
-    public func fetchArtifacts(for cacheKey: CacheKey, to destinationDir: TSCBasic.AbsolutePath) async throws {
+    public func fetchArtifacts(for cacheKey: CacheKey, to destinationDir: URL) async throws {
         let source = try cacheFrameworkPath(for: cacheKey)
-        let destination = destinationDir.appending(component: xcFrameworkFileName(for: cacheKey))
-        try fileSystem.copy(at: source.asURL, to: destination.asURL)
+        let destination = destinationDir.appendingPathComponent(xcFrameworkFileName(for: cacheKey))
+        try fileSystem.copy(at: source, to: destination)
     }
 }

--- a/Sources/ScipioKit/Cache/LocalCacheStorage.swift
+++ b/Sources/ScipioKit/Cache/LocalCacheStorage.swift
@@ -62,7 +62,7 @@ public struct LocalCacheStorage: CacheStorage {
             let directoryPath = destination.deletingLastPathComponent()
 
             try fileSystem.createDirectory(directoryPath, recursive: true)
-            try fileSystem.copy(at: frameworkPath, to: destination)
+            try fileSystem.copy(from: frameworkPath, to: destination)
         } catch {
             // ignore error
         }
@@ -71,6 +71,6 @@ public struct LocalCacheStorage: CacheStorage {
     public func fetchArtifacts(for cacheKey: CacheKey, to destinationDir: URL) async throws {
         let source = try cacheFrameworkPath(for: cacheKey)
         let destination = destinationDir.appendingPathComponent(xcFrameworkFileName(for: cacheKey))
-        try fileSystem.copy(at: source, to: destination)
+        try fileSystem.copy(from: source, to: destination)
     }
 }

--- a/Sources/ScipioKit/Cache/LocalCacheStorage.swift
+++ b/Sources/ScipioKit/Cache/LocalCacheStorage.swift
@@ -21,7 +21,7 @@ public struct LocalCacheStorage: CacheStorage {
     }
 
     private func buildBaseDirectoryPath() throws -> URL {
-        let cacheDir: Foundation.URL
+        let cacheDir: URL
         switch cacheDirectroy {
         case .system:
             guard let systemCacheDir = fileSystem.cachesDirectory else {

--- a/Sources/ScipioKit/Compiler.swift
+++ b/Sources/ScipioKit/Compiler.swift
@@ -14,7 +14,12 @@ struct Compiler<E: Executor> {
         case prepareDependencies
     }
 
-    init(rootPackage: Package, cacheStorage: (any CacheStorage)?, executor: E = ProcessExecutor(), fileSystem: any ScipioKit.FileSystem = ScipioKit.localFileSystem) {
+    init(
+        rootPackage: Package,
+        cacheStorage: (any CacheStorage)?,
+        executor: E = ProcessExecutor(),
+        fileSystem: any ScipioKit.FileSystem = ScipioKit.localFileSystem
+    ) {
         self.rootPackage = rootPackage
         self.cacheStorage = cacheStorage
         self.fileSystem = fileSystem

--- a/Sources/ScipioKit/Compiler.swift
+++ b/Sources/ScipioKit/Compiler.swift
@@ -1,11 +1,10 @@
 import Foundation
 import PackageGraph
-import TSCBasic
 
 struct Compiler<E: Executor> {
     let rootPackage: Package
     let cacheStorage: (any CacheStorage)?
-    let fileSystem: any ScipioKit.FileSystem
+    let fileSystem: any FileSystem
     private let xcodebuild: XcodeBuildClient<E>
     private let extractor: DwarfExtractor<E>
 
@@ -18,7 +17,7 @@ struct Compiler<E: Executor> {
         rootPackage: Package,
         cacheStorage: (any CacheStorage)?,
         executor: E = ProcessExecutor(),
-        fileSystem: any ScipioKit.FileSystem = ScipioKit.localFileSystem
+        fileSystem: any FileSystem = localFileSystem
     ) {
         self.rootPackage = rootPackage
         self.cacheStorage = cacheStorage
@@ -27,15 +26,15 @@ struct Compiler<E: Executor> {
         self.extractor = DwarfExtractor(executor: executor)
     }
 
-    private func buildArtifactsDirectoryPath(buildConfiguration: BuildConfiguration, sdk: SDK) -> AbsolutePath {
-        rootPackage.workspaceDirectory.appending(component: "\(buildConfiguration.settingsValue)-\(sdk.name)")
+    private func buildArtifactsDirectoryPath(buildConfiguration: BuildConfiguration, sdk: SDK) -> URL {
+        rootPackage.workspaceDirectory.appendingPathComponent("\(buildConfiguration.settingsValue)-\(sdk.name)")
     }
 
-    private func buildDebugSymbolPath(buildConfiguration: BuildConfiguration, sdk: SDK, target: ResolvedTarget) -> AbsolutePath {
-        buildArtifactsDirectoryPath(buildConfiguration: buildConfiguration, sdk: sdk).appending(component: "\(target).framework.dSYM")
+    private func buildDebugSymbolPath(buildConfiguration: BuildConfiguration, sdk: SDK, target: ResolvedTarget) -> URL {
+        buildArtifactsDirectoryPath(buildConfiguration: buildConfiguration, sdk: sdk).appendingPathComponent("\(target).framework.dSYM")
     }
 
-    func build(mode: BuildMode, buildOptions: BuildOptions, outputDir: AbsolutePath, isCacheEnabled: Bool) async throws {
+    func build(mode: BuildMode, buildOptions: BuildOptions, outputDir: URL, isCacheEnabled: Bool) async throws {
         let cacheSystem = CacheSystem(rootPackage: rootPackage,
                                       buildOptions: buildOptions,
                                       outputDirectory: outputDir,
@@ -62,8 +61,8 @@ struct Compiler<E: Executor> {
         for subPackage in packages {
             for target in subPackage.targets where target.type == .library {
                 let frameworkName = frameworkName(for: target)
-                let xcframeworkPath = outputDir.appending(component: frameworkName)
-                let exists = fileSystem.exists(xcframeworkPath.asURL)
+                let xcframeworkPath = outputDir.appendingPathComponent(frameworkName)
+                let exists = fileSystem.exists(xcframeworkPath)
 
                 if exists {
                     if isCacheEnabled {
@@ -74,13 +73,13 @@ struct Compiler<E: Executor> {
                         } else {
                             logger.warning("⚠️ Existing \(frameworkName) is outdated.", metadata: .color(.yellow))
                             logger.info("💥 Delete \(frameworkName)", metadata: .color(.red))
-                            try fileSystem.removeFileTree(at: xcframeworkPath.asURL)
+                            try fileSystem.removeFileTree(at: xcframeworkPath)
                         }
                     }
-                    try fileSystem.removeFileTree(at: xcframeworkPath.asURL)
+                    try fileSystem.removeFileTree(at: xcframeworkPath)
                 }
 
-                let frameworkPath = outputDir.appending(component: frameworkName)
+                let frameworkPath = outputDir.appendingPathComponent(frameworkName)
                 if await cacheSystem.restoreCacheIfPossible(subPackage: subPackage, target: target) {
                     logger.info("✅ Restore \(frameworkName) from cache storage", metadata: .color(.green))
                 } else {
@@ -112,7 +111,7 @@ struct Compiler<E: Executor> {
                                    buildConfiguration: BuildConfiguration,
                                    isDebugSymbolsEmbedded: Bool,
                                    sdks: Set<SDK>,
-                                   outputDirectory: AbsolutePath) async throws {
+                                   outputDirectory: URL) async throws {
         let sdkNames = sdks.map(\.displayName).joined(separator: ", ")
         logger.info("📦 Building \(target.name) for \(sdkNames)")
 
@@ -122,7 +121,7 @@ struct Compiler<E: Executor> {
 
         logger.info("🚀 Combining into XCFramework...")
 
-        let debugSymbolPaths: [AbsolutePath]?
+        let debugSymbolPaths: [URL]?
         if isDebugSymbolsEmbedded {
             debugSymbolPaths = try await extractDebugSymbolPaths(target: target,
                                                                  buildConfiguration: buildConfiguration,
@@ -145,22 +144,22 @@ struct Compiler<E: Executor> {
         target: ResolvedTarget,
         buildConfiguration: BuildConfiguration,
         sdks: Set<SDK>
-    ) async throws -> [AbsolutePath] {
+    ) async throws -> [URL] {
         let debugSymbols: [DebugSymbol] = sdks.compactMap { sdk in
             let dsymPath = buildDebugSymbolPath(buildConfiguration: buildConfiguration, sdk: sdk, target: target)
-            guard fileSystem.exists(dsymPath.asURL) else { return nil }
+            guard fileSystem.exists(dsymPath) else { return nil }
             return DebugSymbol(dSYMPath: dsymPath,
                                target: target,
                                sdk: sdk,
                                buildConfiguration: buildConfiguration)
         }
         // You can use AsyncStream
-        var symbolMapPaths: [AbsolutePath] = []
+        var symbolMapPaths: [URL] = []
         for dSYMs in debugSymbols {
             let maps = try await self.extractor.dump(dwarfPath: dSYMs.dwarfPath)
             let paths = maps.values.map { uuid in
                 buildArtifactsDirectoryPath(buildConfiguration: dSYMs.buildConfiguration, sdk: dSYMs.sdk)
-                    .appending(component: "\(uuid.uuidString).bcsymbolmap")
+                    .appendingPathComponent("\(uuid.uuidString).bcsymbolmap")
             }
             symbolMapPaths.append(contentsOf: paths)
         }
@@ -174,7 +173,7 @@ struct Compiler<E: Executor> {
 }
 
 extension Package {
-    var archivesPath: AbsolutePath {
-        workspaceDirectory.appending(component: "archives")
+    var archivesPath: URL {
+        workspaceDirectory.appendingPathComponent("archives")
     }
 }

--- a/Sources/ScipioKit/DebugSymbol.swift
+++ b/Sources/ScipioKit/DebugSymbol.swift
@@ -1,15 +1,17 @@
 import Foundation
-import TSCBasic
 import PackageGraph
 
 struct DebugSymbol {
-    var dSYMPath: AbsolutePath
+    var dSYMPath: URL
     var target: ResolvedTarget
     var sdk: SDK
     var buildConfiguration: BuildConfiguration
 
-    var dwarfPath: AbsolutePath {
-        dSYMPath.appending(components: "Contents", "Resources", "DWARF", target.name)
+    var dwarfPath: URL {
+        dSYMPath.appendingPathComponent("Contents")
+            .appendingPathComponent("Resources")
+            .appendingPathComponent("DWARF")
+            .appendingPathComponent(target.name)
     }
 }
 
@@ -21,8 +23,8 @@ struct DwarfExtractor<E: Executor> {
     }
 
     typealias Arch = String
-    func dump(dwarfPath: AbsolutePath) async throws -> [Arch: UUID] {
-        let result = try await executor.execute("/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.pathString)
+    func dump(dwarfPath: URL) async throws -> [Arch: UUID] {
+        let result = try await executor.execute("/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.path)
 
         let output = try result.unwrapOutput()
 

--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -1,5 +1,6 @@
 import Foundation
-import TSCBasic
+import class TSCBasic.Process
+import struct TSCBasic.ProcessResult
 
 protocol Executor {
     @discardableResult

--- a/Sources/ScipioKit/FileSystem.swift
+++ b/Sources/ScipioKit/FileSystem.swift
@@ -1,16 +1,16 @@
 import Foundation
 
 public protocol FileSystem {
-    @discardableResult
-    func write(_ data: Data, to path: URL) -> Bool
+    var currentWorkingDirectory: URL? { get }
+    var cachesDirectory: URL? { get }
+
     func exists(_ path: URL) -> Bool
     func contents(of path: URL) -> Data?
-    @discardableResult
-    func changeCurrentWorkingDirectory(to destination: URL) -> Bool
-    var currentWorkingDirectory: URL? { get }
+
+    @discardableResult func write(_ data: Data, to path: URL) -> Bool
+    @discardableResult func changeCurrentWorkingDirectory(to destination: URL) -> Bool
     func createDirectory(_ path: URL, recursive: Bool) throws
     func copy(from source: URL, to destination: URL) throws
-    var cachesDirectory: URL? { get }
     func removeFileTree(at path: URL) throws
 }
 

--- a/Sources/ScipioKit/FileSystem.swift
+++ b/Sources/ScipioKit/FileSystem.swift
@@ -4,12 +4,12 @@ public protocol FileSystem {
     @discardableResult
     func write(_ data: Data, to path: URL) -> Bool
     func exists(_ path: URL) -> Bool
-    func contents(at path: URL) -> Data?
+    func contents(of path: URL) -> Data?
     @discardableResult
     func changeCurrentWorkingDirectory(to destination: URL) -> Bool
     var currentWorkingDirectory: URL? { get }
     func createDirectory(_ path: URL, recursive: Bool) throws
-    func copy(at source: URL, to destination: URL) throws
+    func copy(from source: URL, to destination: URL) throws
     var cachesDirectory: URL? { get }
     func removeFileTree(at path: URL) throws
 }
@@ -30,7 +30,7 @@ struct LocalFileSystem: FileSystem {
         fileManager.fileExists(atPath: path.path)
     }
 
-    func contents(at path: URL) -> Data? {
+    func contents(of path: URL) -> Data? {
         fileManager.contents(atPath: path.path)
     }
 
@@ -46,7 +46,7 @@ struct LocalFileSystem: FileSystem {
         try fileManager.createDirectory(at: path, withIntermediateDirectories: recursive)
     }
 
-    func copy(at source: URL, to destination: URL) throws {
+    func copy(from source: URL, to destination: URL) throws {
         try fileManager.copyItem(at: source, to: destination)
     }
 

--- a/Sources/ScipioKit/FileSystem.swift
+++ b/Sources/ScipioKit/FileSystem.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public protocol FileSystem {
+    @discardableResult
+    func write(_ data: Data, to path: URL) -> Bool
+    func exists(_ path: URL) -> Bool
+    func contents(at path: URL) -> Data?
+    @discardableResult
+    func changeCurrentWorkingDirectory(to destination: URL) -> Bool
+    var currentWorkingDirectory: URL? { get }
+    func createDirectory(_ path: URL, recursive: Bool) throws
+    func copy(at source: URL, to destination: URL) throws
+    var cachesDirectory: URL? { get }
+    func removeFileTree(at path: URL) throws
+}
+
+public let localFileSystem: FileSystem = LocalFileSystem()
+
+struct LocalFileSystem: FileSystem {
+    private let fileManager: FileManager = .default
+
+    fileprivate init() { }
+
+    func write(_ data: Data, to path: URL) -> Bool {
+        fileManager.createFile(atPath: path.path,
+                               contents: data)
+    }
+
+    func exists(_ path: URL) -> Bool {
+        fileManager.fileExists(atPath: path.path)
+    }
+
+    func contents(at path: URL) -> Data? {
+        fileManager.contents(atPath: path.path)
+    }
+
+    func changeCurrentWorkingDirectory(to destination: URL) -> Bool {
+        fileManager.changeCurrentDirectoryPath(destination.path)
+    }
+
+    var currentWorkingDirectory: URL? {
+        URL(fileURLWithPath: fileManager.currentDirectoryPath)
+    }
+
+    func createDirectory(_ path: URL, recursive: Bool) throws {
+        try fileManager.createDirectory(at: path, withIntermediateDirectories: recursive)
+    }
+
+    func copy(at source: URL, to destination: URL) throws {
+        try fileManager.copyItem(at: source, to: destination)
+    }
+
+    var cachesDirectory: URL? {
+        fileManager.urls(for: .cachesDirectory,
+                         in: .userDomainMask).first
+    }
+
+    func removeFileTree(at path: URL) throws {
+        try fileManager.removeItem(at: path)
+    }
+}

--- a/Sources/ScipioKit/FileSystem.swift
+++ b/Sources/ScipioKit/FileSystem.swift
@@ -14,7 +14,7 @@ public protocol FileSystem {
     func removeFileTree(at path: URL) throws
 }
 
-public let localFileSystem: FileSystem = LocalFileSystem()
+public let localFileSystem: some FileSystem = LocalFileSystem()
 
 struct LocalFileSystem: FileSystem {
     private let fileManager: FileManager = .default

--- a/Sources/ScipioKit/ProjectGenerator.swift
+++ b/Sources/ScipioKit/ProjectGenerator.swift
@@ -79,6 +79,8 @@ struct ProjectGenerator {
             target.buildSettings.xcconfigFileRef = reference
         }
 
+        try fileSystem.createDirectory(projectPath.asURL, recursive: true)
+
         for target in project.frameworkTargets {
             let name = "\(target.name.spm_mangledToC99ExtendedIdentifier())_Info.plist"
             let path = projectPath.asURL.appendingPathComponent(name)

--- a/Sources/ScipioKit/Resolver.swift
+++ b/Sources/ScipioKit/Resolver.swift
@@ -4,9 +4,9 @@ import TSCBasic
 struct Resolver<E: Executor> {
     private let package: Package
     private let executor: E
-    private let fileSystem: any FileSystem
+    private let fileSystem: any ScipioKit.FileSystem
 
-    init(package: Package, executor: E = ProcessExecutor(), fileSystem: any FileSystem = localFileSystem) {
+    init(package: Package, executor: E = ProcessExecutor(), fileSystem: any ScipioKit.FileSystem = ScipioKit.localFileSystem) {
         self.package = package
         self.executor = executor
         self.fileSystem = fileSystem
@@ -15,7 +15,7 @@ struct Resolver<E: Executor> {
     func resolve() async throws {
         logger.info("🔁 Resolving Dependencies...")
 
-        try fileSystem.changeCurrentWorkingDirectory(to: package.packageDirectory)
+        fileSystem.changeCurrentWorkingDirectory(to: package.packageDirectory.asURL)
         try await executor.execute("/usr/bin/xcrun", "swift", "package", "resolve")
     }
 }

--- a/Sources/ScipioKit/Resolver.swift
+++ b/Sources/ScipioKit/Resolver.swift
@@ -1,12 +1,11 @@
 import Foundation
-import TSCBasic
 
 struct Resolver<E: Executor> {
     private let package: Package
     private let executor: E
-    private let fileSystem: any ScipioKit.FileSystem
+    private let fileSystem: any FileSystem
 
-    init(package: Package, executor: E = ProcessExecutor(), fileSystem: any ScipioKit.FileSystem = ScipioKit.localFileSystem) {
+    init(package: Package, executor: E = ProcessExecutor(), fileSystem: any FileSystem = localFileSystem) {
         self.package = package
         self.executor = executor
         self.fileSystem = fileSystem
@@ -15,7 +14,7 @@ struct Resolver<E: Executor> {
     func resolve() async throws {
         logger.info("🔁 Resolving Dependencies...")
 
-        fileSystem.changeCurrentWorkingDirectory(to: package.packageDirectory.asURL)
+        fileSystem.changeCurrentWorkingDirectory(to: package.packageDirectory)
         try await executor.execute("/usr/bin/xcrun", "swift", "package", "resolve")
     }
 }

--- a/Sources/ScipioKit/XcodeBuild/Commands/ArchiveCommand.swift
+++ b/Sources/ScipioKit/XcodeBuild/Commands/ArchiveCommand.swift
@@ -1,4 +1,4 @@
-import TSCBasic
+import Foundation
 import PackageGraph
 
 struct ArchiveCommand: XcodeBuildCommand {
@@ -12,28 +12,28 @@ struct ArchiveCommand: XcodeBuildCommand {
 
     var options: [XcodeBuildOption] {
         [
-            ("project", projectPath.pathString),
+            ("project", projectPath.path),
             ("configuration", buildConfiguration.settingsValue),
             ("scheme", target.name),
-            ("archivePath", xcArchivePath.pathString),
+            ("archivePath", xcArchivePath.path),
             ("destination", sdk.destination),
         ].map(XcodeBuildOption.init(key:value:))
     }
 
     var environmentVariables: [XcodeBuildEnvironmentVariable] {
         [
-            ("BUILD_DIR", package.workspaceDirectory.pathString),
+            ("BUILD_DIR", package.workspaceDirectory.path),
             ("SKIP_INSTALL", "NO"),
         ].map(XcodeBuildEnvironmentVariable.init(key:value:))
     }
 }
 
 extension ArchiveCommand {
-    private var xcArchivePath: AbsolutePath {
+    private var xcArchivePath: URL {
         buildXCArchivePath(package: package, target: target, sdk: sdk)
     }
 
-    private var projectPath: AbsolutePath {
+    private var projectPath: URL {
         package.projectPath
     }
 }

--- a/Sources/ScipioKit/XcodeBuild/Commands/CleanCommand.swift
+++ b/Sources/ScipioKit/XcodeBuild/Commands/CleanCommand.swift
@@ -1,4 +1,4 @@
-import TSCBasic
+import Foundation
 
 struct CleanCommand: XcodeBuildCommand {
 
@@ -7,10 +7,10 @@ struct CleanCommand: XcodeBuildCommand {
     var package: Package
 
     var options: [XcodeBuildOption] {
-        [.init(key: "project", value: package.projectPath.pathString)]
+        [.init(key: "project", value: package.projectPath.path)]
     }
 
     var environmentVariables: [XcodeBuildEnvironmentVariable] {
-        [.init(key: "BUILD_DIR", value: package.workspaceDirectory.pathString)]
+        [.init(key: "BUILD_DIR", value: package.workspaceDirectory.path)]
     }
 }

--- a/Sources/ScipioKit/XcodeBuild/Commands/CreateXCFrameworkCommand.swift
+++ b/Sources/ScipioKit/XcodeBuild/Commands/CreateXCFrameworkCommand.swift
@@ -1,4 +1,4 @@
-import TSCBasic
+import Foundation
 import PackageGraph
 
 struct CreateXCFrameworkCommand: XcodeBuildCommand {
@@ -9,18 +9,18 @@ struct CreateXCFrameworkCommand: XcodeBuildCommand {
     var target: ResolvedTarget
     var buildConfiguration: BuildConfiguration
     var sdks: Set<SDK>
-    var debugSymbolPaths: [AbsolutePath]?
-    var outputDir: AbsolutePath
+    var debugSymbolPaths: [URL]?
+    var outputDir: URL
 
     var options: [XcodeBuildOption] {
         sdks.map { sdk in
-                .init(key: "framework", value: buildFrameworkPath(sdk: sdk).pathString)
+                .init(key: "framework", value: buildFrameworkPath(sdk: sdk).path)
         }
         +
         (debugSymbolPaths.flatMap {
-            $0.map { .init(key: "debug-symbols", value: $0.pathString) }
+            $0.map { .init(key: "debug-symbols", value: $0.path) }
         } ?? [])
-        + [.init(key: "output", value: xcFrameworkPath.pathString)]
+        + [.init(key: "output", value: xcFrameworkPath.path)]
     }
 
     var environmentVariables: [XcodeBuildEnvironmentVariable] {
@@ -29,13 +29,15 @@ struct CreateXCFrameworkCommand: XcodeBuildCommand {
 }
 
 extension CreateXCFrameworkCommand {
-    private var xcFrameworkPath: AbsolutePath {
-        outputDir.appending(component: "\(target.name.packageNamed()).xcframework")
+    private var xcFrameworkPath: URL {
+        outputDir.appendingPathComponent("\(target.name.packageNamed()).xcframework")
     }
 
-    private func buildFrameworkPath(sdk: SDK) -> AbsolutePath {
+    private func buildFrameworkPath(sdk: SDK) -> URL {
         buildXCArchivePath(package: package, target: target, sdk: sdk)
-            .appending(components: "Products", "Library", "Frameworks")
-            .appending(component: "\(target.name.packageNamed()).framework")
+            .appendingPathComponent("Products")
+            .appendingPathComponent("Library")
+            .appendingPathComponent("Frameworks")
+            .appendingPathComponent("\(target.name.packageNamed()).framework")
     }
 }

--- a/Sources/ScipioKit/XcodeBuild/XcodeBuildClient.swift
+++ b/Sources/ScipioKit/XcodeBuild/XcodeBuildClient.swift
@@ -1,4 +1,4 @@
-import TSCBasic
+import Foundation
 import PackageGraph
 
 struct XcodeBuildClient<E: Executor> {
@@ -9,8 +9,8 @@ struct XcodeBuildClient<E: Executor> {
         target: ResolvedTarget,
         buildConfiguration: BuildConfiguration,
         sdks: Set<SDK>,
-        debugSymbolPaths: [AbsolutePath]?,
-        outputDir: AbsolutePath
+        debugSymbolPaths: [URL]?,
+        outputDir: URL
     ) async throws {
         try await executor.execute(CreateXCFrameworkCommand(
             package: package,

--- a/Sources/ScipioKit/XcodeBuild/XcodeBuildCommand.swift
+++ b/Sources/ScipioKit/XcodeBuild/XcodeBuildCommand.swift
@@ -1,5 +1,5 @@
 import PackageGraph
-import TSCBasic
+import Foundation
 
 protocol XcodeBuildCommand {
     var subCommand: String { get }
@@ -32,7 +32,7 @@ extension XcodeBuildCommand {
         package: Package,
         target: ResolvedTarget,
         sdk: SDK
-    ) -> AbsolutePath {
-        package.archivesPath.appending(component: "\(target.name)_\(sdk.name).xcarchive")
+    ) -> URL {
+        package.archivesPath.appendingPathComponent("\(target.name)_\(sdk.name).xcarchive")
     }
 }

--- a/Tests/ScipioKitTests/DebugSymbolTests.swift
+++ b/Tests/ScipioKitTests/DebugSymbolTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import ScipioKit
 import XCTest
-import TSCBasic
 
 final class DwarfExtractorTests: XCTestCase {
     let fixture = "UUID: 1B6B77A9-436C-3A55-884D-4E78EFCAC3ED (arm64) Delegate.framework.dSYM/Contents/Resources/DWARF/Delegate"
@@ -11,11 +10,11 @@ final class DwarfExtractorTests: XCTestCase {
             return StubbableExecutorResult(arguments: arguments, success: self.fixture)
         }
         let extractor = DwarfExtractor(executor: executor)
-        let dwarfPath = AbsolutePath("/dev/null")
+        let dwarfPath = URL(fileURLWithPath: "/dev/null")
         let uuids = try await extractor.dump(dwarfPath: dwarfPath)
 
         let firstArguments = try XCTUnwrap(executor.calledArguments.first)
-        XCTAssertEqual(firstArguments, ["/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.pathString])
+        XCTAssertEqual(firstArguments, ["/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.path])
 
         XCTAssertEqual(uuids.count, 1)
         XCTAssertEqual(uuids["arm64"], UUID(uuidString: "1B6B77A9-436C-3A55-884D-4E78EFCAC3ED"))

--- a/Tests/ScipioKitTests/PackageTests.swift
+++ b/Tests/ScipioKitTests/PackageTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import ScipioKit
 import XCTest
-import TSCBasic
 
 private let fixturePath = URL(fileURLWithPath: #file)
     .deletingLastPathComponent()
@@ -11,7 +10,7 @@ private let fixturePath = URL(fileURLWithPath: #file)
 final class PackageTests: XCTestCase {
     func testPackage() throws {
         let rootPath = fixturePath.appendingPathComponent("TestingPackage")
-        let package = try XCTUnwrap(try Package(packageDirectory: AbsolutePath(rootPath.path)))
+        let package = try XCTUnwrap(try Package(packageDirectory: rootPath))
         XCTAssertEqual(package.name, "TestingPackage")
 
         let packageNames = package.graph.packages.map(\.manifest.displayName)

--- a/Tests/ScipioKitTests/TestingExecutor.swift
+++ b/Tests/ScipioKitTests/TestingExecutor.swift
@@ -1,6 +1,6 @@
 import Foundation
 @testable import ScipioKit
-import TSCBasic
+import struct TSCBasic.ProcessResult
 
 final class StubbableExecutor: Executor {
     init(executeHook: @escaping (([String]) throws -> ExecutorResult)) {
@@ -14,7 +14,7 @@ final class StubbableExecutor: Executor {
         calledArguments.count
     }
 
-    func execute(_ arguments: [String]) async throws -> ScipioKit.ExecutorResult {
+    func execute(_ arguments: [String]) async throws -> ExecutorResult {
         calledArguments.append(arguments)
         return try executeHook(arguments)
     }


### PR DESCRIPTION
related #3 

To remove SwiftPM dependencies, I'm going to drop swift-support-tools-core dependencies.

- Replace `TSCBasic.FileSystem` to original `FileSystem`
- Replace `TSCBasic.AbsolutePath` to `Foundation.URL`

Some implementations still use `TSCBasic`. they will be removed.