### PR TITLE
Pass buildOptionsMatrix to each target

### DIFF
--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -127,7 +127,8 @@ struct FrameworkProducer {
         for target in targetsToBuild {
             try await buildXCFrameworks(
                 target,
-                outputDir: outputDir
+                outputDir: outputDir,
+                buildOptionsMatrix: buildOptionsMatrix
             )
         }
 
@@ -214,14 +215,15 @@ struct FrameworkProducer {
     @discardableResult
     private func buildXCFrameworks(
         _ target: CacheSystem.CacheTarget,
-        outputDir: URL
+        outputDir: URL,
+        buildOptionsMatrix: [String: BuildOptions]
     ) async throws -> Set<CacheSystem.CacheTarget> {
         let product = target.buildProduct
         let buildOptions = target.buildOptions
 
         switch product.target.type {
         case .library:
-            let compiler = PIFCompiler(descriptionPackage: descriptionPackage, buildOptions: buildOptions)
+            let compiler = PIFCompiler(descriptionPackage: descriptionPackage, buildOptions: buildOptions, buildOptionsMatrix: buildOptionsMatrix)
             try await compiler.createXCFramework(buildProduct: product,
                                                  outputDirectory: outputDir,
                                                  overwrite: overwrite)

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -223,7 +223,11 @@ struct FrameworkProducer {
 
         switch product.target.type {
         case .library:
-            let compiler = PIFCompiler(descriptionPackage: descriptionPackage, buildOptions: buildOptions, buildOptionsMatrix: buildOptionsMatrix)
+            let compiler = PIFCompiler(
+                descriptionPackage: descriptionPackage,
+                buildOptions: buildOptions,
+                buildOptionsMatrix: buildOptionsMatrix
+            )
             try await compiler.createXCFramework(buildProduct: product,
                                                  outputDirectory: outputDir,
                                                  overwrite: overwrite)

--- a/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
@@ -79,8 +79,7 @@ struct BuildParametersGenerator {
             buildOptions.extraFlags?.swiftFlags
         )
         settings["OTHER_LDFLAGS"] = expandFlags(
-            buildParameters.flags.linkerFlags.map { $0.spm_shellEscaped() },
-            buildOptions.extraFlags?.linkerFlags
+            buildParameters.flags.linkerFlags.map { $0.spm_shellEscaped() }
         )
 
         let additionalSettings = buildOptions.extraBuildParameters ?? [:]

--- a/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
@@ -65,18 +65,15 @@ struct BuildParametersGenerator {
         )
         settings["OTHER_CFLAGS"] = expandFlags(
             buildParameters.toolchain.extraFlags.cCompilerFlags,
-            buildParameters.flags.cCompilerFlags.map { $0.spm_shellEscaped() },
-            buildOptions.extraFlags?.cFlags
+            buildParameters.flags.cCompilerFlags.map { $0.spm_shellEscaped() }
         )
         settings["OTHER_CPLUSPLUSFLAGS"] = expandFlags(
             buildParameters.toolchain.extraFlags.cxxCompilerFlags,
-            buildParameters.flags.cxxCompilerFlags.map { $0.spm_shellEscaped() },
-            buildOptions.extraFlags?.cxxFlags
+            buildParameters.flags.cxxCompilerFlags.map { $0.spm_shellEscaped() }
         )
         settings["OTHER_SWIFT_FLAGS"] = expandFlags(
             buildParameters.toolchain.extraFlags.swiftCompilerFlags,
-            buildParameters.flags.swiftCompilerFlags.map { $0.spm_shellEscaped() },
-            buildOptions.extraFlags?.swiftFlags
+            buildParameters.flags.swiftCompilerFlags.map { $0.spm_shellEscaped() }
         )
         settings["OTHER_LDFLAGS"] = expandFlags(
             buildParameters.flags.linkerFlags.map { $0.spm_shellEscaped() }

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -16,14 +16,14 @@ struct PIFCompiler: Compiler {
     init(
         descriptionPackage: DescriptionPackage,
         buildOptions: BuildOptions,
-        fileSystem: any FileSystem = TSCBasic.localFileSystem,
         buildOptionsMatrix: [String: BuildOptions],
+        fileSystem: any FileSystem = TSCBasic.localFileSystem,
         executor: any Executor = ProcessExecutor()
     ) {
         self.descriptionPackage = descriptionPackage
         self.buildOptions = buildOptions
-        self.fileSystem = fileSystem
         self.buildOptionsMatrix = buildOptionsMatrix
+        self.fileSystem = fileSystem
         self.executor = executor
         self.buildParametersGenerator = .init(buildOptions: buildOptions, fileSystem: fileSystem)
     }

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -9,6 +9,7 @@ struct PIFCompiler: Compiler {
     private let buildOptions: BuildOptions
     private let fileSystem: any FileSystem
     private let executor: any Executor
+    private let buildOptionsMatrix: [String: BuildOptions]
 
     private let buildParametersGenerator: BuildParametersGenerator
 
@@ -16,11 +17,13 @@ struct PIFCompiler: Compiler {
         descriptionPackage: DescriptionPackage,
         buildOptions: BuildOptions,
         fileSystem: any FileSystem = TSCBasic.localFileSystem,
+        buildOptionsMatrix: [String: BuildOptions],
         executor: any Executor = ProcessExecutor()
     ) {
         self.descriptionPackage = descriptionPackage
         self.buildOptions = buildOptions
         self.fileSystem = fileSystem
+        self.buildOptionsMatrix = buildOptionsMatrix
         self.executor = executor
         self.buildParametersGenerator = .init(buildOptions: buildOptions, fileSystem: fileSystem)
     }
@@ -61,7 +64,8 @@ struct PIFCompiler: Compiler {
             let generator = try PIFGenerator(
                 package: descriptionPackage,
                 buildParameters: buildParameters,
-                buildOptions: buildOptions
+                buildOptions: buildOptions,
+                buildOptionsMatrix: buildOptionsMatrix
             )
             let pifPath = try generator.generateJSON(for: sdk)
             let buildParametersPath = try buildParametersGenerator.generate(

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -27,17 +27,20 @@ struct PIFGenerator {
     private let descriptionPackage: DescriptionPackage
     private let buildParameters: BuildParameters
     private let buildOptions: BuildOptions
+    private let buildOptionsMatrix: [String: BuildOptions]
     private let fileSystem: any FileSystem
 
     init(
         package: DescriptionPackage,
         buildParameters: BuildParameters,
         buildOptions: BuildOptions,
+        buildOptionsMatrix: [String: BuildOptions],
         fileSystem: any FileSystem = TSCBasic.localFileSystem
     ) throws {
         self.descriptionPackage = package
         self.buildParameters = buildParameters
         self.buildOptions = buildOptions
+        self.buildOptionsMatrix = buildOptionsMatrix
         self.fileSystem = fileSystem
     }
 
@@ -82,6 +85,7 @@ struct PIFGenerator {
                             descriptionPackage: descriptionPackage,
                             buildParameters: buildParameters,
                             buildOptions: buildOptions,
+                            buildOptionsMatrix: buildOptionsMatrix,
                             fileSystem: fileSystem,
                             project: project,
                             pifTarget: target,
@@ -132,6 +136,7 @@ private struct PIFLibraryTargetModifier {
     private let descriptionPackage: DescriptionPackage
     private let buildParameters: BuildParameters
     private let buildOptions: BuildOptions
+    private let buildOptionsMatrix: [String: BuildOptions]
     private let fileSystem: any FileSystem
 
     private let project: PIF.Project
@@ -145,6 +150,7 @@ private struct PIFLibraryTargetModifier {
         descriptionPackage: DescriptionPackage,
         buildParameters: BuildParameters,
         buildOptions: BuildOptions,
+        buildOptionsMatrix: [String: BuildOptions],
         fileSystem: any FileSystem,
         project: PIF.Project,
         pifTarget: PIF.Target,
@@ -155,6 +161,7 @@ private struct PIFLibraryTargetModifier {
         self.descriptionPackage = descriptionPackage
         self.buildParameters = buildParameters
         self.buildOptions = buildOptions
+        self.buildOptionsMatrix = buildOptionsMatrix
         self.fileSystem = fileSystem
         self.project = project
         self.pifTarget = pifTarget
@@ -234,6 +241,10 @@ private struct PIFLibraryTargetModifier {
             settings[.SWIFT_EMIT_MODULE_INTERFACE] = "YES"
         }
         settings[.SWIFT_INSTALL_OBJC_HEADER] = "YES"
+
+        if let partialOption = self.buildOptionsMatrix[pifTarget.name] {
+            settings[.OTHER_LDFLAGS] = partialOption.extraFlags?.linkerFlags ?? []
+        }
 
         // Original PIFBuilder implementation of SwiftPM generates modulemap for Swift target
         // That modulemap refer a bridging header by a relative path

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -242,9 +242,7 @@ private struct PIFLibraryTargetModifier {
         }
         settings[.SWIFT_INSTALL_OBJC_HEADER] = "YES"
 
-        if let partialOption = self.buildOptionsMatrix[pifTarget.name] {
-            settings[.OTHER_LDFLAGS] = partialOption.extraFlags?.linkerFlags ?? []
-        }
+        appendExtraFlagsByBuildOptionsMatrix(to: &settings)
 
         // Original PIFBuilder implementation of SwiftPM generates modulemap for Swift target
         // That modulemap refer a bridging header by a relative path
@@ -272,6 +270,20 @@ private struct PIFLibraryTargetModifier {
         configuration.buildSettings = settings
 
         return configuration
+    }
+
+    // Append extraFlags from BuildOptionsMatrix to each target settings
+    private func appendExtraFlagsByBuildOptionsMatrix(to settings: inout PIF.BuildSettings) {
+        if let partialOption = self.buildOptionsMatrix[pifTarget.name] {
+            settings[.OTHER_CFLAGS]?
+                .append(contentsOf: partialOption.extraFlags?.cFlags ?? [])
+            settings[.OTHER_CPLUSPLUSFLAGS]?
+                .append(contentsOf: partialOption.extraFlags?.cxxFlags ?? [])
+            settings[.OTHER_SWIFT_FLAGS]?
+                .append(contentsOf: partialOption.extraFlags?.swiftFlags ?? [])
+            settings[.OTHER_LDFLAGS]?
+                .append(contentsOf: partialOption.extraFlags?.linkerFlags ?? [])
+        }
     }
 }
 

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -274,16 +274,16 @@ private struct PIFLibraryTargetModifier {
 
     // Append extraFlags from BuildOptionsMatrix to each target settings
     private func appendExtraFlagsByBuildOptionsMatrix(to settings: inout PIF.BuildSettings) {
-        if let partialOption = self.buildOptionsMatrix[pifTarget.name] {
-            settings[.OTHER_CFLAGS]?
-                .append(contentsOf: partialOption.extraFlags?.cFlags ?? [])
-            settings[.OTHER_CPLUSPLUSFLAGS]?
-                .append(contentsOf: partialOption.extraFlags?.cxxFlags ?? [])
-            settings[.OTHER_SWIFT_FLAGS]?
-                .append(contentsOf: partialOption.extraFlags?.swiftFlags ?? [])
-            settings[.OTHER_LDFLAGS]?
-                .append(contentsOf: partialOption.extraFlags?.linkerFlags ?? [])
+        func createOrUpdateFlags(for key: PIF.BuildSettings.MultipleValueSetting, to keyPath: KeyPath<ExtraFlags, [String]?>) {
+            if let extraFlags = self.buildOptionsMatrix[pifTarget.name]?.extraFlags?[keyPath: keyPath] {
+                settings[key] = (settings[key] ?? []) + extraFlags
+            }
         }
+
+        createOrUpdateFlags(for: .OTHER_CFLAGS, to: \.cFlags)
+        createOrUpdateFlags(for: .OTHER_CPLUSPLUSFLAGS, to: \.cxxFlags)
+        createOrUpdateFlags(for: .OTHER_SWIFT_FLAGS, to: \.swiftFlags)
+        createOrUpdateFlags(for: .OTHER_LDFLAGS, to: \.linkerFlags)
     }
 }
 


### PR DESCRIPTION
Fix the issue that `buildOptionsMatrix` sometimes doesn't work for the specific target.

## Description

Scipio generates `PIF` for each package. Each target in the package uses the same PIF. However, `PIFGenerator` doesn't refer to the matrix, so target settings were applied for all targets in the same package.

This PR fixes this issue to refer to the matrix in generating the PIF phase.