### PR TITLE
[xcode15-beta3] 重複してmodulemapが入力されないようにする

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -82,12 +82,30 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "805deae27a7506dcad043604c00a9dc52d465dcb",
+        "version" : "0.7.0"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
         "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "35a7df2d9d71c401a47de9be2e3de629a01370c2",
+        "version" : "0.4.1"
       }
     },
     {
@@ -104,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "75ec60b8b4cc0f085c3ac414f3dca5625fa3588e",
-        "version" : "2.2.4"
+        "revision" : "33a20e650c33f6d72d822d558333f2085effa3dc",
+        "version" : "2.5.0"
       }
     },
     {
@@ -113,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-driver.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "0100f8da690f587beac79900bd8fab4c092c62ca"
+        "branch" : "release/5.9",
+        "revision" : "dbfff3dfb72b81c6a77179107812c5df879267d3"
       }
     },
     {
@@ -122,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-llbuild.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "8d49bd3c84e74bb74ab59fca77282d923f3be520"
+        "branch" : "release/5.9",
+        "revision" : "17a88707e99dc0379eccfcf190ee2361227369fc"
       }
     },
     {
@@ -201,9 +219,9 @@
     {
       "identity" : "swift-package-manager",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/giginet/swift-package-manager.git",
+      "location" : "https://github.com/apple/swift-package-manager.git",
       "state" : {
-        "revision" : "11c88e87e6874a570711d18462ca0ea43ff7ff5e"
+        "revision" : "0872d6fcdeba6539fa836a23db6986d7342f568a"
       }
     },
     {
@@ -220,8 +238,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-tools-support-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "3b9d232d49082d9285018010d587765e85fbc052"
+        "branch" : "release/5.9",
+        "revision" : "279be8ac3fe7829cc15e93693c45931a1bf7f112"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -219,9 +219,10 @@
     {
       "identity" : "swift-package-manager",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-package-manager.git",
+      "location" : "https://github.com/giginet/swift-package-manager.git",
       "state" : {
-        "revision" : "0872d6fcdeba6539fa836a23db6986d7342f568a"
+        "branch" : "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-06-05-a-patched",
+        "revision" : "ec29660315c996c96ed42e78b97f9c99839b9b04"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -219,10 +219,10 @@
     {
       "identity" : "swift-package-manager",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/giginet/swift-package-manager.git",
+      "location" : "https://github.com/apple/swift-package-manager.git",
       "state" : {
-        "branch" : "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-06-05-a-patched",
-        "revision" : "ec29660315c996c96ed42e78b97f9c99839b9b04"
+        "branch" : "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-07-05-a",
+        "revision" : "f45e0be4020f9a97ce250847020e37be51819492"
       }
     },
     {
@@ -248,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
-        "version" : "5.0.5"
+        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+        "version" : "5.0.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
             targets: ["ScipioS3Storage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/giginet/swift-package-manager.git",
-                 branch: "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-06-05-a-patched"),
+        .package(url: "https://github.com/apple/swift-package-manager.git",
+                 branch: "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-07-05-a"),
         .package(url: "https://github.com/apple/swift-log.git",
                  .upToNextMinor(from: "1.4.2")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", 

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
             targets: ["ScipioS3Storage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-package-manager.git",
-                 revision: "0872d6fcdeba6539fa836a23db6986d7342f568a"),
+        .package(url: "https://github.com/giginet/swift-package-manager.git",
+                 branch: "swift-5.9-DEVELOPMENT-SNAPSHOT-2023-06-05-a-patched"),
         .package(url: "https://github.com/apple/swift-log.git",
                  .upToNextMinor(from: "1.4.2")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", 

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
             targets: ["ScipioS3Storage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/giginet/swift-package-manager.git",
-                 revision: "11c88e87e6874a570711d18462ca0ea43ff7ff5e"),
+        .package(url: "https://github.com/apple/swift-package-manager.git",
+                 revision: "0872d6fcdeba6539fa836a23db6986d7342f568a"),
         .package(url: "https://github.com/apple/swift-log.git",
                  .upToNextMinor(from: "1.4.2")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", 

--- a/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
@@ -75,10 +75,6 @@ struct BuildParametersGenerator {
             buildOptions.extraFlags?.linkerFlags
         )
 
-        settings["FRAMEWORK_SEARCH_PATHS"] = expandFlags(
-            "$(BUILT_PRODUCTS_DIR)/PackageFrameworks"
-        )
-
         let additionalSettings = buildOptions.extraBuildParameters ?? [:]
         settings.merge(additionalSettings, uniquingKeysWith: { $1 })
 

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -110,7 +110,7 @@ struct PIFCompiler: Compiler {
     }
 
     private func makeBuildParameters(toolchain: UserToolchain) throws -> BuildParameters {
-        .init(
+        try .init(
             dataPath: descriptionPackage.buildDirectory,
             configuration: buildOptions.buildConfiguration.spmConfiguration,
             toolchain: toolchain,

--- a/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
@@ -39,12 +39,13 @@ struct ToolchainGenerator {
         extraSwiftCFlags += ["-I", sdkPaths.lib.pathString]
         extraSwiftCFlags += ["-L", sdkPaths.lib.pathString]
 
-        return Destination(
-            hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
-            targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+        let destination = Destination(
+//            hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+//            targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
             sdkRootDir: sdkPath,
             toolchainBinDir: toolchainDirPath,
             extraFlags: BuildFlags(cCompilerFlags: extraCCFlags, swiftCompilerFlags: extraSwiftCFlags)
         )
+        return destination
     }
 }

--- a/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
@@ -2,6 +2,7 @@ import Foundation
 import TSCUtility
 import PackageModel
 import TSCBasic
+import struct Basics.Triple
 
 struct ToolchainGenerator {
     private let toolchainDirPath: AbsolutePath
@@ -40,8 +41,8 @@ struct ToolchainGenerator {
         extraSwiftCFlags += ["-L", sdkPaths.lib.pathString]
 
         let destination = Destination(
-//            hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
-//            targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+            hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+            targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
             sdkRootDir: sdkPath,
             toolchainBinDir: toolchainDirPath,
             extraFlags: BuildFlags(cCompilerFlags: extraCCFlags, swiftCompilerFlags: extraSwiftCFlags)


### PR DESCRIPTION
# 概要

#80 を解決します。
ただし、このパッチだけだと運によってビルドできたりできなかったりします。
#84 と合わせることにより、安定して swift-nio-ssl がビルドできるようになります。

---

# 解説

現在の Scipio は、 `XCBuildClient.copyModulemap` によってmodulemapを生成します。
また、`SwiftPM.PIFBuilder` が生成するPIFファイルには、
ターゲットのCヘッダ情報を読み込めるようにするための modulemap の生成指令が含まれます。

以後、これらを 「Scipioのmodulemap」と「SwiftPMのmodulemap」と呼びます。
なおこれらは微妙に内容が異なります。

そして、これら両方が可視になっているとき、
SwiftがCヘッダをインポートする時に、
plain enumが見えなくなるという現象があることがわかりました。

この現象は @kateinoigakukun により発見され、教えてもらいました。ありがとうございました。

なお、なぜplain enumだけで問題が起きるのかはよくわかりません。

とにかく、この問題を解決するために、
ビルドするときに可視化されるmodulemapを1つにします。

設計上の選択肢はいくつかあるのですが、このパッチでは、SwiftPMのmodulemapを、
依存元から見えないようにします。
SwiftPMのmodulemapの生成自体は止めません。

このmodulemapが依存元に見えるようにする仕組みは、
PIFの `buildSettings` の子要素の `impartedBuildProperties` 要素によって実現されています。

`impartedBuildProperties` はそれ自体も `buildSettings` の構造を持っていて、
ターゲット間に依存関係がある場合に、
依存先ターゲットの `impartedBuildProperties` を、依存元ターゲットの `buildSettings` に上書きします。

SwiftPMが生成するPIFは、この仕組みを使って、依存元ターゲットの
`OTHER_CFLAGS` と `OTHER_SWIFT_FLAGS` に `-fmodule-map-file` オプションの追記を行います。

この挙動自体を `PIFBuilder` のAPIから無効化することはできなかったので、
生成されたPIFからこれを取り除くようにしました。

なお、この修正によって、
フレームワークのビルド順序が不定であることが問題になります。
Scipioのmodulemapは、フレームワークをビルドするタイミングで生成されるため、
依存先よりも先に依存元フレームワークが処理された場合、
依存先のmodulemapが存在しないからです。
この問題は #84 で修正しています。

---

# 将来的な予定

PIFによるmodulemapを使わないようにするのではなく、
Scipioの生成するmodulemapをPIFによって生成させるのが、
一番安定しそうと思っています。

そうすればビルドは `xcbuild build` だけで完結するし、
未だに2系統のmodulemapが生成されているという不自然な点も解消できます。

ただ、変更が大きくなるため簡単に試すことができなかったため、
まずは簡単な方法を実装しました。

このパッチの内容は仮対応ないし、
問題と修正方法の実装例として捉えてください。
(もちろん採用やリリースの判断は任せます)