### PR TITLE
Remove addLink process to avoid duplicated symbols

### DIFF
--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -185,8 +185,6 @@ private struct PIFLibraryTargetModifier {
         if let clangTarget = resolvedTarget.underlyingTarget as? ClangTarget {
             addPublicHeaders(clangTarget: clangTarget)
         }
-
-        addLinkSettings(of: pifTarget)
     }
 
     private func updateBuildConfiguration(_ original: PIF.BuildConfiguration) -> PIF.BuildConfiguration {
@@ -312,24 +310,6 @@ private struct PIFLibraryTargetModifier {
         } else {
             let buildPhase = PIF.HeadersBuildPhase(
                guid: guid("HEADERS_BUILD_PHASE"),
-               buildFiles: buildFiles
-            )
-            pifTarget.buildPhases.append(buildPhase)
-        }
-    }
-
-    private func addLinkSettings(of pifTarget: PIF.Target) {
-        let buildFiles = pifTarget.dependencies.enumerated().map { (index, dependency) in
-            PIF.BuildFile(guid: guid("FRAMEWORKS_BUILD_FILE_\(index)"),
-                          targetGUID: dependency.targetGUID,
-                          platformFilters: dependency.platformFilters)
-        }
-
-        if let buildPhase = fetchBuildPhase(of: PIF.FrameworksBuildPhase.self, in: pifTarget) {
-            buildPhase.buildFiles.append(contentsOf: buildFiles)
-        } else {
-            let buildPhase = PIF.FrameworksBuildPhase(
-               guid: guid("FRAMEWORKS_BUILD_PHASE"),
                buildFiles: buildFiles
             )
             pifTarget.buildPhases.append(buildPhase)

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -108,7 +108,6 @@ struct XCBuildClient {
                 to: destination
             )
         }
-        print(modulesDir.appending(component: "module.modulemap"))
     }
 
     private func frameworkPath(target: ResolvedTarget, of sdk: SDK) throws -> AbsolutePath {


### PR DESCRIPTION
<img width="361" alt="Screenshot 2023-03-15 at 17 01 14" src="https://user-images.githubusercontent.com/147051/225247400-3e4006d2-6a2f-4cba-9aa9-258c7a457519.png">

These link settings are already added on SwiftPM's `PIFBuilder`.

So this process causes duplicated symbols when libraries are statics.

I checked in some situations this change will work fine.