### PR TITLE
NIOSSLのテストを追加する

### DIFF
--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -37,8 +37,6 @@ final class DescriptionPackageTests: XCTestCase {
             [
                 "Atomics",
                 "CNIOAtomics",
-                "CNIOBoringSSL",
-                "CNIOBoringSSLShims",
                 "CNIODarwin",
                 "CNIOLinux",
                 "CNIOWindows",
@@ -49,8 +47,6 @@ final class DescriptionPackageTests: XCTestCase {
                 "NIOCore",
                 "NIOEmbedded",
                 "NIOPosix",
-                "NIOSSL",
-                "NIOTLS",
                 "OrderedCollections",
                 "SDWebImage",
                 "SDWebImageMapKit",

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -33,13 +33,29 @@ final class DescriptionPackageTests: XCTestCase {
         XCTAssertEqual(package.name, "IntegrationTestPackage")
 
         XCTAssertEqual(
-            Set(try package.resolveBuildProducts().map(\.target.name)),
+            try package.resolveBuildProducts().map(\.target.name).sorted(),
             [
-                "CNIOWindows", "NIOConcurrencyHelpers",
-                "NIO", "CNIOAtomics", "Logging", "NIOEmbedded", "Atomics",
-                "DequeModule", "_AtomicsShims", "NIOPosix", "_NIODataStructures",
-                "SDWebImageMapKit", "NIOCore", "CNIOLinux",
-                "OrderedCollections", "SDWebImage", "CNIODarwin",
+                "Atomics",
+                "CNIOAtomics",
+                "CNIOBoringSSL",
+                "CNIOBoringSSLShims",
+                "CNIODarwin",
+                "CNIOLinux",
+                "CNIOWindows",
+                "DequeModule",
+                "Logging",
+                "NIO",
+                "NIOConcurrencyHelpers",
+                "NIOCore",
+                "NIOEmbedded",
+                "NIOPosix",
+                "NIOSSL",
+                "NIOTLS",
+                "OrderedCollections",
+                "SDWebImage",
+                "SDWebImageMapKit",
+                "_AtomicsShims",
+                "_NIODataStructures"
             ]
         )
     }

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -55,7 +55,7 @@ final class DescriptionPackageTests: XCTestCase {
                 "SDWebImage",
                 "SDWebImageMapKit",
                 "_AtomicsShims",
-                "_NIODataStructures"
+                "_NIODataStructures",
             ]
         )
     }

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -27,6 +27,7 @@ final class IntegrationTests: XCTestCase {
 
     private enum Destination: String {
         case iOS = "ios-arm64"
+        case macOS = "macos-arm64_x86_64"
         case watchOS = "watchos-arm64_arm64_32_armv7k"
     }
 
@@ -45,6 +46,7 @@ final class IntegrationTests: XCTestCase {
                     "Atomics": .init(frameworkType: .static),
                     "_AtomicsShims": .init(frameworkType: .static),
                     "Logging": .init(platforms: .specific([.iOS, .watchOS])),
+                    "NIOSSL": .init(platforms: .specific([.macOS]), frameworkType: .static),
                 ],
                 cacheMode: .disabled,
                 overwrite: true,
@@ -80,6 +82,10 @@ final class IntegrationTests: XCTestCase {
             ("CNIOLinux", .static, [.iOS], true),
             ("CNIODarwin", .static, [.iOS], true),
             ("CNIOWindows", .static, [.iOS], true),
+            ("CNIOBoringSSL", .static, [.macOS], true),
+            ("CNIOBoringSSLShims", .static, [.macOS], true),
+            ("NIOTLS", .static, [.macOS], false),
+            ("NIOSSL", .static, [.macOS], false),
         ]
 
         let outputDirContents = try fileManager.contentsOfDirectory(atPath: outputDir.path)
@@ -102,9 +108,9 @@ final class IntegrationTests: XCTestCase {
             let xcFrameworkPath = outputDir
                 .appendingPathComponent(xcFrameworkName)
 
-            XCTAssertEqual(
-                Set(try fileManager.contentsOfDirectory(atPath: xcFrameworkPath.path)),
-                Set(["Info.plist"]).union(expectedDestinations),
+            XCTAssertTrue(
+                Set(try fileManager.contentsOfDirectory(atPath: xcFrameworkPath.path))
+                    .isSuperset(of: expectedDestinations),
                 "\(xcFrameworkName) must contains \(expectedDestinations.joined(separator: ", "))"
             )
 

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -113,7 +113,6 @@ final class IntegrationTests: XCTestCase {
         let outputDir = fileManager.temporaryDirectory
             .appendingPathComponent("Scipio")
             .appendingPathComponent(packageName)
-        try? fileManager.removeItem(at: outputDir)
         let packageDir = fixturePath.appendingPathComponent(packageName)
         print("package directory: \(packageDir.path)")
         print("output directory: \(outputDir.path)")
@@ -122,6 +121,10 @@ final class IntegrationTests: XCTestCase {
             packageDirectory: packageDir,
             frameworkOutputDir: .custom(outputDir)
         )
+        addTeardownBlock {
+            print("remove output directory: \(outputDir.path)")
+            try self.fileManager.removeItem(atPath: outputDir.path)
+        }
 
         let outputDirContents = try fileManager.contentsOfDirectory(atPath: outputDir.path)
         let allExpectedFrameworkNames = testCases.map { "\($0.0).xcframework" }

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -115,12 +115,13 @@ final class IntegrationTests: XCTestCase {
             .appendingPathComponent(packageName)
         try? fileManager.removeItem(at: outputDir)
         let packageDir = fixturePath.appendingPathComponent(packageName)
+        print("package directory: \(packageDir.path)")
+        print("output directory: \(outputDir.path)")
+
         try await runner.run(
             packageDirectory: packageDir,
             frameworkOutputDir: .custom(outputDir)
         )
-        print("package directory: \(packageDir.path)")
-        print("output directory: \(outputDir.path)")
 
         let outputDirContents = try fileManager.contentsOfDirectory(atPath: outputDir.path)
         let allExpectedFrameworkNames = testCases.map { "\($0.0).xcframework" }

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -103,15 +103,16 @@ final class IntegrationTests: XCTestCase {
                 "\(xcFrameworkName) should be built"
             )
 
-            let expectedDestinations = platforms.map(\.rawValue)
+            let expectedDestinations = platforms.map(\.rawValue).sorted()
 
             let xcFrameworkPath = outputDir
                 .appendingPathComponent(xcFrameworkName)
 
-            XCTAssertTrue(
-                Set(try fileManager.contentsOfDirectory(atPath: xcFrameworkPath.path))
-                    .isSuperset(of: expectedDestinations),
-                "\(xcFrameworkName) must contains \(expectedDestinations.joined(separator: ", "))"
+            XCTAssertEqual(
+                try fileManager.contentsOfDirectory(atPath: xcFrameworkPath.path)
+                    .filter { $0 != "Info.plist" }.sorted(),
+                expectedDestinations,
+                "\(xcFrameworkName) must contain platforms that are equal to \(expectedDestinations.joined(separator: ", "))"
             )
 
             for destination in expectedDestinations {

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -56,7 +56,7 @@ final class IntegrationTests: XCTestCase {
                 ("CNIOAtomics", .static, [.iOS], true),
                 ("CNIOLinux", .static, [.iOS], true),
                 ("CNIODarwin", .static, [.iOS], true),
-                ("CNIOWindows", .static, [.iOS], true)
+                ("CNIOWindows", .static, [.iOS], true),
             ]
         )
     }

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/.gitignore
@@ -1,0 +1,2 @@
+.build
+.swiftpm

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Package.resolved
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "a2e487b77f17edbce9a65f2b7415f2f479dc8e48",
+        "version" : "2.57.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl",
+      "state" : {
+        "revision" : "e866a626e105042a6a72a870c88b4c531ba05f83",
+        "version" : "2.24.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "IntegrationMacTestPackage",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(
+            name: "IntegrationMacTestPackage",
+            targets: ["IntegrationMacTestPackage"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.24.0")
+    ],
+    targets: [
+        .target(
+            name: "IntegrationMacTestPackage",
+            dependencies: [
+                .product(name: "NIOSSL", package: "swift-nio-ssl")
+            ]
+        ),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Sources/IntegrationMacTestPackage/Dummy.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Sources/IntegrationMacTestPackage/Dummy.swift
@@ -1,0 +1,1 @@
+public let dummy = 1

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.resolved
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
-        "version" : "1.0.3"
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
       }
     },
     {
@@ -41,8 +41,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "45167b8006448c79dda4b7bd604e07a034c15c49",
-        "version" : "2.48.0"
+        "revision" : "a2e487b77f17edbce9a65f2b7415f2f479dc8e48",
+        "version" : "2.57.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "e866a626e105042a6a72a870c88b4c531ba05f83",
+        "version" : "2.24.0"
       }
     }
   ],

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "IntegrationTestPackage",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v14), .macOS(.v13)],
     products: [
         .library(
             name: "IntegrationTestPackage",
@@ -17,6 +17,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.15.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.24.0")
     ],
     targets: [
         .target(
@@ -27,6 +28,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SDWebImageMapKit", package: "SDWebImage"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl")
             ]),
     ]
 )

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.swift
@@ -17,7 +17,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.15.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.24.0")
     ],
     targets: [
         .target(
@@ -28,7 +27,6 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "SDWebImageMapKit", package: "SDWebImage"),
-                .product(name: "NIOSSL", package: "swift-nio-ssl")
             ]),
     ]
 )

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "IntegrationTestPackage",
-    platforms: [.iOS(.v14), .macOS(.v13)],
+    platforms: [.iOS(.v14)],
     products: [
         .library(
             name: "IntegrationTestPackage",


### PR DESCRIPTION
#87 #88 によって、 swift-nio-sslがビルドできるようになったので、
それをテストで保守します。

これがマージされたら #80 をクローズしたいです。