### PR TITLE
Fix log level

### DIFF
--- a/Sources/scipio/CreateCommands.swift
+++ b/Sources/scipio/CreateCommands.swift
@@ -21,7 +21,7 @@ extension Scipio {
         var platforms: [Runner.Options.Platform] = []
 
         mutating func run() async throws {
-            let logLevel: Logger.Level = globalOptions.verbose ? .info : .warning
+            let logLevel: Logger.Level = globalOptions.verbose ? .trace : .info
             LoggingSystem.bootstrap(logLevel: logLevel)
 
             let platformSpecifier: Runner.Options.PlatformSpecifier

--- a/Sources/scipio/PrepareCommands.swift
+++ b/Sources/scipio/PrepareCommands.swift
@@ -28,7 +28,7 @@ extension Scipio {
         @OptionGroup var globalOptions: GlobalOptionGroup
 
         mutating func run() async throws {
-            let logLevel: Logger.Level = globalOptions.verbose ? .info : .warning
+            let logLevel: Logger.Level = globalOptions.verbose ? .trace : .info
             LoggingSystem.bootstrap(logLevel: logLevel)
 
             let runnerCacheMode: Runner.Options.CacheMode


### PR DESCRIPTION
`scipio` command doesn't show info log when `verbose`  is not specified from https://github.com/giginet/Scipio/commit/9fb11bf27ae650576edccafb6696012ba096af09 .
I asked @giginet about the issue in person, and he said it's a bug.

In this PR, I fixed the log level.