### PR TITLE
Introduce PlatformMatrix

### DIFF
--- a/Sources/ScipioKit/BuildOptions.swift
+++ b/Sources/ScipioKit/BuildOptions.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OrderedCollections
 
 struct BuildOptions: Hashable, Codable {
     init(
@@ -6,7 +7,7 @@ struct BuildOptions: Hashable, Codable {
         isSimulatorSupported: Bool,
         isDebugSymbolsEmbedded: Bool,
         frameworkType: FrameworkType,
-        sdks: [SDK]
+        sdks: OrderedSet<SDK>
     ) {
         self.buildConfiguration = buildConfiguration
         self.isSimulatorSupported = isSimulatorSupported
@@ -19,7 +20,7 @@ struct BuildOptions: Hashable, Codable {
     var isSimulatorSupported: Bool
     var isDebugSymbolsEmbedded: Bool
     var frameworkType: FrameworkType
-    var sdks: [SDK]
+    var sdks: OrderedSet<SDK>
 }
 
 public enum BuildConfiguration: String, Codable {
@@ -39,7 +40,7 @@ public enum FrameworkType: String, Codable {
     case `static`
 }
 
-enum SDK: String, Codable {
+public enum SDK: String, Codable {
     case macOS
     case macCatalyst
     case iOS

--- a/Sources/ScipioKit/Package.swift
+++ b/Sources/ScipioKit/Package.swift
@@ -6,6 +6,7 @@ import PackageModel
 import PackageLoading
 import PackageGraph
 import Basics
+import OrderedCollections
 
 struct Package {
     let packageDirectory: URL
@@ -30,8 +31,8 @@ struct Package {
         buildDirectory.appendingPathComponent("\(name).xcodeproj")
     }
 
-    var supportedSDKs: [SDK] {
-        manifest.platforms.map(\.platformName).compactMap(SDK.init(platformName:))
+    var supportedSDKs: OrderedSet<SDK> {
+        OrderedSet(manifest.platforms.map(\.platformName).compactMap(SDK.init(platformName:)))
     }
 
     init(packageDirectory: URL) throws {

--- a/Sources/ScipioKit/Producer/Cleaner.swift
+++ b/Sources/ScipioKit/Producer/Cleaner.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct Cleaner<E: Executor> {
-    let rootPackage: Package
+    private let rootPackage: Package
     private let xcodebuild: XcodeBuildClient<E>
 
     init(rootPackage: Package, executor: E = ProcessExecutor()) {

--- a/Sources/ScipioKit/Producer/Cleaner.swift
+++ b/Sources/ScipioKit/Producer/Cleaner.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct Cleaner<E: Executor> {
+    let rootPackage: Package
+    private let xcodebuild: XcodeBuildClient<E>
+
+    init(rootPackage: Package, executor: E = ProcessExecutor()) {
+        self.rootPackage = rootPackage
+        self.xcodebuild = .init(executor: executor)
+    }
+
+    func clean() async throws {
+        logger.info("🗑️ Cleaning \(rootPackage.name)...")
+        try await xcodebuild.clean(package: rootPackage)
+    }
+}

--- a/Sources/ScipioKit/Producer/Compiler.swift
+++ b/Sources/ScipioKit/Producer/Compiler.swift
@@ -21,11 +21,6 @@ struct Compiler<E: Executor> {
         self.extractor = DwarfExtractor(executor: executor)
     }
 
-    func clean() async throws {
-        logger.info("🗑️ Cleaning \(rootPackage.name)...")
-        try await xcodebuild.clean(package: rootPackage)
-    }
-
     func createXCFramework(target: ResolvedTarget,
                            outputDirectory: URL) async throws {
         let buildConfiguration = buildOptions.buildConfiguration

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -59,11 +59,12 @@ struct FrameworkProducer {
             return
         }
 
-//        do {
-//            try await compiler.clean()
-//        } catch {
-//            logger.warning("⚠️ Unable to clean project.")
-//        }
+        let cleaner = Cleaner(rootPackage: rootPackage)
+        do {
+            try await cleaner.clean()
+        } catch {
+            logger.warning("⚠️ Unable to clean project.")
+        }
 
         for product in libraryTargets {
             assert(product.target.type == .library)

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -1,4 +1,7 @@
 import Foundation
+import OrderedCollections
+
+public typealias PlatformMatrix = [String: OrderedSet<SDK>]
 
 public struct Runner {
     private let options: Options
@@ -39,6 +42,7 @@ public struct Runner {
             frameworkType: FrameworkType,
             outputDirectory: URL? = nil,
             cacheMode: CacheMode,
+            platformMatrix: PlatformMatrix = [:],
             verbose: Bool
         ) {
             self.buildConfiguration = buildConfiguration
@@ -47,6 +51,7 @@ public struct Runner {
             self.frameworkType = frameworkType
             self.outputDirectory = outputDirectory
             self.cacheMode = cacheMode
+            self.platformMatrix = platformMatrix
             self.verbose = verbose
         }
 
@@ -56,6 +61,7 @@ public struct Runner {
         public var frameworkType: FrameworkType
         public var outputDirectory: URL?
         public var cacheMode: CacheMode
+        public var platformMatrix: PlatformMatrix
         public var verbose: Bool
 
         public enum CacheMode {
@@ -147,6 +153,7 @@ public struct Runner {
             rootPackage: package,
             buildOptions: buildOptions,
             cacheMode: options.cacheMode,
+            platformMatrix: options.platformMatrix,
             outputDir: outputDir
         )
         do {

--- a/Tests/ScipioKitTests/Resources/Fixtures/E2ETestPackage/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/E2ETestPackage/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["TestingPackage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/giginet/scipio-testing.git", .upToNextMinor(from: "1.0.0")),
+        .package(url: "https://github.com/giginet/scipio-testing.git", .upToNextMinor(from: "2.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
closes #12

I added `platformMatrix` to Runner.

```swift
        let runner = Runner(
            mode: .prepareDependencies,
            options: .init(
                buildConfiguration: .release,
                isSimulatorSupported: true,
                isDebugSymbolsEmbedded: false,
                frameworkType: .dynamic,
                cacheMode: .project,
                platformMatrix: ["TargetName": [.iOS, .watchOS]],
                verbose: false)
        )
```

Passing this parameter, configure target platforms by each target.