### PR TITLE
Invert forceResolvedVersions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .swiftpm
-**/Resources/**/Package.resolved
 *.xcframework
 .build
 Tests/**/XCFrameworks/*

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -84,7 +84,7 @@ struct DescriptionPackage {
             rootInput: PackageGraphRootInput(packages: [packageDirectory]),
             // This option is same with resolver option `--disable-automatic-resolution`
             // Never update Package.resolved of the package
-            forceResolvedVersions: false,
+            forceResolvedVersions: true,
             observabilityScope: scope
         )
         self.manifest = try tsc_await {

--- a/Tests/ScipioKitTests/Resources/Fixtures/E2ETestPackage/Package.resolved
+++ b/Tests/ScipioKitTests/Resources/Fixtures/E2ETestPackage/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "scipio-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/giginet/scipio-testing.git",
+      "state" : {
+        "revision" : "88188847e047db6d49767b881eadced45a1bdbce",
+        "version" : "2.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.resolved
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.resolved
@@ -1,0 +1,50 @@
+{
+  "pins" : [
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "fb50c1d20f24db5322b2f8f379de3618f75fe08e",
+        "version" : "5.15.5"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
+        "version" : "1.5.2"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "45167b8006448c79dda4b7bd604e07a034c15c49",
+        "version" : "2.48.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Package.resolved
+++ b/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
+        "version" : "1.4.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/UsingBinaryPackage/Package.resolved
+++ b/Tests/ScipioKitTests/Resources/Fixtures/UsingBinaryPackage/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "scipio-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/giginet/scipio-testing.git",
+      "state" : {
+        "revision" : "bbe2e2c1e2a3d372a880e4bf99f25db312390f9b",
+        "version" : "3.0.0"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
I was mistaken.

`forceResolvedVersions` should be `true`. Default value is `false`
https://github.com/apple/swift-package-manager/blob/main/Sources/CoreCommands/Options.swift