### PR TITLE
Use `.product(...)` instead of `.productItem(...)`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,15 +33,15 @@ let package = Package(
         .executableTarget(name: "scipio",
                           dependencies: [
                             .target(name: "ScipioKit"),
-                            .productItem(name: "ArgumentParser", package: "swift-argument-parser"),
+                            .product(name: "ArgumentParser", package: "swift-argument-parser"),
                           ]),
         .target(
             name: "ScipioKit",
             dependencies: [
-                .productItem(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
-                .productItem(name: "Logging", package: "swift-log"),
-                .productItem(name: "Rainbow", package: "Rainbow"),
-                .productItem(name: "XcodeProj", package: "XcodeProj"),
+                .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Rainbow", package: "Rainbow"),
+                .product(name: "XcodeProj", package: "XcodeProj"),
             ]),
         .testTarget(
             name: "ScipioKitTests",

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ let package = Package(
             name: "MyAppDependency",
             dependencies: [
                 // List all dependencies to build
-                .productItem(name: "APNGKit", package: "APNGKit"),
+                .product(name: "APNGKit", package: "APNGKit"),
             ]),
     ]
 )


### PR DESCRIPTION
## What

Use `.product(...)` instead of `.productItem(...)` in Package.swift and README.md.

## Why

SwiftPM adds `Target.Dependency` to the `dependencies` property as an object representing dependencies.

Dependency is an enum like the following. ([ref](https://github.com/apple/swift-package-manager/blob/release/5.7/Sources/PackageDescription/Target.swift#L42-L66))

```swift
    /// The different types of a target's dependency on another entity.
    public enum Dependency {
        /// A denpendency on a target.
        ///
        ///  - Parameters:
        ///    - name: The name of the target.
        ///    - condition: A condition that limits the application of the target dependency. For example, only apply a dependency for a specific platform.
        case targetItem(name: String, condition: TargetDependencyCondition?)
        /// A dependency on a product.
        ///
        /// - Parameters:
        ///    - name: The name of the product.
        ///    - package: The name of the package.
        ///    - moduleAlias: The module aliases for targets in the product.
        ///    - condition: A condition that limits the application of the target dependency. For example, only apply a dependency for a specific platform.
        case productItem(name: String, package: String?, moduleAliases: [String: String]?, condition: TargetDependencyCondition?)
        /// A by-name dependency on either a target or a product.
        ///
        /// - Parameters:
        ///   - name: The name of the dependency, either a target or a product.
        ///   - condition: A condition that limits the application of the target
        ///     dependency. For example, only apply a dependency for a specific
        ///     platform.
        case byNameItem(name: String, condition: TargetDependencyCondition?)
    }
```

Generally, `Target.Dependency` is generated using a static method, but it is recommended to use `product(...)` instead of `productItem(...)` in the method. ([ref](https://github.com/apple/swift-package-manager/blob/release/5.7/Sources/PackageDescription/Target.swift#L975-L978))

```swift
    @available(_PackageDescription, obsoleted: 5.7, message: "use .product(name:package:condition) instead.")
    public static func productItem(name: String, package: String? = nil, condition: TargetDependencyCondition? = nil) -> Target.Dependency {
        return .productItem(name: name, package: package, moduleAliases: nil, condition: nil)
    }
```