### PR TITLE
Support visionOS

### DIFF
--- a/Sources/ScipioKit/BuildOptions.swift
+++ b/Sources/ScipioKit/BuildOptions.swift
@@ -76,6 +76,8 @@ public enum SDK: String, Codable {
     case tvOSSimulator
     case watchOS
     case watchOSSimulator
+    case visionOS
+    case visionOSSimulator
 
     init?(platformName: String) {
         switch platformName {
@@ -89,6 +91,8 @@ public enum SDK: String, Codable {
             self = .tvOS
         case "watchos":
             self = .watchOS
+        case "visionos":
+            self = .visionOS
         default:
             return nil
         }
@@ -100,6 +104,7 @@ public enum SDK: String, Codable {
         case .iOS: return [.iOS, .iOSSimulator]
         case .tvOS: return [.tvOS, .tvOSSimulator]
         case .watchOS: return [.watchOS, .watchOSSimulator]
+        case .visionOS: return [.visionOS, .visionOSSimulator]
         default: return [self]
         }
     }
@@ -122,6 +127,10 @@ public enum SDK: String, Codable {
             return "tvOS"
         case .tvOSSimulator:
             return "TV Simulator"
+        case .visionOS:
+            return "visionOS"
+        case .visionOSSimulator:
+            return "visionOS Simulator"
         }
     }
 
@@ -143,27 +152,10 @@ public enum SDK: String, Codable {
             return "watchos"
         case .watchOSSimulator:
             return "watchsimulator"
-        }
-    }
-
-    var destination: String {
-        switch self {
-        case .macOS:
-            return "generic/platform=macOS,name=Any Mac"
-        case .macCatalyst:
-            return "generic/platform=macOS,variant=Mac Catalyst"
-        case .iOS:
-            return "generic/platform=iOS"
-        case .iOSSimulator:
-            return "generic/platform=iOS Simulator"
-        case .tvOS:
-            return "generic/platform=tvOS"
-        case .tvOSSimulator:
-            return "generic/platform=tvOS Simulator"
-        case .watchOS:
-            return "generic/platform=watchOS"
-        case .watchOSSimulator:
-            return "generic/platform=watchOS Simulator"
+        case .visionOS:
+            return "xros"
+        case .visionOSSimulator:
+            return "xrsimulator"
         }
     }
 }

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -214,6 +214,7 @@ extension Runner {
             case macCatalyst
             case tvOS
             case watchOS
+            case visionOS
         }
 
         public var buildOptionsContainer: BuildOptionsContainer
@@ -252,6 +253,8 @@ extension Runner.Options.Platform {
             return isSimulatorSupported ? [.tvOS, .tvOSSimulator] : [.tvOS]
         case .watchOS:
             return isSimulatorSupported ? [.watchOS, .watchOSSimulator] : [.watchOS]
+        case .visionOS:
+            return isSimulatorSupported ? [.visionOS, .visionOSSimulator] : [.visionOS]
         }
     }
 }


### PR DESCRIPTION
In this PR, I added support for visionOS to scipio.

I confirmed that the generated XFramework for the below package can be used on visionOS project.

```swift
// swift-tools-version: 5.9

import PackageDescription

let package = Package(
    name: "Dependencies",
    platforms: [.visionOS(.v1)],
    products: [
        .library(name: "Dependencies", targets: ["Dependencies"]),
    ],
    dependencies: [
        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.6.4"))
    ],
    targets: [
        .target(name: "Dependencies", dependencies: ["Alamofire"]),
        .testTarget(name: "DependenciesTests", dependencies: ["Dependencies"]),
    ]
)
```

And, I noticed that `destination` of `SDK` is not used, so I removed the propertiy.