### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ All XCFrameworks are generated into `MyAppDependencies/XCFramework` in default.
 |-\-configuration, -c|Build configuration for generated frameworks (debug / release)|release|
 |-\-output, -o|Path indicates a XCFrameworks output directory|$PACKAGE_ROOT/XCFrameworks|
 |-\-embed-debug-symbols|Whether embed debug symbols to frameworks or not|-|
-|-\--static|Whether generated frameworks are Static Frameworks or not|-|
+|-\-static|Whether generated frameworks are Static Frameworks or not|-|
 |-\-support-simulators|Whether also building for simulators of each SDKs or not|-|
 |-\-cache-policy|How to reuse built frameworks|project|
 


### PR DESCRIPTION
Fixed an incorrect description of the `static` option.

<details>
<summary>ScreenShot</summary>

Before:
<img width="838" alt="image" src="https://user-images.githubusercontent.com/9880704/210934539-be9edf72-9a3b-440d-9c11-c5551a98619f.png">

After:
<img width="839" alt="image" src="https://user-images.githubusercontent.com/9880704/210934817-e7352a0d-3896-48fe-9da0-55ad5cd45697.png">

</details>
