### PR TITLE
Add CFBundleVersion and CFBundleShortVersionString to Info.plist

### DIFF
--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -210,7 +210,11 @@ private struct PIFLibraryTargetModifier {
         settings[.SKIP_INSTALL] = "NO"
         settings[.INSTALL_PATH] = "/usr/local/lib"
         settings[.ONLY_ACTIVE_ARCH] = "NO"
+
         settings[.GENERATE_INFOPLIST_FILE] = "YES"
+        // These values are required to ship built frameworks to AppStore as embedded frameworks
+        settings[.MARKETING_VERSION] = "1.0"
+        settings[.CURRENT_PROJECT_VERSION] = "1"
 
         // Set framework type
         switch buildOptions.frameworkType {

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -97,6 +97,8 @@ final class RunnerTests: XCTestCase {
 
             let infoPlist = try plistDecoder.decode(InfoPlist.self, from: infoPlistData)
             XCTAssertEqual(infoPlist.bundleExecutable, library)
+            XCTAssertEqual(infoPlist.bundleVersion, "1")
+            XCTAssertEqual(infoPlist.bundleShortVersionString, "1.0")
 
             XCTAssertFalse(fileManager.fileExists(atPath: simulatorFramework.path),
                            "Should not create Simulator framework")

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -17,12 +17,12 @@ private let clangPackageWithUmbrellaDirectoryPath = fixturePath.appendingPathCom
 
 private struct InfoPlist: Decodable {
     var bundleVersion: String
-    var shortVersionString: String
+    var bundleShortVersionString: String
     var bundleExecutable: String
 
     enum CodingKeys: String, CodingKey {
         case bundleVersion = "CFBundleVersion"
-        case shortVersionString = "CFShortVersionString"
+        case bundleShortVersionString = "CFBundleShortVersionString"
         case bundleExecutable = "CFBundleExecutable"
     }
 }

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -15,10 +15,24 @@ private let clangPackagePath = fixturePath.appendingPathComponent("ClangPackage"
 private let clangPackageWithCustomModuleMapPath = fixturePath.appendingPathComponent("ClangPackageWithCustomModuleMap")
 private let clangPackageWithUmbrellaDirectoryPath = fixturePath.appendingPathComponent("ClangPackageWithUmbrellaDirectory")
 
+private struct InfoPlist: Decodable {
+    var bundleVersion: String
+    var shortVersionString: String
+    var bundleExecutable: String
+
+    enum CodingKeys: String, CodingKey {
+        case bundleVersion = "CFBundleVersion"
+        case shortVersionString = "CFShortVersionString"
+        case bundleExecutable = "CFBundleExecutable"
+    }
+}
+
 final class RunnerTests: XCTestCase {
     private let fileManager: FileManager = .default
     lazy var tempDir = fileManager.temporaryDirectory
     lazy var frameworkOutputDir = tempDir.appendingPathComponent("XCFrameworks")
+
+    private let plistDecoder: PropertyListDecoder = .init()
 
     override class func setUp() {
         LoggingSystem.bootstrap { _ in SwiftLogNoOpLogHandler() }
@@ -74,6 +88,15 @@ final class RunnerTests: XCTestCase {
                 .dynamic,
                 "Binary should be a dynamic library"
             )
+
+            let infoPlistPath = deviceFramework.appendingPathComponent("Info.plist")
+            let infoPlistData = try XCTUnwrap(
+                fileManager.contents(atPath: infoPlistPath.path),
+                "Info.plist should be exist"
+            )
+
+            let infoPlist = try plistDecoder.decode(InfoPlist.self, from: infoPlistData)
+            XCTAssertEqual(infoPlist.bundleExecutable, library)
 
             XCTAssertFalse(fileManager.fileExists(atPath: simulatorFramework.path),
                            "Should not create Simulator framework")


### PR DESCRIPTION
Since 0.17.0, these values are missing in Info.plist

It causes validation error on AppStore.