### PR TITLE
Implement ModuleMapGenerator

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -52,6 +52,13 @@ struct DescriptionPackage {
         workspaceDirectory.appending(component: "DerivedData")
     }
 
+    func generatedModuleMapPath(of target: ResolvedTarget, sdk: SDK) throws -> AbsolutePath {
+        let relativePath = try RelativePath(validating: "GeneratedModuleMaps/\(sdk.settingValue)")
+        return workspaceDirectory
+            .appending(relativePath)
+            .appending(component: target.modulemapName)
+    }
+
     // MARK: Initializer
 
     private static func makeWorkspace(packagePath: AbsolutePath) throws -> Workspace {

--- a/Sources/ScipioKit/PackageGraph+Extensions.swift
+++ b/Sources/ScipioKit/PackageGraph+Extensions.swift
@@ -5,4 +5,8 @@ extension ResolvedTarget {
     var xcFrameworkName: String {
         "\(c99name.packageNamed()).xcframework"
     }
+
+    var modulemapName: String {
+        "\(c99name.packageNamed()).modulemap"
+    }
 }

--- a/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
@@ -1,0 +1,117 @@
+import Foundation
+import TSCBasic
+import PackageGraph
+import PackageModel
+
+struct ModuleMapGenerator {
+    private struct Context {
+        var resolvedTarget: ResolvedTarget
+        var sdk: SDK
+        var configuration: BuildConfiguration
+    }
+
+    private var descriptionPackage: DescriptionPackage
+    private var fileSystem: any FileSystem
+
+    enum Error: LocalizedError {
+        case unableToLoadCustomModuleMap(AbsolutePath)
+
+        var errorDescription: String? {
+            switch self {
+            case .unableToLoadCustomModuleMap(let customModuleMapPath):
+                return "Something went wrong to load \(customModuleMapPath.pathString)"
+            }
+        }
+    }
+
+    init(descriptionPackage: DescriptionPackage, fileSystem: any FileSystem) {
+        self.descriptionPackage = descriptionPackage
+        self.fileSystem = fileSystem
+    }
+
+    @discardableResult
+    func generate(resolvedTarget: ResolvedTarget, sdk: SDK, buildConfiguration: BuildConfiguration) throws -> AbsolutePath? {
+        let context = Context(resolvedTarget: resolvedTarget, sdk: sdk, configuration: buildConfiguration)
+
+        if let clangTarget = resolvedTarget.underlyingTarget as? ClangTarget {
+            switch clangTarget.moduleMapType {
+            case .custom, .umbrellaHeader, .umbrellaDirectory:
+                let path = try constructGeneratedModuleMapPath(context: context)
+                try generateModuleMapFile(context: context, outputPath: path)
+                return path
+            case .none:
+                return nil
+            }
+        } else {
+            let path = try constructGeneratedModuleMapPath(context: context)
+            try generateModuleMapFile(context: context, outputPath: path)
+            return path
+        }
+    }
+
+    private func generateModuleMapContents(context: Context) throws -> String {
+        if let clangTarget = context.resolvedTarget.underlyingTarget as? ClangTarget {
+            switch clangTarget.moduleMapType {
+            case .custom(let customModuleMap):
+                return try convertCustomModuleMapForFramework(customModuleMap)
+            case .umbrellaHeader(let headerPath):
+                return """
+                framework module \(context.resolvedTarget.c99name) {
+                    umbrella header "\(headerPath.basename)"
+                    export *
+                }
+                """
+                    .trimmingCharacters(in: .whitespaces)
+            case .umbrellaDirectory(let directoryPath):
+                return """
+                framework module \(context.resolvedTarget.c99name) {
+                    umbrella "\(directoryPath.basename)"
+                    export *
+                }
+                """
+                    .trimmingCharacters(in: .whitespaces)
+            case .none:
+                fatalError("Unsupported moduleMapType")
+            }
+        } else {
+            let bridgingHeaderName = "\(context.resolvedTarget.name)-Swift.h"
+            return """
+                framework module \(context.resolvedTarget.c99name) {
+                    header "\(bridgingHeaderName)"
+                    export *
+                }
+            """
+                .trimmingCharacters(in: .whitespaces)
+        }
+    }
+
+    private func generateModuleMapFile(context: Context, outputPath: AbsolutePath) throws {
+        let dirPath = outputPath.parentDirectory
+        try fileSystem.createDirectory(dirPath, recursive: true)
+
+        let contents = try generateModuleMapContents(context: context)
+        try fileSystem.writeFileContents(outputPath, string: contents)
+    }
+
+    private func constructGeneratedModuleMapPath(context: Context) throws -> AbsolutePath {
+        let generatedModuleMapPath = try descriptionPackage.generatedModuleMapPath(of: context.resolvedTarget, sdk: context.sdk)
+        return generatedModuleMapPath
+    }
+
+    private func convertCustomModuleMapForFramework(_ customModuleMap: AbsolutePath) throws -> String {
+        // Sometimes, targets have their custom modulemaps.
+        // However, these are not for frameworks
+        // This process converts them to modulemaps for frameworks
+        // like `module MyModule` to `framework module MyModule`
+        let rawData = try fileSystem.readFileContents(customModuleMap).contents
+        guard let contents = String(bytes: rawData, encoding: .utf8) else {
+            throw Error.unableToLoadCustomModuleMap(customModuleMap)
+        }
+        // TODO: Use modern regex
+        let regex = try NSRegularExpression(pattern: "^module", options: [])
+        let replaced = regex.stringByReplacingMatches(in: contents,
+                                                      range: NSRange(location: 0, length: contents.utf16.count),
+                                                      withTemplate: "framework module")
+        return replaced
+    }
+}

--- a/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
@@ -54,6 +54,7 @@ struct ModuleMapGenerator {
             switch clangTarget.moduleMapType {
             case .custom(let customModuleMap):
                 return try convertCustomModuleMapForFramework(customModuleMap)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
             case .umbrellaHeader(let headerPath):
                 return """
                 framework module \(context.resolvedTarget.c99name) {

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -73,6 +73,7 @@ struct PIFCompiler: Compiler {
 
             do {
                 try await xcBuildClient.buildFramework(
+                    sdk: sdk,
                     pifPath: pifPath,
                     buildParametersPath: buildParametersPath
                 )

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -232,13 +232,6 @@ private struct PIFLibraryTargetModifier {
         }
         settings[.SWIFT_INSTALL_OBJC_HEADER] = "YES"
 
-//        // Generating modulemap to default location
-//        // Location set by the original PIFBuilder may not be work
-//        settings[.MODULEMAP_PATH] = nil
-//        // Removing `-fmodule-map-file` flag set on the original PIFBuilder
-//        pifTarget.impartedBuildProperties.buildSettings[.OTHER_CFLAGS] = ["$(inherited)"]
-//        pifTarget.impartedBuildProperties.buildSettings[.OTHER_SWIFT_FLAGS] = ["$(inherited)"]
-
         if let clangTarget = resolvedTarget.underlyingTarget as? ClangTarget {
             switch clangTarget.moduleMapType {
             case .custom(let moduleMapPath):

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -237,31 +237,9 @@ private struct PIFLibraryTargetModifier {
             case .custom(let moduleMapPath):
                 settings[.MODULEMAP_FILE] = moduleMapPath.moduleEscapedPathString
                 settings[.MODULEMAP_FILE_CONTENTS] = nil
-            case .umbrellaHeader(let headerPath):
-                settings[.MODULEMAP_FILE_CONTENTS] = """
-                    framework module \(c99Name) {
-                        umbrella header "\(headerPath.moduleEscapedPathString)"
-                        export *
-                    }
-                """
-            case .umbrellaDirectory(let directoryPath):
-                settings[.MODULEMAP_FILE_CONTENTS] = """
-                    framework module \(c99Name) {
-                        umbrella "\(directoryPath.moduleEscapedPathString)"
-                        export *
-                    }
-                """
-            case .none:
-                settings[.MODULEMAP_FILE_CONTENTS] = nil
+            case .umbrellaHeader, .umbrellaDirectory, .none:
+                break
             }
-        } else {
-            let bridgingHeaderName = settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME] ?? "\(name)-Swift.h"
-            settings[.MODULEMAP_FILE_CONTENTS] = """
-                framework module \(c99Name) {
-                    header "\(bridgingHeaderName)"
-                    export *
-                }
-            """
         }
 
         configuration.buildSettings = settings

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -232,12 +232,12 @@ private struct PIFLibraryTargetModifier {
         }
         settings[.SWIFT_INSTALL_OBJC_HEADER] = "YES"
 
-        // Generating modulemap to default location
-        // Location set by the original PIFBuilder may not be work
-        settings[.MODULEMAP_PATH] = nil
-        // Removing `-fmodule-map-file` flag set on the original PIFBuilder
-        pifTarget.impartedBuildProperties.buildSettings[.OTHER_CFLAGS] = ["$(inherited)"]
-        pifTarget.impartedBuildProperties.buildSettings[.OTHER_SWIFT_FLAGS] = ["$(inherited)"]
+//        // Generating modulemap to default location
+//        // Location set by the original PIFBuilder may not be work
+//        settings[.MODULEMAP_PATH] = nil
+//        // Removing `-fmodule-map-file` flag set on the original PIFBuilder
+//        pifTarget.impartedBuildProperties.buildSettings[.OTHER_CFLAGS] = ["$(inherited)"]
+//        pifTarget.impartedBuildProperties.buildSettings[.OTHER_SWIFT_FLAGS] = ["$(inherited)"]
 
         if let clangTarget = resolvedTarget.underlyingTarget as? ClangTarget {
             switch clangTarget.moduleMapType {

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -59,6 +59,9 @@ struct XCBuildClient {
             descriptionPackage: descriptionPackage,
             fileSystem: fileSystem
         )
+        // xcbuild automatically generates modulemaps. However, these are not for frameworks.
+        // Therefore, it's difficult to contain to final XCFrameworks.
+        // So generate modulemap for frameworks manually
         try modulemapGenerator.generate(
             resolvedTarget: buildProduct.target,
             sdk: sdk,
@@ -80,7 +83,7 @@ struct XCBuildClient {
             buildProduct.target.name
         )
 
-        // Copy modulemap to outputFramework
+        // Copy modulemap to built frameworks
         // xcbuild generates modulemap for each frameworks
         // However, these are not includes in Frameworks
         // So they should be copied into frameworks manually.

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -1,6 +1,7 @@
 import Foundation
 import TSCBasic
 import PackageGraph
+import PackageModel
 
 struct XCBuildClient {
     private let descriptionPackage: DescriptionPackage
@@ -54,6 +55,16 @@ struct XCBuildClient {
         pifPath: AbsolutePath,
         buildParametersPath: AbsolutePath
     ) async throws {
+
+        let modulemapGenerator = ModuleMapGenerator(
+            descriptionPackage: descriptionPackage,
+            sdk: sdk,
+            configuration: configuration,
+            resolvedTarget: buildProduct.target,
+            fileSystem: fileSystem
+        )
+        try modulemapGenerator.generate()
+
         let xcbuildPath = try await fetchXCBuildPath()
         try await buildExecutor.execute(
             xcbuildPath.pathString,
@@ -83,7 +94,7 @@ struct XCBuildClient {
             try fileSystem.createDirectory(modulesDir)
         }
 
-        let generatedModuleMapPath = try generatedModuleMapPath(of: buildProduct.target, sdk: sdk)
+        let generatedModuleMapPath = try generatedModuleMapPath(of: buildProduct.target, sdk: sdk, workspaceDirectory: descriptionPackage.workspaceDirectory)
         if fileSystem.exists(generatedModuleMapPath) {
             try fileSystem.copy(
                 from: generatedModuleMapPath,
@@ -96,13 +107,6 @@ struct XCBuildClient {
         let frameworkPath = try RelativePath(validating: "./Products/\(productDirectoryName(sdk: sdk))/PackageFrameworks")
             .appending(component: "\(buildProduct.target.c99name).framework")
         return descriptionPackage.derivedDataPath.appending(frameworkPath)
-    }
-
-    private func generatedModuleMapPath(of target: ResolvedTarget, sdk: SDK) throws -> AbsolutePath {
-        let relativePath = try RelativePath(validating: "Intermediates.noindex/GeneratedModuleMaps/\(sdk.settingValue)")
-        return descriptionPackage.derivedDataPath
-            .appending(relativePath)
-            .appending(component: target.modulemapName)
     }
 
     private func productDirectoryName(sdk: SDK) -> String {
@@ -180,4 +184,100 @@ private struct XCBuildErrorInfo: Decodable {
         }
         return false
     }
+}
+
+struct ModuleMapGenerator {
+    struct ModuleMapResult {
+        var moduleMapPath: AbsolutePath
+        var isGenerated: Bool
+    }
+
+    private var descriptionPackage: DescriptionPackage
+    private var sdk: SDK
+    private var configuration: BuildConfiguration
+    private var resolvedTarget: ResolvedTarget
+    private var fileSystem: any FileSystem
+
+    init(descriptionPackage: DescriptionPackage, sdk: SDK, configuration: BuildConfiguration, resolvedTarget: ResolvedTarget, fileSystem: any FileSystem) {
+        self.descriptionPackage = descriptionPackage
+        self.sdk = sdk
+        self.configuration = configuration
+        self.resolvedTarget = resolvedTarget
+        self.fileSystem = fileSystem
+    }
+
+    private func makeModuleMapContents() -> String {
+        if let clangTarget = resolvedTarget.underlyingTarget as? ClangTarget {
+            switch clangTarget.moduleMapType {
+            case .custom, .none:
+                fatalError("Unsupported moduleMapType")
+            case .umbrellaHeader(let headerPath):
+                return """
+                framework module \(resolvedTarget.c99name) {
+                    umbrella header "\(headerPath.basename)"
+                    export *
+                }
+                """
+                    .trimmingCharacters(in: .whitespaces)
+            case .umbrellaDirectory(let directoryPath):
+                return """
+                framework module \(resolvedTarget.c99name) {
+                    umbrella "\(directoryPath.basename)"
+                    export *
+                }
+                """
+                    .trimmingCharacters(in: .whitespaces)
+            }
+        } else {
+            // "settings[.SWIFT_OBJC_INTERFACE_HEADER_NAME]"
+            let bridgingHeaderName = nil ?? "\(resolvedTarget.name)-Swift.h"
+            return """
+                framework module \(resolvedTarget.c99name) {
+                    header "\(bridgingHeaderName)"
+                    export *
+                }
+            """
+                .trimmingCharacters(in: .whitespaces)
+        }
+    }
+
+    private func generateModuleMapFile(outputPath: AbsolutePath) throws {
+        let dirPath = outputPath.parentDirectory
+        try fileSystem.createDirectory(dirPath, recursive: true)
+
+        let contents = makeModuleMapContents()
+        try fileSystem.writeFileContents(outputPath, string: contents)
+    }
+
+    private func constructGeneratedModuleMapPath() throws -> AbsolutePath {
+        let generatedModuleMapPath = try generatedModuleMapPath(of: resolvedTarget, sdk: sdk, workspaceDirectory: descriptionPackage.workspaceDirectory)
+        return generatedModuleMapPath
+    }
+
+    func generate() throws -> ModuleMapResult? {
+        if let clangTarget = resolvedTarget.underlyingTarget as? ClangTarget {
+            switch clangTarget.moduleMapType {
+            case .custom(let moduleMapPath):
+                let path = try AbsolutePath(validating: moduleMapPath.pathString)
+                return .init(moduleMapPath: path, isGenerated: true)
+            case .umbrellaHeader, .umbrellaDirectory:
+                let path = try constructGeneratedModuleMapPath()
+                try generateModuleMapFile(outputPath: path)
+                return .init(moduleMapPath: path, isGenerated: true)
+            case .none:
+                return .none
+            }
+        } else {
+            let path = try constructGeneratedModuleMapPath()
+            try generateModuleMapFile(outputPath: path)
+            return .init(moduleMapPath: path, isGenerated: true)
+        }
+    }
+}
+
+private func generatedModuleMapPath(of target: ResolvedTarget, sdk: SDK, workspaceDirectory: AbsolutePath) throws -> AbsolutePath {
+    let relativePath = try RelativePath(validating: "GeneratedModuleMaps/\(sdk.settingValue)")
+    return workspaceDirectory
+        .appending(relativePath)
+        .appending(component: target.modulemapName)
 }

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -58,7 +58,7 @@ struct XCBuildClient {
             "--configuration",
             configuration.settingsValue,
             "--derivedDataPath",
-            descriptionPackage.derivedDataPath(for: buildProduct.target).pathString,
+            descriptionPackage.derivedDataPath.pathString,
             "--buildParametersFile",
             buildParametersPath.pathString,
             "--target",
@@ -69,7 +69,7 @@ struct XCBuildClient {
     private func frameworkPath(target: ResolvedTarget, of sdk: SDK) throws -> AbsolutePath {
         let frameworkPath = try RelativePath(validating: "./Products/\(productDirectoryName(sdk: sdk))/PackageFrameworks")
             .appending(component: "\(buildProduct.target.c99name).framework")
-        return descriptionPackage.derivedDataPath(for: target).appending(frameworkPath)
+        return descriptionPackage.derivedDataPath.appending(frameworkPath)
     }
 
     private func productDirectoryName(sdk: SDK) -> String {
@@ -112,13 +112,6 @@ struct XCBuildClient {
         // Default behavior, this command requires swiftinterface. If they don't exist, `-allow-internal-distribution` must be required.
         let additionalFlags = buildOptions.enableLibraryEvolution ? [] : ["-allow-internal-distribution"]
         return frameworksArguments + debugSymbolsArguments + outputPathArguments + additionalFlags
-    }
-}
-
-extension DescriptionPackage {
-    fileprivate func derivedDataPath(for target: ResolvedTarget) -> AbsolutePath {
-        derivedDataPath
-            .appending(components: self.name, target.name)
     }
 }
 

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -96,11 +96,16 @@ struct XCBuildClient {
 
         let generatedModuleMapPath = try descriptionPackage.generatedModuleMapPath(of: buildProduct.target, sdk: sdk)
         if fileSystem.exists(generatedModuleMapPath) {
+            let destination = modulesDir.appending(component: "module.modulemap")
+            if fileSystem.exists(destination) {
+                try fileSystem.removeFileTree(destination)
+            }
             try fileSystem.copy(
                 from: generatedModuleMapPath,
-                to: modulesDir.appending(component: "module.modulemap")
+                to: destination
             )
         }
+        print(modulesDir.appending(component: "module.modulemap"))
     }
 
     private func frameworkPath(target: ResolvedTarget, of sdk: SDK) throws -> AbsolutePath {

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ClangPackageWithCustomModuleMap",
+    platforms: [
+        .iOS(.v13),
+    ],
+    products: [
+        .library(
+            name: "ClangPackageWithCustomModuleMap",
+            targets: ["ClangPackageWithCustomModuleMap"]),
+    ],
+    dependencies: [
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "ClangPackageWithCustomModuleMap",
+            dependencies: []),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/README.md
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/README.md
@@ -1,0 +1,3 @@
+# ClangTargetWithCustomModuleMapPackage
+
+A description of this package.

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/Sources/ClangPackageWithCustomModuleMap/include/module.modulemap
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/Sources/ClangPackageWithCustomModuleMap/include/module.modulemap
@@ -1,0 +1,3 @@
+module ClangPackageWithCustomModuleMap {
+  header "mycalc.h"
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/Sources/ClangPackageWithCustomModuleMap/include/mycalc.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/Sources/ClangPackageWithCustomModuleMap/include/mycalc.h
@@ -1,0 +1,8 @@
+#ifndef mycalc_c_h
+#define mycalc_c_h
+
+#include <stdio.h>
+
+int add(int lhs, int rhs);
+
+#endif /* mycalc_c_h */

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/Sources/ClangPackageWithCustomModuleMap/src/mycalc.c
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithCustomModuleMap/Sources/ClangPackageWithCustomModuleMap/src/mycalc.c
@@ -1,0 +1,5 @@
+#include "mycalc.h"
+
+int add(int lhs, int rhs) {
+    return lhs + rhs;
+}


### PR DESCRIPTION
xcbuild also generates modulemaps. However, these are not for including final frameworks.

Therefore, Scipio generates modulemaps for frameworks manually.

If custom modulemap is included, convert them for frameworks.