### PR TITLE
Change default value of enableLibraryEvolution

### DIFF
--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -135,7 +135,7 @@ extension Runner {
                 frameworkType: FrameworkType = .dynamic,
                 extraFlags: ExtraFlags? = nil,
                 extraBuildParameters: [String: String]? = nil,
-                enableLibraryEvolution: Bool = true
+                enableLibraryEvolution: Bool = false
             ) {
                 self.buildConfiguration = buildConfiguration
                 self.platforms = platforms

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -32,7 +32,7 @@ struct BuildOptionGroup: ParsableArguments {
     @Flag(name: [.customLong("library-evolution")],
           inversion: .prefixedEnableDisable,
           help: "Whether to enable Library Evolution feature or not")
-    var shouldEnableLibraryEvolution = true
+    var shouldEnableLibraryEvolution = false
 
     @Flag(name: [.customShort("f", allowingJoined: false), .long],
           help: "Whether overwrite generated frameworks or not")

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -35,7 +35,7 @@ final class RunnerTests: XCTestCase {
         let runner = Runner(
             mode: .prepareDependencies,
             options: .init(
-                baseBuildOptions: .init(isSimulatorSupported: false)
+                baseBuildOptions: .init(isSimulatorSupported: false, enableLibraryEvolution: true)
             )
         )
         do {
@@ -205,6 +205,7 @@ final class RunnerTests: XCTestCase {
         let runner = Runner(
             mode: .prepareDependencies,
             options: .init(
+                baseBuildOptions: .init(enableLibraryEvolution: true),
                 cacheMode: .project
             )
         )
@@ -369,7 +370,8 @@ final class RunnerTests: XCTestCase {
                     buildConfiguration: .release,
                     isSimulatorSupported: false,
                     isDebugSymbolsEmbedded: false,
-                    frameworkType: .dynamic
+                    frameworkType: .dynamic,
+                    enableLibraryEvolution: true
                 ),
                 cacheMode: .project,
                 overwrite: false,


### PR DESCRIPTION
closes #91 

This PR makes LibraryEvolution to be disabled by default.

As discussed in #91, Scipio focuses on preparing frameworks for specific projects. So keeping ABI compatibility is not the primary purpose.
Additionally, there are some limitations if enabling LibraryEvolution.

It's better to disable LibraryEvolution by default.