### PR TITLE
Add the missing argument

### DIFF
--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -181,6 +181,7 @@ extension Runner {
                 self.isSimulatorSupported = isSimulatorSupported
                 self.isDebugSymbolsEmbedded = isDebugSymbolsEmbedded
                 self.frameworkType = frameworkType
+                self.extraBuildParameters = extraBuildParameters
                 self.extraFlags = extraFlags
                 self.enableLibraryEvolution = enableLibraryEvolution
             }


### PR DESCRIPTION
`extraBuildParametes` are not passed for the buildSettingsMatrix.

So we couldn't override `extraBuildParameters`....