### PR TITLE
[xcode15-beta3] verboseモードの場合にはxcbuildの出力を表示する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ on:
       - '*'
 jobs:
   Tests:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v2
     - name: Select Xcode version
-      run: sudo xcode-select -s '/Applications/Xcode_14.0.app/Contents/Developer'
+      run: sudo xcode-select -s '/Applications/Xcode_14.3.1.app/Contents/Developer'
     - name: SwiftLint
       run: swiftlint --strict
     - name: Run Tests

--- a/Package.resolved
+++ b/Package.resolved
@@ -82,12 +82,30 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "805deae27a7506dcad043604c00a9dc52d465dcb",
+        "version" : "0.7.0"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
         "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "35a7df2d9d71c401a47de9be2e3de629a01370c2",
+        "version" : "0.4.1"
       }
     },
     {
@@ -104,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "75ec60b8b4cc0f085c3ac414f3dca5625fa3588e",
-        "version" : "2.2.4"
+        "revision" : "33a20e650c33f6d72d822d558333f2085effa3dc",
+        "version" : "2.5.0"
       }
     },
     {
@@ -113,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-driver.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "0100f8da690f587beac79900bd8fab4c092c62ca"
+        "branch" : "release/5.9",
+        "revision" : "dbfff3dfb72b81c6a77179107812c5df879267d3"
       }
     },
     {
@@ -122,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-llbuild.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "8d49bd3c84e74bb74ab59fca77282d923f3be520"
+        "branch" : "release/5.9",
+        "revision" : "17a88707e99dc0379eccfcf190ee2361227369fc"
       }
     },
     {
@@ -201,9 +219,9 @@
     {
       "identity" : "swift-package-manager",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/giginet/swift-package-manager.git",
+      "location" : "https://github.com/apple/swift-package-manager.git",
       "state" : {
-        "revision" : "11c88e87e6874a570711d18462ca0ea43ff7ff5e"
+        "revision" : "0872d6fcdeba6539fa836a23db6986d7342f568a"
       }
     },
     {
@@ -220,8 +238,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-tools-support-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "3b9d232d49082d9285018010d587765e85fbc052"
+        "branch" : "release/5.9",
+        "revision" : "279be8ac3fe7829cc15e93693c45931a1bf7f112"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -219,9 +219,10 @@
     {
       "identity" : "swift-package-manager",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-package-manager.git",
+      "location" : "https://github.com/giginet/swift-package-manager.git",
       "state" : {
-        "revision" : "0872d6fcdeba6539fa836a23db6986d7342f568a"
+        "branch" : "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-06-05-a-patched",
+        "revision" : "ec29660315c996c96ed42e78b97f9c99839b9b04"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -219,10 +219,10 @@
     {
       "identity" : "swift-package-manager",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/giginet/swift-package-manager.git",
+      "location" : "https://github.com/apple/swift-package-manager.git",
       "state" : {
-        "branch" : "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-06-05-a-patched",
-        "revision" : "ec29660315c996c96ed42e78b97f9c99839b9b04"
+        "branch" : "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-07-05-a",
+        "revision" : "f45e0be4020f9a97ce250847020e37be51819492"
       }
     },
     {
@@ -248,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
-        "version" : "5.0.5"
+        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+        "version" : "5.0.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
             targets: ["ScipioS3Storage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/giginet/swift-package-manager.git",
-                 branch: "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-06-05-a-patched"),
+        .package(url: "https://github.com/apple/swift-package-manager.git",
+                 branch: "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-07-05-a"),
         .package(url: "https://github.com/apple/swift-log.git",
                  .upToNextMinor(from: "1.4.2")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", 

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
             targets: ["ScipioS3Storage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-package-manager.git",
-                 revision: "0872d6fcdeba6539fa836a23db6986d7342f568a"),
+        .package(url: "https://github.com/giginet/swift-package-manager.git",
+                 branch: "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-06-05-a-patched"),
         .package(url: "https://github.com/apple/swift-log.git",
                  .upToNextMinor(from: "1.4.2")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", 

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
             targets: ["ScipioS3Storage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/giginet/swift-package-manager.git",
-                 revision: "11c88e87e6874a570711d18462ca0ea43ff7ff5e"),
+        .package(url: "https://github.com/apple/swift-package-manager.git",
+                 revision: "0872d6fcdeba6539fa836a23db6986d7342f568a"),
         .package(url: "https://github.com/apple/swift-log.git",
                  .upToNextMinor(from: "1.4.2")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", 

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -110,7 +110,7 @@ struct PIFCompiler: Compiler {
     }
 
     private func makeBuildParameters(toolchain: UserToolchain) throws -> BuildParameters {
-        .init(
+        try .init(
             dataPath: descriptionPackage.buildDirectory,
             configuration: buildOptions.buildConfiguration.spmConfiguration,
             toolchain: toolchain,

--- a/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
@@ -39,12 +39,13 @@ struct ToolchainGenerator {
         extraSwiftCFlags += ["-I", sdkPaths.lib.pathString]
         extraSwiftCFlags += ["-L", sdkPaths.lib.pathString]
 
-        return Destination(
-            hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
-            targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+        let destination = Destination(
+//            hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+//            targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
             sdkRootDir: sdkPath,
             toolchainBinDir: toolchainDirPath,
             extraFlags: BuildFlags(cCompilerFlags: extraCCFlags, swiftCompilerFlags: extraSwiftCFlags)
         )
+        return destination
     }
 }

--- a/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
@@ -2,6 +2,7 @@ import Foundation
 import TSCUtility
 import PackageModel
 import TSCBasic
+import struct Basics.Triple
 
 struct ToolchainGenerator {
     private let toolchainDirPath: AbsolutePath
@@ -40,8 +41,8 @@ struct ToolchainGenerator {
         extraSwiftCFlags += ["-L", sdkPaths.lib.pathString]
 
         let destination = Destination(
-//            hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
-//            targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+            hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+            targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
             sdkRootDir: sdkPath,
             toolchainBinDir: toolchainDirPath,
             extraFlags: BuildFlags(cCompilerFlags: extraCCFlags, swiftCompilerFlags: extraSwiftCFlags)


### PR DESCRIPTION
#80 の調査をするにあたって、 `xcbuild` が最終的に発行したコンパイラやリンカのコマンドラインが知りたいと思いました。
現状すでに `-v` が指定されると詳細な出力が表示される挙動があったので、
それに合わせて `xcbuild` の出力をコンソールに表示するようにします。

`-v` に応じてログレベルを `info` と `trace` で切り替えるようになっていたので、
出力を常に `trace` に出します。

`xcbuild` の出力はJSONストリームなので、ユーザフレンドリではないですが、
開発者にとっては出ないよりマシだと思います。

この出力をきれいにする改修も追って実装する予定です。

コードの詳細についてインラインで自己レビューします。