### PR TITLE
Fix DescriptionPackage resolves targets not exported via products

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -188,7 +188,8 @@ extension DescriptionPackage {
             // In create mode, all products should be built
             // In future update, users will be enable to specify products want to build
             let rootPackage = try fetchRootPackage()
-            let productsToBuild = rootPackage.products
+            let productNamesToBuild = rootPackage.manifest.products.map { $0.name }
+            let productsToBuild = rootPackage.products.filter { productNamesToBuild.contains($0.name) }
             return Set(productsToBuild.flatMap(\.targets))
         case .prepareDependencies:
             // In prepare mode, all targets should be built

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -65,17 +65,20 @@ final class DescriptionPackageTests: XCTestCase {
     }
 
     func testBuildProductsInCreateMode() throws {
-        let rootPath = fixturePath.appendingPathComponent("BinaryPackage")
+        let rootPath = fixturePath.appendingPathComponent("TestingPackage")
         let package = try XCTUnwrap(try DescriptionPackage(
             packageDirectory: rootPath.absolutePath,
             mode: .createPackage,
             onlyUseVersionsFromResolvedFile: false
         ))
-        XCTAssertEqual(package.name, "BinaryPackage")
+        XCTAssertEqual(package.name, "TestingPackage")
 
         XCTAssertEqual(
             Set(try package.resolveBuildProducts().map(\.target.name)),
-            ["SomeBinary"]
+            [
+                "Logging",
+                "TestingPackage"
+            ]
         )
     }
 }

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -95,5 +95,4 @@ final class DescriptionPackageTests: XCTestCase {
             ["SomeBinary"]
         )
     }
-
 }

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -77,8 +77,23 @@ final class DescriptionPackageTests: XCTestCase {
             Set(try package.resolveBuildProducts().map(\.target.name)),
             [
                 "Logging",
-                "TestingPackage"
+                "TestingPackage",
             ]
         )
     }
+
+    func testBinaryBuildProductsInCreateMode() throws {
+        let rootPath = fixturePath.appendingPathComponent("BinaryPackage")
+        let package = try XCTUnwrap(try DescriptionPackage(
+            packageDirectory: rootPath.absolutePath,
+            mode: .createPackage,
+            onlyUseVersionsFromResolvedFile: false
+        ))
+        XCTAssertEqual(package.name, "BinaryPackage")
+        XCTAssertEqual(
+            Set(try package.resolveBuildProducts().map(\.target.name)),
+            ["SomeBinary"]
+        )
+    }
+
 }

--- a/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Package.swift
@@ -22,6 +22,16 @@ let package = Package(
             name: "TestingPackage",
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
-            ]),
+            ]
+        ),
+        .executableTarget(
+            name: "InternalExecutableTarget",
+            dependencies: ["InternalRegularTarget"]
+        ),
+        .target(name: "InternalRegularTarget"),
+        .testTarget(
+            name: "TestingPackageTests",
+            dependencies: ["InternalRegularTarget"]
+        )
     ]
 )

--- a/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Sources/InternalExecutableTarget/InternalExecutableTarget.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Sources/InternalExecutableTarget/InternalExecutableTarget.swift
@@ -1,0 +1,4 @@
+@main
+public struct InternalExecutableTarget {
+    static func main() {}
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Sources/InternalRegularTarget/InternalRegularTarget.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Sources/InternalRegularTarget/InternalRegularTarget.swift
@@ -1,0 +1,3 @@
+public struct InternalRegularTarget {
+    public init() {}
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Tests/TestingPackageTests/TestingPackageTests.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/TestingPackage/Tests/TestingPackageTests/TestingPackageTests.swift
@@ -1,0 +1,4 @@
+import XCTest
+import InternalRegularTarget
+
+class TestingPackageTests: XCTest {}


### PR DESCRIPTION
### Issue
The `DescriptionPackage` in `createPackage` mode may currently export internal targets that are not intended to be exported via `products`. This occurs because [PackageBuilder](https://github.com/swiftlang/swift-package-manager/blob/338edfdec96ce8fa8b9f33e12838f74a45063afc/Sources/PackageLoading/PackageBuilder.swift#L275) implicitly generates additional products in `ResolvedPackage.products` for executable and test targets (in addition to the actually exported products). These generated products may depend on internal targets that must not be built by `Scipio`.

### Solution
Unlike `ResolvedPackage`, the [Manifest](https://github.com/swiftlang/swift-package-manager/blob/338edfdec96ce8fa8b9f33e12838f74a45063afc/Sources/PackageModel/Manifest/Manifest.swift#L80-L81) object accurately reflects all the original manifest properties and is not affected by the issue/feature described above. I suggest using the `products` from `Manifest` instead of the ones from `ResolvedPackage`.

### Example
`Swift-DocC Plugin` [exports two products](https://github.com/apple/swift-docc-plugin/blob/main/Package.swift#L19-L22): "Swift-DocC" and "Swift-DocC Preview", but `Scipio` in the current implementation resolves (for the reason described above) 4 products: 
```
po package.products
▿ 4 elements
  ▿ 0 : <Product: Swift-DocC Preview>
  ▿ 1 : <Product: Swift-DocC>
  ▿ 2 : <Product: SwiftDocCPluginPackageTests>
  ▿ 3 : <Product: snippet-extract>
```
The last two products `SwiftDocCPluginPackageTests` and `snippet-extract` are test and executable targets respectively that were implicitly generated by `SwiftPM`. In addition, these generated products export some internal targets that should be ignored and not pre-built by `Scipio`.

### Detailed description
`products` for `ResolvedPackage` are constructed in [PackageBuilder.constructProducts](https://github.com/swiftlang/swift-package-manager/blob/338edfdec96ce8fa8b9f33e12838f74a45063afc/Sources/PackageLoading/PackageBuilder.swift#L1363). During the product construction process the builder treats `test` and `executable` targets in a special way, including them in the resulting product arrays, namely:
- An implicit product for test targets with the `PackageTests` prefix [is appended to the resulting products ](https://github.com/swiftlang/swift-package-manager/blob/338edfdec96ce8fa8b9f33e12838f74a45063afc/Sources/PackageLoading/PackageBuilder.swift#L1406).
- [An implicit product is generated for executable targets](https://github.com/swiftlang/swift-package-manager/blob/338edfdec96ce8fa8b9f33e12838f74a45063afc/Sources/PackageLoading/PackageBuilder.swift#L1520-L1528).

### Questions
- @giginet  Would it be fine to open PRs for similar issues right away in the future, or would it be better to discuss them in `Issues` first?
