### PR TITLE
Generate Info.plist for resource bundles

### DIFF
--- a/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
+++ b/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
@@ -1,0 +1,41 @@
+import Foundation
+import TSCBasic
+
+struct InfoPlistGenerator {
+    private let fileSystem: any FileSystem
+
+    init(fileSystem: any FileSystem) {
+        self.fileSystem = fileSystem
+    }
+
+    func generateForResourceBundle(at path: AbsolutePath) throws {
+        let body = resourceBundleBody
+
+        try fileSystem.writeFileContents(path, string: body)
+    }
+
+    private var resourceBundleBody: String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleDevelopmentRegion</key>
+            <string>$(DEVELOPMENT_LANGUAGE)</string>
+            <key>CFBundleIdentifier</key>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+            <key>CFBundleInfoDictionaryVersion</key>
+            <string>6.0</string>
+            <key>CFBundleName</key>
+            <string>$(PRODUCT_NAME)</string>
+            <key>CFBundlePackageType</key>
+            <string>BNDL</string>
+            <key>CFBundleShortVersionString</key>
+            <string>1.0</string>
+            <key>CFBundleVersion</key>
+            <string>1</string>
+        </dict>
+        </plist>
+        """
+    }
+}


### PR DESCRIPTION
Auto-generated Info.plist causes code signing issue when submitting to AppStore.

Generate Info.plist for resource bundle.