### PR TITLE
Add subcommand to dump cache key

### DIFF
--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -10,6 +10,11 @@ private let jsonEncoder = {
     return encoder
 }()
 
+private let jsonDecoder = {
+    let decoder = JSONDecoder()
+    return decoder
+}()
+
 struct ClangChecker<E: Executor> {
     private let executor: E
 
@@ -267,5 +272,21 @@ extension CacheKey {
     public func calculateChecksum() throws -> String {
         let data = try jsonEncoder.encode(self)
         return SHA256().hash(ByteString(data)).hexadecimalRepresentation
+    }
+}
+
+public struct VersionFileDecoder {
+    private let fileSystem: any FileSystem
+
+    public init(fileSystem: any FileSystem = localFileSystem) {
+        self.fileSystem = fileSystem
+    }
+
+    public func decode(versionFile: URL) throws -> CacheKey {
+        try jsonDecoder.decode(
+            path: versionFile.absolutePath,
+            fileSystem: fileSystem,
+            as: CacheKey.self
+        )
     }
 }

--- a/Sources/scipio/DumpCacheKey.swift
+++ b/Sources/scipio/DumpCacheKey.swift
@@ -1,0 +1,26 @@
+import Foundation
+import ScipioKit
+import ArgumentParser
+import Logging
+
+extension Scipio {
+    struct DumpCacheKey: AsyncParsableCommand {
+        static var configuration: CommandConfiguration = .init(
+            abstract: "Dump cache key of a VersionFile"
+        )
+
+        @Argument(
+            help: "Path indicates a version file to dump",
+            completion: .file(extensions: ["version"]),
+            transform: URL.init(fileURLWithPath:)
+        )
+        var versionFileURL: URL
+
+        mutating func run() async throws {
+            let decoder = VersionFileDecoder()
+            let cacheKey = try decoder.decode(versionFile: versionFileURL)
+            let checksum = try cacheKey.calculateChecksum()
+            print(checksum)
+        }
+    }
+}

--- a/Sources/scipio/DumpCacheKey.swift
+++ b/Sources/scipio/DumpCacheKey.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ScipioKit
 import ArgumentParser
-import Logging
 
 extension Scipio {
     struct DumpCacheKey: AsyncParsableCommand {

--- a/Sources/scipio/Scipio.swift
+++ b/Sources/scipio/Scipio.swift
@@ -5,6 +5,6 @@ import ArgumentParser
 struct Scipio: AsyncParsableCommand {
     static var configuration = CommandConfiguration(
         abstract: "A build tool to create XCFrameworks from Swift packages.",
-        subcommands: [Create.self, Prepare.self],
+        subcommands: [Create.self, Prepare.self, DumpCacheKey.self],
         defaultSubcommand: Prepare.self)
 }


### PR DESCRIPTION
Add subcommand `dump-cache-key` to dump VersionFile

```
$ scipio dump-cache-key XCFrameworks/.Logging.version
```