### PR TITLE
Fix order issue of `BuildOptions` #55

### DIFF
--- a/Sources/ScipioKit/BuildOptions.swift
+++ b/Sources/ScipioKit/BuildOptions.swift
@@ -6,7 +6,7 @@ struct BuildOptions: Hashable, Codable {
         buildConfiguration: BuildConfiguration,
         isDebugSymbolsEmbedded: Bool,
         frameworkType: FrameworkType,
-        sdks: OrderedSet<SDK>,
+        sdks: Set<SDK>,
         extraFlags: ExtraFlags?,
         extraBuildParameters: ExtraBuildParameters?,
         enableLibraryEvolution: Bool
@@ -14,19 +14,19 @@ struct BuildOptions: Hashable, Codable {
         self.buildConfiguration = buildConfiguration
         self.isDebugSymbolsEmbedded = isDebugSymbolsEmbedded
         self.frameworkType = frameworkType
-        self.sdks = sdks
+        self.sdks = OrderedSet(sdks.sorted(by: { $0.rawValue < $1.rawValue }))
         self.extraFlags = extraFlags
         self.extraBuildParameters = extraBuildParameters
         self.enableLibraryEvolution = enableLibraryEvolution
     }
 
-    var buildConfiguration: BuildConfiguration
-    var isDebugSymbolsEmbedded: Bool
-    var frameworkType: FrameworkType
-    var sdks: OrderedSet<SDK>
-    var extraFlags: ExtraFlags?
-    var extraBuildParameters: ExtraBuildParameters?
-    var enableLibraryEvolution: Bool
+    let buildConfiguration: BuildConfiguration
+    let isDebugSymbolsEmbedded: Bool
+    let frameworkType: FrameworkType
+    let sdks: OrderedSet<SDK>
+    let extraFlags: ExtraFlags?
+    let extraBuildParameters: ExtraBuildParameters?
+    let enableLibraryEvolution: Bool
 }
 
 public struct ExtraFlags: Hashable, Codable {

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -5,7 +5,6 @@ import PackageModel
 import PackageLoading
 import PackageGraph
 import Basics
-import OrderedCollections
 
 struct DescriptionPackage {
     let mode: Runner.Mode
@@ -44,8 +43,8 @@ struct DescriptionPackage {
         buildDirectory.appending(component: "\(name).xcodeproj")
     }
 
-    var supportedSDKs: OrderedCollections.OrderedSet<SDK> {
-        OrderedSet(manifest.platforms.map(\.platformName).compactMap(SDK.init(platformName:)))
+    var supportedSDKs: Set<SDK> {
+        Set(manifest.platforms.map(\.platformName).compactMap(SDK.init(platformName:)))
     }
 
     var derivedDataPath: AbsolutePath {

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -5,7 +5,7 @@ import PackageGraph
 
 private let jsonEncoder = {
     let encoder = JSONEncoder()
-    encoder.outputFormatting = .prettyPrinted
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     return encoder
 }()
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -1,7 +1,6 @@
 import Foundation
 import PackageGraph
 import PackageModel
-import OrderedCollections
 import TSCBasic
 
 struct FrameworkProducer {

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -2,7 +2,6 @@ import Foundation
 import PackageModel
 import SPMBuildCore
 import PackageGraph
-import OrderedCollections
 import TSCBasic
 
 struct PIFCompiler: Compiler {

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -1,10 +1,9 @@
 import Foundation
-import OrderedCollections
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
 import var TSCBasic.localFileSystem
 
-public typealias PlatformMatrix = [String: OrderedSet<SDK>]
+public typealias PlatformMatrix = [String: Set<SDK>]
 
 public struct Runner {
     private let options: Options
@@ -269,7 +268,7 @@ extension Runner.Options.BuildOptions {
             buildConfiguration: buildConfiguration,
             isDebugSymbolsEmbedded: isDebugSymbolsEmbedded,
             frameworkType: frameworkType,
-            sdks: OrderedSet(sdks),
+            sdks: Set(sdks),
             extraFlags: extraFlags,
             extraBuildParameters: extraBuildParameters,
             enableLibraryEvolution: enableLibraryEvolution

--- a/Sources/scipio/CreateCommands.swift
+++ b/Sources/scipio/CreateCommands.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ScipioKit
 import ArgumentParser
-import OrderedCollections
 import Logging
 
 extension Scipio {
@@ -50,6 +49,6 @@ extension Scipio {
     }
 }
 
-private let availablePlatforms: OrderedSet<SDK> = [.iOS, .macOS, .tvOS, .watchOS]
+private let availablePlatforms: Set<SDK> = [.iOS, .macOS, .tvOS, .watchOS]
 
 extension Runner.Options.Platform: ExpressibleByArgument { }


### PR DESCRIPTION
The `sdk` of `BuildOptions` is `OrderedSet`, but some codes handles `sdk` as `Set<SDK>`.
As a result, the cache is sometimes not reused.

To fix the issue, I did
- Replacing most of `OrderedSet` with `Set`.
- Sorting the `sdk` when `BuildOptions` is created.

close #55
