### PR TITLE
Add option to enable manifest update closes #97

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -78,7 +78,13 @@ struct DescriptionPackage {
         return workspace
     }
 
-    init(packageDirectory: AbsolutePath, mode: Runner.Mode) throws {
+    /// Make DescriptionPackage from a passed package directory
+    /// - Parameter packageDirectory: A path for the Swift package to build
+    /// - Parameter mode: A Scipio running mode
+    /// - Parameter onlyUseVersionsFromResolvedFile: A boolean value indicates disabling force updating of Package.resolved.
+    ///   If it is `true` Package.resolved never be updated
+    ///   instead the resolving will fail if the Package.resolved is mis-matched with the workspace.
+    init(packageDirectory: AbsolutePath, mode: Runner.Mode, onlyUseVersionsFromResolvedFile: Bool) throws {
         self.packageDirectory = packageDirectory
         self.mode = mode
 
@@ -91,7 +97,7 @@ struct DescriptionPackage {
             rootInput: PackageGraphRootInput(packages: [packageDirectory]),
             // This option is same with resolver option `--disable-automatic-resolution`
             // Never update Package.resolved of the package
-            forceResolvedVersions: true,
+            forceResolvedVersions: onlyUseVersionsFromResolvedFile,
             observabilityScope: scope
         )
         self.manifest = try tsc_await {

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -81,7 +81,8 @@ struct DescriptionPackage {
     /// Make DescriptionPackage from a passed package directory
     /// - Parameter packageDirectory: A path for the Swift package to build
     /// - Parameter mode: A Scipio running mode
-    /// - Parameter onlyUseVersionsFromResolvedFile: A boolean value indicates disabling force updating of Package.resolved.
+    /// - Parameter onlyUseVersionsFromResolvedFile: A boolean value if true disabling force updating of Package.resolved.
+    /// Then, use package versions only from existing Package.resolved.
     ///   If it is `true`, Package.resolved never be updated.
     ///   Instead, the resolving will fail if the Package.resolved is mis-matched with the workspace.
     init(packageDirectory: AbsolutePath, mode: Runner.Mode, onlyUseVersionsFromResolvedFile: Bool) throws {

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -82,8 +82,8 @@ struct DescriptionPackage {
     /// - Parameter packageDirectory: A path for the Swift package to build
     /// - Parameter mode: A Scipio running mode
     /// - Parameter onlyUseVersionsFromResolvedFile: A boolean value indicates disabling force updating of Package.resolved.
-    ///   If it is `true` Package.resolved never be updated
-    ///   instead the resolving will fail if the Package.resolved is mis-matched with the workspace.
+    ///   If it is `true`, Package.resolved never be updated.
+    ///   Instead, the resolving will fail if the Package.resolved is mis-matched with the workspace.
     init(packageDirectory: AbsolutePath, mode: Runner.Mode, onlyUseVersionsFromResolvedFile: Bool) throws {
         self.packageDirectory = packageDirectory
         self.mode = mode

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -78,7 +78,7 @@ public struct Runner {
             descriptionPackage = try DescriptionPackage(
                 packageDirectory: packagePath,
                 mode: mode,
-                onlyUseVersionsFromResolvedFile: true
+                onlyUseVersionsFromResolvedFile: false
             )
         } catch {
             throw Error.invalidPackage(packageDirectory)
@@ -229,8 +229,8 @@ extension Runner {
 
         public init(
             baseBuildOptions: BuildOptions = .init(),
-            shouldOnlyUseVersionsFromResolvedFile: Bool = false,
             buildOptionsMatrix: [String: TargetBuildOptions] = [:],
+            shouldOnlyUseVersionsFromResolvedFile: Bool = false,
             cacheMode: CacheMode = .project,
             overwrite: Bool = false,
             verbose: Bool = false

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -75,7 +75,11 @@ public struct Runner {
 
         logger.info("🔁 Resolving Dependencies...")
         do {
-            descriptionPackage = try DescriptionPackage(packageDirectory: packagePath, mode: mode)
+            descriptionPackage = try DescriptionPackage(
+                packageDirectory: packagePath,
+                mode: mode,
+                onlyUseVersionsFromResolvedFile: true
+            )
         } catch {
             throw Error.invalidPackage(packageDirectory)
         }
@@ -218,12 +222,14 @@ extension Runner {
         }
 
         public var buildOptionsContainer: BuildOptionsContainer
+        public var shouldOnlyUseVersionsFromResolvedFile: Bool
         public var cacheMode: CacheMode
         public var overwrite: Bool
         public var verbose: Bool
 
         public init(
             baseBuildOptions: BuildOptions = .init(),
+            shouldOnlyUseVersionsFromResolvedFile: Bool = false,
             buildOptionsMatrix: [String: TargetBuildOptions] = [:],
             cacheMode: CacheMode = .project,
             overwrite: Bool = false,
@@ -233,6 +239,7 @@ extension Runner {
                 baseBuildOptions: baseBuildOptions,
                 buildOptionsMatrix: buildOptionsMatrix
             )
+            self.shouldOnlyUseVersionsFromResolvedFile = shouldOnlyUseVersionsFromResolvedFile
             self.cacheMode = cacheMode
             self.overwrite = overwrite
             self.verbose = verbose

--- a/Sources/scipio/CommandType.swift
+++ b/Sources/scipio/CommandType.swift
@@ -45,6 +45,7 @@ extension Runner {
         )
         let runnerOptions = Runner.Options(
             baseBuildOptions: baseBuildOptions,
+            shouldOnlyUseVersionsFromResolvedFile: true,
             cacheMode: Self.cacheMode(from: commandType),
             overwrite: buildOptions.overwrite,
             verbose: globalOptions.verbose

--- a/Sources/scipio/CommandType.swift
+++ b/Sources/scipio/CommandType.swift
@@ -45,7 +45,7 @@ extension Runner {
         )
         let runnerOptions = Runner.Options(
             baseBuildOptions: baseBuildOptions,
-            shouldOnlyUseVersionsFromResolvedFile: true,
+            shouldOnlyUseVersionsFromResolvedFile: buildOptions.shouldOnlyUseVersionsFromResolvedFile,
             cacheMode: Self.cacheMode(from: commandType),
             overwrite: buildOptions.overwrite,
             verbose: globalOptions.verbose

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -34,6 +34,10 @@ struct BuildOptionGroup: ParsableArguments {
           help: "Whether to enable Library Evolution feature or not")
     var shouldEnableLibraryEvolution = false
 
+    @Flag(name: [.customLong("only-use-versions-from-resolved-file")],
+          help: "Whether to disable updating Package.resolved automatically")
+    var shouldOnlyUseVersionsFromResolvedFile: Bool = false
+
     @Flag(name: [.customShort("f", allowingJoined: false), .long],
           help: "Whether overwrite generated frameworks or not")
     var overwrite: Bool = false

--- a/Sources/scipio/scipio.docc/prepare-cache-for-applications.md
+++ b/Sources/scipio/scipio.docc/prepare-cache-for-applications.md
@@ -95,6 +95,7 @@ All XCFrameworks are generated into `MyAppDependencies/XCFramework` by default.
 |-\-support-simulators|Whether also building for simulators of each SDKs or not|-|
 |-\-cache-policy|How to reuse built frameworks|project|
 |-\-enable-library-evolution|Whether to enable Library Evolution feature or not|-|
+|-\-only-use-versions-from-resolved-file|Whether to disable updating Package.resolved automatically|false|
 
 
 See `--help` for details.

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -10,7 +10,11 @@ private let fixturePath = URL(fileURLWithPath: #file)
 final class DescriptionPackageTests: XCTestCase {
     func testDescriptionPackage() throws {
         let rootPath = fixturePath.appendingPathComponent("TestingPackage")
-        let package = try XCTUnwrap(try DescriptionPackage(packageDirectory: rootPath.absolutePath, mode: .prepareDependencies))
+        let package = try XCTUnwrap(try DescriptionPackage(
+            packageDirectory: rootPath.absolutePath,
+            mode: .prepareDependencies,
+            onlyUseVersionsFromResolvedFile: false
+        ))
         XCTAssertEqual(package.name, "TestingPackage")
 
         let packageNames = package.graph.packages.map(\.manifest.displayName)
@@ -29,7 +33,11 @@ final class DescriptionPackageTests: XCTestCase {
 
     func testBuildProductsInPrepareMode() throws {
         let rootPath = fixturePath.appendingPathComponent("IntegrationTestPackage")
-        let package = try XCTUnwrap(try DescriptionPackage(packageDirectory: rootPath.absolutePath, mode: .prepareDependencies))
+        let package = try XCTUnwrap(try DescriptionPackage(
+            packageDirectory: rootPath.absolutePath,
+            mode: .prepareDependencies,
+            onlyUseVersionsFromResolvedFile: false
+        ))
         XCTAssertEqual(package.name, "IntegrationTestPackage")
 
         XCTAssertEqual(
@@ -58,7 +66,11 @@ final class DescriptionPackageTests: XCTestCase {
 
     func testBuildProductsInCreateMode() throws {
         let rootPath = fixturePath.appendingPathComponent("BinaryPackage")
-        let package = try XCTUnwrap(try DescriptionPackage(packageDirectory: rootPath.absolutePath, mode: .createPackage))
+        let package = try XCTUnwrap(try DescriptionPackage(
+            packageDirectory: rootPath.absolutePath,
+            mode: .createPackage,
+            onlyUseVersionsFromResolvedFile: false
+        ))
         XCTAssertEqual(package.name, "BinaryPackage")
 
         XCTAssertEqual(

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -107,6 +107,7 @@ final class IntegrationTests: XCTestCase {
                     enableLibraryEvolution: false
                 ),
                 buildOptionsMatrix: buildOptionsMatrix,
+                shouldOnlyUseVersionsFromResolvedFile: true,
                 cacheMode: .disabled,
                 overwrite: true,
                 verbose: false

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -36,7 +36,8 @@ final class RunnerTests: XCTestCase {
         let runner = Runner(
             mode: .prepareDependencies,
             options: .init(
-                baseBuildOptions: .init(isSimulatorSupported: false, enableLibraryEvolution: true)
+                baseBuildOptions: .init(isSimulatorSupported: false, enableLibraryEvolution: true),
+                shouldOnlyUseVersionsFromResolvedFile: true
             )
         )
         do {
@@ -83,7 +84,8 @@ final class RunnerTests: XCTestCase {
         let runner = Runner(
             mode: .createPackage,
             options: .init(
-                baseBuildOptions: .init(isSimulatorSupported: false)
+                baseBuildOptions: .init(isSimulatorSupported: false),
+                shouldOnlyUseVersionsFromResolvedFile: true
             )
         )
         do {
@@ -132,7 +134,8 @@ final class RunnerTests: XCTestCase {
         let runner = Runner(
             mode: .createPackage,
             options: .init(
-                baseBuildOptions: .init(isSimulatorSupported: false)
+                baseBuildOptions: .init(isSimulatorSupported: false),
+                shouldOnlyUseVersionsFromResolvedFile: true
             )
         )
         do {
@@ -211,6 +214,7 @@ final class RunnerTests: XCTestCase {
             mode: .prepareDependencies,
             options: .init(
                 baseBuildOptions: .init(enableLibraryEvolution: true),
+                shouldOnlyUseVersionsFromResolvedFile: true,
                 cacheMode: .project
             )
         )
@@ -240,6 +244,7 @@ final class RunnerTests: XCTestCase {
         let runner = Runner(
             mode: .prepareDependencies,
             options: .init(
+                shouldOnlyUseVersionsFromResolvedFile: true,
                 cacheMode: .storage(storage, [.consumer, .producer])
             )
         )
@@ -281,6 +286,7 @@ final class RunnerTests: XCTestCase {
                     isDebugSymbolsEmbedded: false,
                     frameworkType: .dynamic
                 ),
+                shouldOnlyUseVersionsFromResolvedFile: true,
                 cacheMode: .project,
                 overwrite: false,
                 verbose: false)
@@ -309,6 +315,7 @@ final class RunnerTests: XCTestCase {
                     isDebugSymbolsEmbedded: false,
                     frameworkType: .dynamic
                 ),
+                shouldOnlyUseVersionsFromResolvedFile: true,
                 cacheMode: .project,
                 overwrite: false,
                 verbose: false)
@@ -379,6 +386,7 @@ final class RunnerTests: XCTestCase {
                     frameworkType: .dynamic,
                     enableLibraryEvolution: true
                 ),
+                shouldOnlyUseVersionsFromResolvedFile: true,
                 cacheMode: .project,
                 overwrite: false,
                 verbose: false)
@@ -416,6 +424,7 @@ final class RunnerTests: XCTestCase {
                         isSimulatorSupported: true
                     ),
                 ],
+                shouldOnlyUseVersionsFromResolvedFile: true,
                 cacheMode: .project,
                 overwrite: false,
                 verbose: false)
@@ -453,6 +462,7 @@ final class RunnerTests: XCTestCase {
                     platforms: .specific([.iOS]),
                     isSimulatorSupported: true
                 ),
+                shouldOnlyUseVersionsFromResolvedFile: true,
                 cacheMode: .disabled
             )
         )
@@ -496,7 +506,8 @@ final class RunnerTests: XCTestCase {
                     extraBuildParameters: [
                         "SWIFT_OPTIMIZATION_LEVEL": "-Osize",
                     ]
-                )
+                ),
+                shouldOnlyUseVersionsFromResolvedFile: true
             )
         )
 
@@ -527,7 +538,8 @@ final class RunnerTests: XCTestCase {
                 baseBuildOptions: .init(
                     isSimulatorSupported: false,
                     enableLibraryEvolution: false
-                )
+                ),
+                shouldOnlyUseVersionsFromResolvedFile: true
             )
         )
         do {
@@ -572,7 +584,8 @@ final class RunnerTests: XCTestCase {
         let runner = Runner(
             mode: .createPackage,
             options: .init(
-                baseBuildOptions: .init(platforms: .specific([.iOS]))
+                baseBuildOptions: .init(platforms: .specific([.iOS])),
+                shouldOnlyUseVersionsFromResolvedFile: true
             )
         )
         do {

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -177,7 +177,11 @@ final class RunnerTests: XCTestCase {
     }
 
     func testCacheIsValid() async throws {
-        let descriptionPackage = try DescriptionPackage(packageDirectory: testPackagePath.absolutePath, mode: .prepareDependencies)
+        let descriptionPackage = try DescriptionPackage(
+            packageDirectory: testPackagePath.absolutePath,
+            mode: .prepareDependencies,
+            onlyUseVersionsFromResolvedFile: false
+        )
         let cacheSystem = CacheSystem(descriptionPackage: descriptionPackage,
                                       outputDirectory: frameworkOutputDir,
                                       storage: nil)
@@ -333,7 +337,8 @@ final class RunnerTests: XCTestCase {
         // Generate VersionFile
         let descriptionPackage = try DescriptionPackage(
             packageDirectory: usingBinaryPackagePath.absolutePath,
-            mode: .prepareDependencies
+            mode: .prepareDependencies,
+            onlyUseVersionsFromResolvedFile: false
         )
         let cacheSystem = CacheSystem(descriptionPackage: descriptionPackage,
                                       outputDirectory: frameworkOutputDir,


### PR DESCRIPTION
closes #97

Introduce new option `--only-use-versions-from-resolved-file`.

Enabling this option, SwiftPM never updated `Package.resolved` automatically.
If `Package. resolved` and the existing workspace is mismatched, resolving will fail.

Since this PR, the default behavior is changed. The default value becomes `false`.
Because it's inconvenient to enable this for common use cases.