### PR TITLE
Introduce Mergeable Library Support

### DIFF
--- a/Sources/ScipioKit/BuildOptions.swift
+++ b/Sources/ScipioKit/BuildOptions.swift
@@ -65,6 +65,7 @@ public enum BuildConfiguration: String, Codable, Sendable {
 public enum FrameworkType: String, Codable, Sendable {
     case dynamic
     case `static`
+    case mergeable
 }
 
 public enum SDK: String, Codable, Hashable, Sendable {

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -227,7 +227,7 @@ private struct PIFLibraryTargetModifier {
 
         // Set framework type
         switch frameworkType {
-        case .dynamic:
+        case .dynamic, .mergeable:
             settings[.MACH_O_TYPE] = "mh_dylib"
         case .static:
             settings[.MACH_O_TYPE] = "staticlib"
@@ -243,6 +243,10 @@ private struct PIFLibraryTargetModifier {
             settings[.SWIFT_EMIT_MODULE_INTERFACE] = "YES"
         }
         settings[.SWIFT_INSTALL_OBJC_HEADER] = "YES"
+        
+        if frameworkType == .mergeable {
+            settings[.OTHER_LDFLAGS] = ["-Wl,-make_mergeable"]
+        }
 
         appendExtraFlagsByBuildOptionsMatrix(to: &settings)
 

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -243,7 +243,7 @@ private struct PIFLibraryTargetModifier {
             settings[.SWIFT_EMIT_MODULE_INTERFACE] = "YES"
         }
         settings[.SWIFT_INSTALL_OBJC_HEADER] = "YES"
-        
+
         if frameworkType == .mergeable {
             settings[.OTHER_LDFLAGS] = ["-Wl,-make_mergeable"]
         }

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -245,7 +245,8 @@ private struct PIFLibraryTargetModifier {
         settings[.SWIFT_INSTALL_OBJC_HEADER] = "YES"
 
         if frameworkType == .mergeable {
-            settings[.OTHER_LDFLAGS] = ["-Wl,-make_mergeable"]
+            settings[.OTHER_LDFLAGS, default: ["$(inherited)"]]
+                .append("-Wl,-make_mergeable")
         }
 
         appendExtraFlagsByBuildOptionsMatrix(to: &settings)

--- a/Sources/scipio/CommandType.swift
+++ b/Sources/scipio/CommandType.swift
@@ -35,6 +35,11 @@ enum CommandType {
 
 extension Runner {
     init(commandType: CommandType, buildOptions: BuildOptionGroup, globalOptions: GlobalOptionGroup) {
+        // FIXME it's strange to raise the error here, but it will be removed in a future release
+        if buildOptions.shouldBuildStaticFramework {
+            fatalError("--static is deprecated. Use `-framework-type static` instead.")
+        }
+        
         let baseBuildOptions = Runner.Options.BuildOptions(
             buildConfiguration: buildOptions.buildConfiguration,
             platforms: commandType.platformSpecifier,

--- a/Sources/scipio/CommandType.swift
+++ b/Sources/scipio/CommandType.swift
@@ -39,7 +39,7 @@ extension Runner {
         if buildOptions.shouldBuildStaticFramework {
             fatalError("--static is deprecated. Use `-framework-type static` instead.")
         }
-        
+
         let baseBuildOptions = Runner.Options.BuildOptions(
             buildConfiguration: buildOptions.buildConfiguration,
             platforms: commandType.platformSpecifier,

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -28,6 +28,10 @@ struct BuildOptionGroup: ParsableArguments {
     @Flag(name: [.customLong("static")],
           help: "Whether generated frameworks are Static Frameworks or not")
     var shouldBuildStaticFramework = false
+    
+    @Option(name: [.customLong("framework-type")],
+            help: "Specify the frameworkType. Availables: dynamic, static or mergeable")
+    var frameworkType: FrameworkType = .dynamic
 
     @Flag(name: [.customLong("library-evolution")],
           inversion: .prefixedEnableDisable,
@@ -43,8 +47,4 @@ struct BuildOptionGroup: ParsableArguments {
     var overwrite: Bool = false
 }
 
-extension BuildOptionGroup {
-    var frameworkType: FrameworkType {
-        shouldBuildStaticFramework ? .static : .dynamic
-    }
-}
+extension FrameworkType: ExpressibleByArgument { }

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -28,7 +28,7 @@ struct BuildOptionGroup: ParsableArguments {
     @Flag(name: [.customLong("static")],
           help: "Whether generated frameworks are Static Frameworks or not")
     var shouldBuildStaticFramework = false
-    
+
     @Option(name: [.customLong("framework-type")],
             help: "Specify the frameworkType. Availables: dynamic, static or mergeable")
     var frameworkType: FrameworkType = .dynamic

--- a/Sources/scipio/scipio.docc/mergeable-library.md
+++ b/Sources/scipio/scipio.docc/mergeable-library.md
@@ -20,7 +20,7 @@ In general, mergeable frameworks will be about 2x bigger binary size than the no
 Mergeable frameworks have `LC_ATOM_INFO` load command in the binary. You can check it by `otool` command.
 
 ```shell
-echo $(otool -l path/to/binary) | grep "LC_ATOM_INFO"
+echo $(otool -l MyFramework.framework/MyFramework) | grep "LC_ATOM_INFO"
 ```
 
 ## Limitation

--- a/Sources/scipio/scipio.docc/mergeable-library.md
+++ b/Sources/scipio/scipio.docc/mergeable-library.md
@@ -1,0 +1,28 @@
+# Support Mergeable Library
+
+Apple announced [Mergeable Library](https://developer.apple.com/documentation/xcode/configuring-your-project-to-use-mergeable-libraries) in WWDC23. Mergeable Library is the new framework type which can switch the linking style by the build configuration. It has the metadata to change the linking style on the link time.
+
+Scipio supports `mergeable` framework type to distribute packages as mergeable libraries.
+
+```shell
+$ scipio create path/to/MyPackage --framework-type mergeable --enable-library-evolution
+```
+
+See details the official documentation and following WWDC session.
+
+- [Configuring your project to use mergeable libraries | Apple Developer Documentation](https://developer.apple.com/documentation/xcode/configuring-your-project-to-use-mergeable-libraries)
+- [Meet mergeable libraries - WWDC23 - Videos - Apple Developer](https://developer.apple.com/videos/play/wwdc2023/10268/)
+
+In general, mergeable frameworks will be about 2x bigger binary size than the normal dynamic frameworks.
+
+## How to check whether the built framework is mergeable or not
+
+Mergeable frameworks have `LC_ATOM_INFO` load command in the binary. You can check it by `otool` command.
+
+```shell
+echo $(otool -l path/to/binary) | grep "LC_ATOM_INFO"
+```
+
+## Limitation
+
+Some frameworks can't build as a dynamic framework by some reasons. They can't be distributed as mergeable libraries. Try `--framework-type static` instead.

--- a/Sources/scipio/scipio.docc/prepare-cache-for-applications.md
+++ b/Sources/scipio/scipio.docc/prepare-cache-for-applications.md
@@ -86,16 +86,16 @@ All XCFrameworks are generated into `MyAppDependencies/XCFramework` by default.
 
 `prepare` command has some options. These are available options.
 
-|Flag|Description|Default|
-|---------|------------|-----------|
-|-\-configuration, -c|Build configuration for generated frameworks (debug / release)|release|
-|-\-output, -o|Path indicates a XCFrameworks output directory|$PACKAGE_ROOT/XCFrameworks|
-|-\-embed-debug-symbols|Whether embed debug symbols to frameworks or not|-|
-|-\-static|Whether generated frameworks are Static Frameworks or not|-|
-|-\-support-simulators|Whether also building for simulators of each SDKs or not|-|
-|-\-cache-policy|How to reuse built frameworks|project|
-|-\-enable-library-evolution|Whether to enable Library Evolution feature or not|-|
-|-\-only-use-versions-from-resolved-file|Whether to disable updating Package.resolved automatically|false|
+| Flag                                    | Description                                                         | Default                    |
+|-----------------------------------------|---------------------------------------------------------------------|----------------------------|
+| -\-configuration, -c                    | Build configuration for generated frameworks (debug / release)      | release                    |
+| -\-output, -o                           | Path indicates a XCFrameworks output directory                      | $PACKAGE_ROOT/XCFrameworks |
+| -\-embed-debug-symbols                  | Whether embed debug symbols to frameworks or not                    | -                          |
+| -\-framework-type                       | Framework type to generate Available: dynamic, static or mergeable) | dynamic                    |
+| -\-support-simulators                   | Whether also building for simulators of each SDKs or not            | -                          |
+| -\-cache-policy                         | How to reuse built frameworks                                       | project                    |
+| -\-enable-library-evolution             | Whether to enable Library Evolution feature or not                  | -                          |
+| -\-only-use-versions-from-resolved-file | Whether to disable updating Package.resolved automatically          | false                      |
 
 
 See `--help` for details.

--- a/Sources/scipio/scipio.docc/scipio.md
+++ b/Sources/scipio/scipio.docc/scipio.md
@@ -23,4 +23,4 @@ A new build tool to generate XCFramework from Swift Package
 - <doc:cache-system>
 - <doc:build-pipeline>
 - <doc:using-s3-storage>
-
+- <doc:mergeable-library>

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -519,7 +519,7 @@ final class RunnerTests: XCTestCase {
             )
         }
     }
-    
+
     func testMergeableLibrary() async throws {
         let runner = Runner(
             mode: .createPackage,
@@ -537,10 +537,10 @@ final class RunnerTests: XCTestCase {
                              frameworkOutputDir: .custom(frameworkOutputDir))
 
         let xcFramework = frameworkOutputDir.appendingPathComponent("TestingPackage.xcframework")
-        
+
         let executor = ProcessExecutor()
-        
-        for arch in ["ios-arm64",] {
+
+        for arch in ["ios-arm64"] {
             let binaryPath = xcFramework
                 .appendingPathComponent(arch)
                 .appendingPathComponent("TestingPackage.framework")
@@ -549,7 +549,7 @@ final class RunnerTests: XCTestCase {
                 fileManager.fileExists(atPath: binaryPath.path),
                 "A framework for \(arch) should contain binary"
             )
-            
+
             let executionResult = try await executor.execute("/usr/bin/otool", "-l", binaryPath.path())
             let loadCommands = try XCTUnwrap(executionResult.unwrapOutput())
             XCTAssertTrue(


### PR DESCRIPTION
Introduce a new framework type, `mergeable,` to build a Mergeable Library.

`--static` flag is deprecated. Use `--framework-type static` instead.