### PR TITLE
Link all dependencies of targets

### DIFF
--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -222,9 +222,11 @@ private struct PIFLibraryTargetModifier {
         // These values are required to ship built frameworks to AppStore as embedded frameworks
         settings[.MARKETING_VERSION] = "1.0"
         settings[.CURRENT_PROJECT_VERSION] = "1"
+        
+        let frameworkType = buildOptionsMatrix[pifTarget.name]?.frameworkType ?? buildOptions.frameworkType
 
         // Set framework type
-        switch buildOptions.frameworkType {
+        switch frameworkType {
         case .dynamic:
             settings[.MACH_O_TYPE] = "mh_dylib"
         case .static:
@@ -268,8 +270,41 @@ private struct PIFLibraryTargetModifier {
         }
 
         configuration.buildSettings = settings
+        
+        linkAllDependencies(of: pifTarget)
 
         return configuration
+    }
+    
+    /// Link all dependencies of the target
+    /// The original implementations of PIFBuilder links all dependencies to the PackageProduct targets
+    /// However, Scipio ignores PackageProduct so targets' dependencies haven't be linked
+    private func linkAllDependencies(of pifTarget: PIF.Target) {
+         let buildFiles = pifTarget.dependencies.enumerated().map { (index, dependency) in
+             PIF.BuildFile(guid: guid("FRAMEWORKS_BUILD_FILE_\(index)"),
+                           targetGUID: dependency.targetGUID,
+                           platformFilters: dependency.platformFilters)
+         }
+
+         if let buildPhase = fetchBuildPhase(of: PIF.FrameworksBuildPhase.self, in: pifTarget) {
+             buildPhase.buildFiles.append(contentsOf: buildFiles)
+         } else {
+             let buildPhase = PIF.FrameworksBuildPhase(
+                guid: guid("FRAMEWORKS_BUILD_PHASE"),
+                buildFiles: buildFiles
+             )
+             pifTarget.buildPhases.append(buildPhase)
+         }
+     }
+
+    /// Fetch BuildPhase of the passed type
+    private func fetchBuildPhase<BuildPhase: PIF.BuildPhase>(of buildPhasesType: BuildPhase.Type, in pifTarget: PIF.Target) -> BuildPhase? {
+        pifTarget.buildPhases.compactMap({ $0 as? BuildPhase }).first
+    }
+    
+    /// Build GUID with suffixes
+    private func guid(_ suffixes: String...) -> String {
+        "GUID::SCIPIO::\(pifTarget.name)::" + suffixes.joined(separator: "::")
     }
 
     // Append extraFlags from BuildOptionsMatrix to each target settings

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -222,7 +222,7 @@ private struct PIFLibraryTargetModifier {
         // These values are required to ship built frameworks to AppStore as embedded frameworks
         settings[.MARKETING_VERSION] = "1.0"
         settings[.CURRENT_PROJECT_VERSION] = "1"
-        
+
         let frameworkType = buildOptionsMatrix[pifTarget.name]?.frameworkType ?? buildOptions.frameworkType
 
         // Set framework type
@@ -270,12 +270,12 @@ private struct PIFLibraryTargetModifier {
         }
 
         configuration.buildSettings = settings
-        
+
         linkAllDependencies(of: pifTarget)
 
         return configuration
     }
-    
+
     /// Link all dependencies of the target
     /// The original implementations of PIFBuilder links all dependencies to the PackageProduct targets
     /// However, Scipio ignores PackageProduct so targets' dependencies haven't be linked
@@ -301,7 +301,7 @@ private struct PIFLibraryTargetModifier {
     private func fetchBuildPhase<BuildPhase: PIF.BuildPhase>(of buildPhasesType: BuildPhase.Type, in pifTarget: PIF.Target) -> BuildPhase? {
         pifTarget.buildPhases.compactMap({ $0 as? BuildPhase }).first
     }
-    
+
     /// Build GUID with suffixes
     private func guid(_ suffixes: String...) -> String {
         "GUID::SCIPIO::\(pifTarget.name)::" + suffixes.joined(separator: "::")


### PR DESCRIPTION
  Link all dependencies to the target automatically. This setting is required when the dependencies are built as dynamic frameworks.
  
  In the original PIFBuilder of SwiftPM, PackageProducts have link frameworks to their dependencies. However, Scipio ignores this and use library target to make framework instead.
  So we need to add dependencies to the framework link phase of the library targets.