### PR TITLE
Fix typo in `scipio.docc/create-frameworks.md`

### DIFF
--- a/Sources/scipio/scipio.docc/create-frameworks.md
+++ b/Sources/scipio/scipio.docc/create-frameworks.md
@@ -17,7 +17,7 @@ Let's see an example to generate XCFrameworks from [apple/swift-log](https://git
 At the first, clone the package to your local machine
 
 ```bash
-$ git clone https://github.com:apple/swift-log.git 
+$ git clone https://github.com/apple/swift-log.git 
 ```
 
 Then, run the create command with the path to the package.


### PR DESCRIPTION
I suggest to fix the typo in the documentation. Thank you!