### PR TITLE
Enable DEFINES_MODULE for all targets

### DIFF
--- a/Sources/ScipioKit/ProjectGenerator/BuildSettingsGenerator.swift
+++ b/Sources/ScipioKit/ProjectGenerator/BuildSettingsGenerator.swift
@@ -135,6 +135,7 @@ struct TargetBuildSettingsGenerator {
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [.inherited],
             "FRAMEWORK_SEARCH_PATHS": [.inherited, "$(PLATFORM_DIR)/Developer/Library/Frameworks"],
             "BUILD_LIBRARY_FOR_DISTRIBUTION": true,
+            "DEFINES_MODULE": true,
         ]
     }
 


### PR DESCRIPTION
In some situations, `DEFINES_MODULE` is needed to build.
According to the swift-package-manager, Enable `DEFINES_MODULE` for all targets.
So I enable this for all targets.