### PR TITLE
Fix cacheMode always become disabled on CLI

### DIFF
--- a/Sources/scipio/CommandType.swift
+++ b/Sources/scipio/CommandType.swift
@@ -50,7 +50,7 @@ extension Runner {
         )
         self.init(mode: commandType.mode, options: runnerOptions)
     }
-    
+
     private static func cacheMode(from commandType: CommandType) -> Runner.Options.CacheMode {
         switch commandType {
         case .create:

--- a/Sources/scipio/CommandType.swift
+++ b/Sources/scipio/CommandType.swift
@@ -44,10 +44,20 @@ extension Runner {
         )
         let runnerOptions = Runner.Options(
             baseBuildOptions: baseBuildOptions,
-            cacheMode: .disabled,
+            cacheMode: Self.cacheMode(from: commandType),
             overwrite: buildOptions.overwrite,
             verbose: globalOptions.verbose
         )
         self.init(mode: commandType.mode, options: runnerOptions)
     }
+    
+    private static func cacheMode(from commandType: CommandType) -> Runner.Options.CacheMode {
+        switch commandType {
+        case .create:
+            return .disabled
+        case .prepare(let cacheMode):
+            return cacheMode
+        }
+    }
+
 }

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -371,7 +371,7 @@ final class RunnerTests: XCTestCase {
                 baseBuildOptions: .init(
                     isSimulatorSupported: false,
                     extraBuildParameters: [
-                        "SWIFT_OPTIMIZATION_LEVEL": "-Osize"
+                        "SWIFT_OPTIMIZATION_LEVEL": "-Osize",
                     ]
                 )
             )


### PR DESCRIPTION
Due to latest changes, `cacheMode` will be always disabled