### PR TITLE
Enable --disable-automatic-resoltion when resolves package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Select Xcode version
-      run: sudo xcode-select -s '/Applications/Xcode_14.0.app/Contents/Developer'
+      run: sudo xcode-select -s '/Applications/Xcode_14.3.1.app/Contents/Developer'
     - name: SwiftLint
       run: swiftlint --strict
     - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 jobs:
   Tests:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v2
     - name: Select Xcode version

--- a/Package.resolved
+++ b/Package.resolved
@@ -229,8 +229,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
-        "version" : "5.0.5"
+        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+        "version" : "5.0.6"
       }
     }
   ],

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -82,6 +82,8 @@ struct DescriptionPackage {
         let scope = observabilitySystem.topScope
         self.graph = try workspace.loadPackageGraph(
             rootInput: PackageGraphRootInput(packages: [packageDirectory]),
+            // This option is same with resolver option `--disable-automatic-resolution`
+            // Never update Package.resolved of the package
             forceResolvedVersions: true,
             observabilityScope: scope
         )

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -79,8 +79,12 @@ struct DescriptionPackage {
         self.toolchain = toolchain
 
         let workspace = try Self.makeWorkspace(toolchain: toolchain, packagePath: packageDirectory)
-        self.graph = try workspace.loadPackageGraph(rootPath: packageDirectory, observabilityScope: observabilitySystem.topScope)
         let scope = observabilitySystem.topScope
+        self.graph = try workspace.loadPackageGraph(
+            rootInput: PackageGraphRootInput(packages: [packageDirectory]),
+            forceResolvedVersions: true,
+            observabilityScope: scope
+        )
         self.manifest = try tsc_await {
             workspace.loadRootManifest(
                 at: packageDirectory,

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -84,7 +84,7 @@ struct DescriptionPackage {
             rootInput: PackageGraphRootInput(packages: [packageDirectory]),
             // This option is same with resolver option `--disable-automatic-resolution`
             // Never update Package.resolved of the package
-            forceResolvedVersions: true,
+            forceResolvedVersions: false,
             observabilityScope: scope
         )
         self.manifest = try tsc_await {


### PR DESCRIPTION
I enabled flag `--disable-automatic-resolution` when package dependencies are resolved.

This flag enables the resolver doesn't change `Package.resolved`.