### PR TITLE
Use only SwiftPM DataModel

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .target(
             name: "ScipioKit",
             dependencies: [
-                .productItem(name: "SwiftPM", package: "swift-package-manager"),
+                .productItem(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
                 .productItem(name: "Logging", package: "swift-log"),
                 .productItem(name: "Rainbow", package: "Rainbow"),
                 .productItem(name: "XcodeProj", package: "XcodeProj"),


### PR DESCRIPTION
We no longer only need `SwiftPMDataModel`. So I update the dependencies.

`SwiftPMDataModel-auto` is a static linking version of the product.
https://github.com/apple/swift-package-manager/blob/main/Package.swift#L53