### PR TITLE
fix: `--embed-debug-symbols` option is not working

### DIFF
--- a/Sources/ScipioKit/BuildOptions.swift
+++ b/Sources/ScipioKit/BuildOptions.swift
@@ -67,7 +67,7 @@ public enum FrameworkType: String, Codable {
     case `static`
 }
 
-public enum SDK: String, Codable {
+public enum SDK: String, Codable, Hashable {
     case macOS
     case macCatalyst
     case iOS

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -50,6 +50,10 @@ struct DescriptionPackage {
         workspaceDirectory.appending(component: "DerivedData")
     }
 
+    var productsPath: AbsolutePath {
+        derivedDataPath.appending(component: "Products")
+    }
+
     func generatedModuleMapPath(of target: ResolvedTarget, sdk: SDK) throws -> AbsolutePath {
         let relativePath = try RelativePath(validating: "GeneratedModuleMaps/\(sdk.settingValue)")
         return workspaceDirectory

--- a/Sources/ScipioKit/Producer/Compiler.swift
+++ b/Sources/ScipioKit/Producer/Compiler.swift
@@ -16,37 +16,37 @@ extension Compiler {
         buildConfiguration: BuildConfiguration,
         sdks: Set<SDK>,
         fileSystem: FileSystem = localFileSystem
-    ) async throws -> [AbsolutePath] {
+    ) async throws -> [SDK: [AbsolutePath]] {
         let extractor = DwarfExtractor()
 
-        let debugSymbols: [DebugSymbol] = sdks.compactMap { sdk in
+        var result = [SDK: [AbsolutePath]]()
+
+        for sdk in sdks {
             let dsymPath = descriptionPackage.buildDebugSymbolPath(buildConfiguration: buildConfiguration, sdk: sdk, target: target)
-            guard fileSystem.exists(dsymPath) else { return nil }
-            return DebugSymbol(dSYMPath: dsymPath,
-                               target: target,
-                               sdk: sdk,
-                               buildConfiguration: buildConfiguration)
-        }
-        // You can use AsyncStream
-        var symbolMapPaths: [AbsolutePath] = []
-        for dSYMs in debugSymbols {
-            let dumpedDSYMsMaps = try await extractor.dump(dwarfPath: dSYMs.dwarfPath)
-            let paths = dumpedDSYMsMaps.values.map { uuid in
-                descriptionPackage.buildArtifactsDirectoryPath(buildConfiguration: dSYMs.buildConfiguration, sdk: dSYMs.sdk)
+            guard fileSystem.exists(dsymPath) else { continue }
+            let debugSymbol = DebugSymbol(dSYMPath: dsymPath,
+                                          target: target,
+                                          sdk: sdk,
+                                          buildConfiguration: buildConfiguration)
+            let dumpedDSYMsMaps = try await extractor.dump(dwarfPath: debugSymbol.dwarfPath)
+            let bcSymbolMapPaths: [AbsolutePath] = dumpedDSYMsMaps.values.compactMap { uuid in
+                let path = descriptionPackage.buildArtifactsDirectoryPath(buildConfiguration: debugSymbol.buildConfiguration, sdk: debugSymbol.sdk)
                     .appending(component: "\(uuid.uuidString).bcsymbolmap")
+                guard fileSystem.exists(path) else { return nil }
+                return path
             }
-            symbolMapPaths.append(contentsOf: paths)
+            result[sdk] = [debugSymbol.dSYMPath] + bcSymbolMapPaths
         }
-        return debugSymbols.map { $0.dSYMPath } + symbolMapPaths
+        return result
     }
 }
 
 extension DescriptionPackage {
     fileprivate func buildArtifactsDirectoryPath(buildConfiguration: BuildConfiguration, sdk: SDK) -> AbsolutePath {
-        workspaceDirectory.appending(component: "\(buildConfiguration.settingsValue)-\(sdk.settingValue)")
+        productsPath.appending(component: "\(buildConfiguration.settingsValue)-\(sdk.settingValue)")
     }
 
     fileprivate func buildDebugSymbolPath(buildConfiguration: BuildConfiguration, sdk: SDK, target: ResolvedTarget) -> AbsolutePath {
-        buildArtifactsDirectoryPath(buildConfiguration: buildConfiguration, sdk: sdk).appending(component: "\(target).framework.dSYM")
+        buildArtifactsDirectoryPath(buildConfiguration: buildConfiguration, sdk: sdk).appending(component: "\(target.name).framework.dSYM")
     }
 }

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -92,7 +92,7 @@ struct PIFCompiler: Compiler {
             try fileSystem.removeFileTree(outputXCFrameworkPath)
         }
 
-        let debugSymbolPaths: [AbsolutePath]?
+        let debugSymbolPaths: [SDK: [AbsolutePath]]?
         if buildOptions.isDebugSymbolsEmbedded {
             debugSymbolPaths = try await extractDebugSymbolPaths(target: target,
                                                                  buildConfiguration: buildOptions.buildConfiguration,

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -117,7 +117,7 @@ struct XCBuildClient {
         }
     }
 
-    func createXCFramework(sdks: Set<SDK>, debugSymbols: [AbsolutePath]?, outputPath: AbsolutePath) async throws {
+    func createXCFramework(sdks: Set<SDK>, debugSymbols: [SDK: [AbsolutePath]]?, outputPath: AbsolutePath) async throws {
         let xcbuildPath = try await fetchXCBuildPath()
 
         let additionalArguments = try buildCreateXCFrameworkArguments(
@@ -134,21 +134,23 @@ struct XCBuildClient {
         try await executor.execute(arguments)
     }
 
-    private func buildCreateXCFrameworkArguments(sdks: Set<SDK>, debugSymbols: [AbsolutePath]?, outputPath: AbsolutePath) throws -> [String] {
-        let frameworksArguments: [String] = try sdks.reduce([]) { arguments, sdk in
+    private func buildCreateXCFrameworkArguments(sdks: Set<SDK>, debugSymbols: [SDK: [AbsolutePath]]?, outputPath: AbsolutePath) throws -> [String] {
+        let frameworksWithDebugSymbolArguments: [String] = try sdks.reduce([]) { arguments, sdk in
             let path = try frameworkPath(target: buildProduct.target, of: sdk)
-            return arguments + ["-framework", path.pathString]
+            var result = arguments + ["-framework", path.pathString]
+            if let debugSymbols, let paths = debugSymbols[sdk] {
+                paths.forEach { path in
+                    result += ["-debug-symbols", path.pathString]
+                }
+            }
+            return result
         }
-
-        let debugSymbolsArguments: [String] = debugSymbols?.reduce(into: []) { arguments, path in
-            arguments.append(contentsOf: ["-debug-symbols", path.pathString])
-        } ?? []
 
         let outputPathArguments: [String] = ["-output", outputPath.pathString]
 
         // Default behavior, this command requires swiftinterface. If they don't exist, `-allow-internal-distribution` must be required.
         let additionalFlags = buildOptions.enableLibraryEvolution ? [] : ["-allow-internal-distribution"]
-        return frameworksArguments + debugSymbolsArguments + outputPathArguments + additionalFlags
+        return frameworksWithDebugSymbolArguments + outputPathArguments + additionalFlags
     }
 }
 

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -26,6 +26,7 @@ final class IntegrationTests: XCTestCase {
 
     private enum Destination: String {
         case iOS = "ios-arm64"
+        case iOSSimulator = "ios-arm64_x86_64-simulator"
         case macOS = "macos-arm64_x86_64"
         case watchOS = "watchos-arm64_arm64_32_armv7k"
     }
@@ -38,6 +39,7 @@ final class IntegrationTests: XCTestCase {
                 "_AtomicsShims": .init(frameworkType: .static),
                 "Logging": .init(platforms: .specific([.iOS, .watchOS])),
                 "NIO": .init(platforms: .specific([.iOS]), frameworkType: .static),
+                "SDWebImage": .init(platforms: .specific([.iOS]), isSimulatorSupported: true, isDebugSymbolsEmbedded: true, frameworkType: .dynamic),
             ],
             testCases: [
                 ("Atomics", .static, [.iOS], false),
@@ -45,7 +47,7 @@ final class IntegrationTests: XCTestCase {
                 ("OrderedCollections", .static, [.iOS], false),
                 ("DequeModule", .static, [.iOS], false),
                 ("_AtomicsShims", .static, [.iOS], true),
-                ("SDWebImage", .static, [.iOS], true),
+                ("SDWebImage", .dynamic, [.iOS, .iOSSimulator], true),
                 ("SDWebImageMapKit", .static, [.iOS], true),
                 ("NIO", .static, [.iOS], false),
                 ("NIOEmbedded", .static, [.iOS], false),
@@ -154,8 +156,25 @@ final class IntegrationTests: XCTestCase {
             )
 
             for destination in expectedDestinations {
-                let frameworkRoot = xcFrameworkPath
+                let sdkRoot = xcFrameworkPath
                     .appendingPathComponent(destination)
+
+                if let buildOption = buildOptionsMatrix[frameworkName],
+                   buildOption.isDebugSymbolsEmbedded == true,
+                   buildOption.frameworkType == .dynamic {
+                    XCTAssertTrue(
+                        fileManager.fileExists(atPath: sdkRoot
+                            .appendingPathComponent("dSYMs/\(frameworkName).framework.dSYM/Contents/Info.plist").path),
+                        "\(xcFrameworkName) should contain a Info.plist file in dSYMs directory"
+                    )
+                    XCTAssertTrue(
+                        fileManager.fileExists(atPath: sdkRoot
+                            .appendingPathComponent("dSYMs/\(frameworkName).framework.dSYM/Contents/Resources/DWARF/\(frameworkName)").path),
+                        "\(xcFrameworkName) should contain a DWARF file in dSYMs directory"
+                    )
+                }
+
+                let frameworkRoot = sdkRoot
                     .appendingPathComponent("\(frameworkName).framework")
 
                 if isClangFramework {

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -172,6 +172,11 @@ final class IntegrationTests: XCTestCase {
                             .appendingPathComponent("dSYMs/\(frameworkName).framework.dSYM/Contents/Resources/DWARF/\(frameworkName)").path),
                         "\(xcFrameworkName) should contain a DWARF file in dSYMs directory"
                     )
+                } else {
+                    XCTAssertFalse(
+                        fileManager.fileExists(atPath: sdkRoot.appendingPathComponent("dSYMs").path),
+                        "\(xcFrameworkName) should not contain a dSYMs directory"
+                    )
                 }
 
                 let frameworkRoot = sdkRoot


### PR DESCRIPTION
- fix: https://github.com/giginet/Scipio/issues/101

correctly copy `dSYMs` directory into xcframeworks.

testsed with Xcode 14.3.1

### result

```
$ /Users/hyde/gitclone/Scipio/.build/arm64-apple-macosx/release/scipio prepare --embed-debug-symbols --support-simulators
🔁 Resolving Dependencies...
📦 Building Alamofire for iOS, iPhone Simulator
🚀 Combining into XCFramework...
🚀 Cache Alamofire.xcframework to cache storage
❇️ Succeeded.

$ tree XCFrameworks
XCFrameworks
└── Alamofire.xcframework
    ├── Info.plist
    ├── ios-arm64
    │   ├── Alamofire.framework
    │   │   ├── Alamofire
    │   │   ├── Headers
    │   │   │   └── Alamofire-Swift.h
    │   │   ├── Info.plist
    │   │   └── Modules
    │   │       ├── Alamofire.swiftmodule
    │   │       │   ├── Project
    │   │       │   │   └── arm64-apple-ios.swiftsourceinfo
    │   │       │   ├── arm64-apple-ios.abi.json
    │   │       │   ├── arm64-apple-ios.swiftdoc
    │   │       │   └── arm64-apple-ios.swiftmodule
    │   │       └── module.modulemap
    │   └── dSYMs
    │       └── Alamofire.framework.dSYM
    │           └── Contents
    │               ├── Info.plist
    │               └── Resources
    │                   └── DWARF
    │                       └── Alamofire
    └── ios-arm64_x86_64-simulator
        ├── Alamofire.framework
        │   ├── Alamofire
        │   ├── Headers
        │   │   └── Alamofire-Swift.h
        │   ├── Info.plist
        │   ├── Modules
        │   │   ├── Alamofire.swiftmodule
        │   │   │   ├── Project
        │   │   │   │   ├── arm64-apple-ios-simulator.swiftsourceinfo
        │   │   │   │   └── x86_64-apple-ios-simulator.swiftsourceinfo
        │   │   │   ├── arm64-apple-ios-simulator.abi.json
        │   │   │   ├── arm64-apple-ios-simulator.swiftdoc
        │   │   │   ├── arm64-apple-ios-simulator.swiftmodule
        │   │   │   ├── x86_64-apple-ios-simulator.abi.json
        │   │   │   ├── x86_64-apple-ios-simulator.swiftdoc
        │   │   │   └── x86_64-apple-ios-simulator.swiftmodule
        │   │   └── module.modulemap
        │   └── _CodeSignature
        │       └── CodeResources
        └── dSYMs
            └── Alamofire.framework.dSYM
                └── Contents
                    ├── Info.plist
                    └── Resources
                        └── DWARF
                            └── Alamofire

25 directories, 26 files
```