### PR TITLE
Use default authorizationProvider to support netrc and keychain credentials for private packages

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -97,9 +97,12 @@ struct DescriptionPackage {
         workspaceConfiguration.additionalFileRules = FileRuleDescription.xcbuildFileTypes
 
         let fileSystem = TSCBasic.localFileSystem
+        let authorizationProvider =  try Workspace.Configuration.Authorization.default
+            .makeAuthorizationProvider(fileSystem: fileSystem, observabilityScope: observabilitySystem.topScope)
         let workspace = try Workspace(
             fileSystem: fileSystem,
             location: Workspace.Location(forRootPackage: packagePath, fileSystem: fileSystem),
+            authorizationProvider: authorizationProvider,
             configuration: workspaceConfiguration,
             customHostToolchain: toolchain
         )


### PR DESCRIPTION
Some SPM packages like, for example, [this package from Mapbox](https://github.com/mapbox/mapbox-navigation-native-ios/blob/6423b7abb6365b5f5731afd7265c0e5164ca9d94/Package.swift#L29C12-L29C12), have binary targets that point to a server requiring authorization. 

Both SPM and Xcode [support this out of the box](https://github.com/apple/swift-package-manager/pull/2833) since 2020.
The `authorizationProvider` is injected into SwiftPM's Workspace during initialization, however, Scipio doesn't provide this argument, so netrc/Keychain auth doesn't work when trying to download SPM dependencies.

This PR fixes the issue by using the default `authorizationProvider` same way SwiftPM already does here: https://github.com/apple/swift-package-manager/blob/351222f5b0d7dc9b1bbdffe6c86c1ec97659b36b/Sources/CoreCommands/SwiftTool.swift#L491-L509

