### PR TITLE
Support Swift 6 snapshot

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 env: 
-  DEVELOPER_DIR: "/Applications/Xcode_15.3.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_15.4.app/Contents/Developer"
 jobs:
   DocC:
     runs-on: macos-14

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   SwiftLint:
     strategy:
       matrix:
-        xcode_version: ["15.3"]
+        xcode_version: ["15.4"]
     env: 
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
     runs-on: macos-14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
 
 name: Upload Artifact Bundle to Release
 env: 
-  DEVELOPER_DIR: "/Applications/Xcode_15.3.app/Contents/Developer"
+  DEVELOPER_DIR: "/Applications/Xcode_15.4.app/Contents/Developer"
   SCIPIO_DEVELOPMENT: 1
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ jobs:
   Tests:
     strategy:
       matrix:
-        xcode_version: ["15.3"]
-        swift: ["5.9.2", "5.10.0"]
+        xcode_version: ["15.4", "16.0"]
+        swift: ["5.9.2", "5.10.0", "6.0"]
     env: 
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
     runs-on: macos-14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         xcode_version: ["15.4", "16.0"]
         swift: ["5.9.2", "5.10.0", "6.0"]
+        exclude:
+          # Xcode 15.4 & Swift 6.0 shouldn't be supported
+          - xcode_version: "15.4"
+            swift: "6.0"
     env: 
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
     runs-on: macos-14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,31 +11,20 @@ jobs:
   Tests:
     strategy:
       matrix:
-        xcode_version: ["15.4", "16.0"]
-        swift: ["5.9.2", "5.10.0", "6.0"]
-        exclude:
-          # Xcode 15.4 & Swift 6.0 shouldn't be supported
-          - xcode_version: "15.4"
-            swift: "6.0"
+        xcode_version:
+          - "15.2" # 5.9
+          - "15.4" # 5.10
+          - "16.0" # 6.0
     env: 
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
     runs-on: macos-14
     steps:
-    - uses: SwiftyLab/setup-swift@latest
-      with:
-        development: true
-        swift-version: ${{ matrix.swift }}
     - name: Get swift version
       run: swift --version
     - uses: actions/checkout@v2
     - name: Run Tests
       run: |
-        # If default toolchain in Xcode is used, `env.TOOLCHAINS` will be empty
-        if [[ -n "${{ env.TOOLCHAINS }}" ]]; then
-          xcrun --toolchain ${{ env.TOOLCHAINS }} swift test --verbose
-        else
-          swift test --verbose
-        fi
+        swift test --verbose
       env:
         ENABLE_INTEGRATION_TESTS: 1
         IS_CI: 1

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-package-manager.git",
-                 branch: "release/6.0"),
+                 revision: "swift-5.10-RELEASE"),
         .package(url: "https://github.com/apple/swift-log.git",
                  from: "1.5.2"),
         .package(url: "https://github.com/apple/swift-collections",
@@ -75,8 +75,7 @@ let package = Package(
             resources: [.copy("Resources/Fixtures")],
             swiftSettings: swiftSettings
         ),
-    ],
-    swiftLanguageVersions: [.v6]
+    ]
 )
 
 let isDevelopment = ProcessInfo.processInfo.environment["SCIPIO_DEVELOPMENT"] == "1"

--- a/Plugins/GenerateScipioVersion/plugin.swift
+++ b/Plugins/GenerateScipioVersion/plugin.swift
@@ -85,7 +85,7 @@ extension Command {
             executable: Path(executable.path()),
             arguments: arguments,
             outputFilesDirectory: Path(outputFilesDirectory.path())
-        ),
+        )
     }
 }
 

--- a/Plugins/GenerateScipioVersion/plugin.swift
+++ b/Plugins/GenerateScipioVersion/plugin.swift
@@ -4,14 +4,14 @@ import PackagePlugin
 @main
 struct GenerateScipioVersion: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
-        let zshPath = URL(filePath: "/bin/zsh")
+        let zshPath = URL(filePath: "/bin/zsh") // execute dummy command
         
         #if compiler(>=6.0)
         let generatedSourceDir = context.pluginWorkDirectoryURL
         #else
         let generatedSourceDir = URL(filePath: context.pluginWorkDirectory.string)
         #endif
-        // execute dummy command
+        
         let generatedSourcePath = generatedSourceDir
             .appending(component: "ScipioVersion.generated.swift")
 

--- a/Plugins/GenerateScipioVersion/plugin.swift
+++ b/Plugins/GenerateScipioVersion/plugin.swift
@@ -67,3 +67,26 @@ struct GenerateScipioVersion: BuildToolPlugin {
         return revision
     }
 }
+
+#if compiler(<6.0)
+
+// Backward compatibility below 6.0 compiler
+// Convert Foundation.URL to Path
+extension Command {
+    fileprivate static func prebuildCommand(
+        displayName: String?,
+        executable: URL,
+        arguments: [any CustomStringConvertible],
+        environment: [String : any CustomStringConvertible] = [:],
+        outputFilesDirectory: URL
+    ) -> PackagePlugin.Command {
+        .prebuildCommand(
+            displayName: displayName,
+            executable: Path(executable.path()),
+            arguments: arguments,
+            outputFilesDirectory: Path(outputFilesDirectory.path())
+        ),
+    }
+}
+
+#endif

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Scipio
 
 ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/giginet/Scipio/tests.yml?style=flat-square&logo=github)
+![Swift 6.0](https://img.shields.io/badge/Swift-6.0-FA7343?logo=swift&style=flat-square)
 ![Swift 5.10](https://img.shields.io/badge/Swift-5.10-FA7343?logo=swift&style=flat-square)
 ![Swift 5.9](https://img.shields.io/badge/Swift-5.9-FA7343?logo=swift&style=flat-square)
-[![Xcode 15.3](https://img.shields.io/badge/Xcode-15.3-147EFB?style=flat-square&logo=xcode&link=https%3A%2F%2Fdeveloper.apple.com%2Fxcode%2F)](https://developer.apple.com/xcode/)
+[![Xcode 16.0 Beta](https://img.shields.io/badge/Xcode-16.0-147EFB?style=flat-square&logo=xcode&link=https%3A%2F%2Fdeveloper.apple.com%2Fxcode%2F)](https://developer.apple.com/xcode/)
+[![Xcode 15.4](https://img.shields.io/badge/Xcode-15.4-147EFB?style=flat-square&logo=xcode&link=https%3A%2F%2Fdeveloper.apple.com%2Fxcode%2F)](https://developer.apple.com/xcode/)
 [![Xcode 15.2](https://img.shields.io/badge/Xcode-15.2-147EFB?style=flat-square&logo=xcode&link=https%3A%2F%2Fdeveloper.apple.com%2Fxcode%2F)](https://developer.apple.com/xcode/)
 [![SwiftPM](https://img.shields.io/badge/SwiftPM-compatible-green?logo=swift&style=flat-square)](https://swift.org/package-manager/) 
 [![Documentation](https://img.shields.io/badge/Documentation-available-green?style=flat-square)](https://giginet.github.io/Scipio/documentation/scipio/)

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -12,7 +12,7 @@ struct DescriptionPackage {
     let packageDirectory: ScipioAbsolutePath
     private let toolchain: UserToolchain
     let workspace: Workspace
-    let graph: PackageGraph
+    let graph: ModulesGraph
     let manifest: Manifest
 
     enum Error: LocalizedError {
@@ -168,12 +168,14 @@ extension DescriptionPackage {
                     #if compiler(>=6.0)
                     case .module(let module, conditions: _):
                         return [resolvedTargetToBuildProduct(module)]
+                    case .product(let product, conditions: _):
+                        return product.modules.map(resolvedTargetToBuildProduct)
                     #else
                     case .target(let target, conditions: _):
                         return [resolvedTargetToBuildProduct(target)]
-                    #endif
                     case .product(let product, conditions: _):
                         return product.targets.map(resolvedTargetToBuildProduct)
+                    #endif
                     }
                 }
             }

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -163,7 +163,7 @@ extension DescriptionPackage {
 
         do {
             products = try topologicalSort(products) { (product) in
-                return product.target.dependencies.flatMap { (dependency) in
+                return product.target.dependencies.flatMap { (dependency) -> [BuildProduct] in
                     switch dependency {
                     #if compiler(>=6.0)
                     case .module(let module, conditions: _):
@@ -173,7 +173,7 @@ extension DescriptionPackage {
                         return [resolvedTargetToBuildProduct(target)]
                     #endif
                     case .product(let product, conditions: _):
-                        return product.modules.map(resolvedTargetToBuildProduct)
+                        return product.targets.map(resolvedTargetToBuildProduct)
                     }
                 }
             }
@@ -187,7 +187,7 @@ extension DescriptionPackage {
         return products.reversed()
     }
 
-    private func targetsToBuild() throws -> IdentifiableSet< ScipioResolvedModule> {
+    private func targetsToBuild() throws -> [ScipioResolvedModule] {
         switch mode {
         case .createPackage:
             // In create mode, all products should be built

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -196,7 +196,7 @@ extension DescriptionPackage {
             let productNamesToBuild = rootPackage.manifest.products.map { $0.name }
             let productsToBuild = rootPackage.products.filter { productNamesToBuild.contains($0.name) }
             #if compiler(>=6.0)
-            return IdentifiableSet(productsToBuild.flatMap(\.modules))
+            return productsToBuild.flatMap(\.modules)
             #else
             return productsToBuild.flatMap(\.targets)
             #endif
@@ -204,7 +204,7 @@ extension DescriptionPackage {
             // In prepare mode, all targets should be built
             // In future update, users will be enable to specify targets want to build
             #if compiler(>=6.0)
-            return try fetchRootPackage().modules
+            return Array(try fetchRootPackage().modules)
             #else
             return try fetchRootPackage().targets
             #endif

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -51,7 +51,7 @@ struct DescriptionPackage {
         workspaceDirectory.appending(component: "DerivedData")
     }
 
-    func generatedModuleMapPath(of target: ResolvedTarget, sdk: SDK) throws -> ScipioAbsolutePath {
+    func generatedModuleMapPath(of target: ScipioResolvedModule, sdk: SDK) throws -> ScipioAbsolutePath {
         let relativePath = try TSCBasic.RelativePath(validating: "ModuleMapsForFramework/\(sdk.settingValue)")
         return workspaceDirectory
             .appending(relativePath)
@@ -154,7 +154,7 @@ extension DescriptionPackage {
         var products = try targetsToBuild.flatMap(resolveBuildProduct(from:))
 
         let productMap: [String: BuildProduct] = Dictionary(products.map { ($0.target.name, $0) }) { $1 }
-        func resolvedTargetToBuildProduct(_ target: ResolvedTarget) -> BuildProduct {
+        func resolvedTargetToBuildProduct(_ target: ScipioResolvedModule) -> BuildProduct {
             guard let product = productMap[target.name] else {
                 preconditionFailure("The dependency target (\(target.name)) was not found in the build target list")
             }
@@ -165,10 +165,15 @@ extension DescriptionPackage {
             products = try topologicalSort(products) { (product) in
                 return product.target.dependencies.flatMap { (dependency) in
                     switch dependency {
+                    #if compiler(>=6.0)
+                    case .module(let module, conditions: _):
+                        return [resolvedTargetToBuildProduct(module)]
+                    #else
                     case .target(let target, conditions: _):
                         return [resolvedTargetToBuildProduct(target)]
+                    #endif
                     case .product(let product, conditions: _):
-                        return product.targets.map(resolvedTargetToBuildProduct)
+                        return product.modules.map(resolvedTargetToBuildProduct)
                     }
                 }
             }
@@ -182,7 +187,7 @@ extension DescriptionPackage {
         return products.reversed()
     }
 
-    private func targetsToBuild() throws -> Set<ResolvedTarget> {
+    private func targetsToBuild() throws -> IdentifiableSet< ScipioResolvedModule> {
         switch mode {
         case .createPackage:
             // In create mode, all products should be built
@@ -190,11 +195,19 @@ extension DescriptionPackage {
             let rootPackage = try fetchRootPackage()
             let productNamesToBuild = rootPackage.manifest.products.map { $0.name }
             let productsToBuild = rootPackage.products.filter { productNamesToBuild.contains($0.name) }
-            return Set(productsToBuild.flatMap(\.targets))
+            #if compiler(>=6.0)
+            return IdentifiableSet(productsToBuild.flatMap(\.modules))
+            #else
+            return productsToBuild.flatMap(\.targets)
+            #endif
         case .prepareDependencies:
             // In prepare mode, all targets should be built
             // In future update, users will be enable to specify targets want to build
-            return Set(try fetchRootPackage().targets)
+            #if compiler(>=6.0)
+            return try fetchRootPackage().modules
+            #else
+            return try fetchRootPackage().targets
+            #endif
         }
     }
 
@@ -205,8 +218,14 @@ extension DescriptionPackage {
         return rootPackage
     }
 
-    private func resolveBuildProduct(from rootTarget: ResolvedTarget) throws -> Set<BuildProduct> {
-        let dependencyProducts = Set(try rootTarget.recursiveTargetDependencies().flatMap(buildProducts(from:)))
+    private func resolveBuildProduct(from rootTarget: ScipioResolvedModule) throws -> Set<BuildProduct> {
+        #if compiler(>=6.0)
+        let dependencyProducts = Set(try rootTarget.recursiveModuleDependencies()
+            .flatMap(buildProducts(from:)))
+        #else
+        let dependencyProducts = Set(try rootTarget.recursiveTargetDependencies()
+            .flatMap(buildProducts(from:)))
+        #endif
 
         switch mode {
         case .createPackage:
@@ -219,26 +238,30 @@ extension DescriptionPackage {
         }
     }
 
-    private func buildProducts(from target: ResolvedTarget) throws -> Set<BuildProduct> {
+    private func buildProducts(from target: ScipioResolvedModule) throws -> Set<BuildProduct> {
         guard let package = graph.package(for: target) else {
             return []
         }
 
         let rootTargetProduct = BuildProduct(package: package, target: target)
+        #if compiler(>=6.0)
+        let dependencyProducts = try target.recursiveDependencies().compactMap(\.module).flatMap(buildProducts(from:))
+        #else
         let dependencyProducts = try target.recursiveDependencies().compactMap(\.target).flatMap(buildProducts(from:))
+        #endif
         return Set([rootTargetProduct] + dependencyProducts)
     }
 }
 
 struct BuildProduct: Hashable, Sendable {
     var package: ResolvedPackage
-    var target: ResolvedTarget
+    var target: ScipioResolvedModule
 
     var frameworkName: String {
         "\(target.name.packageNamed()).xcframework"
     }
 
-    var binaryTarget: BinaryTarget? {
-        target.underlyingTarget as? BinaryTarget
+    var binaryTarget: ScipioBinaryModule? {
+        target.underlying as? ScipioBinaryModule
     }
 }

--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -37,6 +37,15 @@ extension Executor {
 
 extension ProcessResult {
     mutating func setOutput(_ newValue: Result<[UInt8], Swift.Error>) {
+        #if compiler(>=6.0)
+        self = ProcessResult(
+            arguments: arguments,
+            environmentBlock: environmentBlock,
+            exitStatus: exitStatus,
+            output: newValue,
+            stderrOutput: stderrOutput
+        )
+        #else
         self = ProcessResult(
             arguments: arguments,
             environment: environment,
@@ -44,9 +53,19 @@ extension ProcessResult {
             output: newValue,
             stderrOutput: stderrOutput
         )
+        #endif
     }
 
     mutating func setStderrOutput(_ newValue: Result<[UInt8], Swift.Error>) {
+        #if compiler(>=6.0)
+        self = ProcessResult(
+            arguments: arguments,
+            environmentBlock: environmentBlock,
+            exitStatus: exitStatus,
+            output: output,
+            stderrOutput: newValue
+        )
+        #else
         self = ProcessResult(
             arguments: arguments,
             environment: environment,
@@ -54,6 +73,7 @@ extension ProcessResult {
             output: output,
             stderrOutput: newValue
         )
+        #endif
     }
 }
 

--- a/Sources/ScipioKit/PackageGraph+Extensions.swift
+++ b/Sources/ScipioKit/PackageGraph+Extensions.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PackageGraph
 
-extension ResolvedTarget {
+extension ScipioResolvedModule {
     var xcFrameworkName: String {
         "\(c99name.packageNamed()).xcframework"
     }

--- a/Sources/ScipioKit/Producer/BinaryExtractor.swift
+++ b/Sources/ScipioKit/Producer/BinaryExtractor.swift
@@ -9,7 +9,7 @@ struct BinaryExtractor {
     var fileSystem: any FileSystem
 
     @discardableResult
-    func extract(of binaryTarget: BinaryTarget, overwrite: Bool) throws -> URL {
+    func extract(of binaryTarget: ScipioBinaryModule, overwrite: Bool) throws -> URL {
         let sourcePath = binaryTarget.artifactPath
         let frameworkName = "\(binaryTarget.c99name).xcframework"
         let fileName = sourcePath.basename

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -77,7 +77,7 @@ extension PinsStore.PinState: Codable {
     }
 }
 
-extension PinsStore.PinState: Hashable {
+extension PinsStore.PinState: @retroactive Hashable {
     public func hash(into hasher: inout Hasher) {
         switch self {
         case .revision(let revision):

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -77,6 +77,8 @@ extension PinsStore.PinState: Codable {
     }
 }
 
+#if compiler(>=6.0)
+
 extension PinsStore.PinState: @retroactive Hashable {
     public func hash(into hasher: inout Hasher) {
         switch self {
@@ -91,6 +93,25 @@ extension PinsStore.PinState: @retroactive Hashable {
         }
     }
 }
+
+#else
+
+extension PinsStore.PinState: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .revision(let revision):
+            hasher.combine(revision)
+        case .version(let version, let revision):
+            hasher.combine(version)
+            hasher.combine(revision)
+        case .branch(let branchName, let revision):
+            hasher.combine(branchName)
+            hasher.combine(revision)
+        }
+    }
+}
+
+#endif
 
 public struct SwiftPMCacheKey: CacheKey {
     public var targetName: String

--- a/Sources/ScipioKit/Producer/Compiler.swift
+++ b/Sources/ScipioKit/Producer/Compiler.swift
@@ -12,7 +12,7 @@ protocol Compiler {
 
 extension Compiler {
     func extractDebugSymbolPaths(
-        target: ResolvedTarget,
+        target: ScipioResolvedModule,
         buildConfiguration: BuildConfiguration,
         sdks: Set<SDK>,
         fileSystem: FileSystem = localFileSystem
@@ -45,7 +45,7 @@ extension Compiler {
 }
 
 extension DescriptionPackage {
-    fileprivate func buildDebugSymbolPath(buildConfiguration: BuildConfiguration, sdk: SDK, target: ResolvedTarget) -> AbsolutePath {
+    fileprivate func buildDebugSymbolPath(buildConfiguration: BuildConfiguration, sdk: SDK, target: ScipioResolvedModule) -> AbsolutePath {
         productsDirectory(buildConfiguration: buildConfiguration, sdk: sdk)
             .appending(component: "\(target.name).framework.dSYM")
     }

--- a/Sources/ScipioKit/Producer/DebugSymbol.swift
+++ b/Sources/ScipioKit/Producer/DebugSymbol.swift
@@ -4,7 +4,7 @@ import TSCBasic
 
 struct DebugSymbol {
     var dSYMPath: AbsolutePath
-    var target: ResolvedTarget
+    var target: ScipioResolvedModule
     var sdk: SDK
     var buildConfiguration: BuildConfiguration
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -240,9 +240,15 @@ struct FrameworkProducer {
                                                  outputDirectory: outputDir,
                                                  overwrite: overwrite)
         case .binary:
+            #if compiler(>=6.0)
+            guard let binaryTarget = product.target.underlying as? BinaryModule else {
+                fatalError("Unexpected failure")
+            }
+            #else
             guard let binaryTarget = product.target.underlyingTarget as? BinaryTarget else {
                 fatalError("Unexpected failure")
             }
+            #endif
             let binaryExtractor = BinaryExtractor(
                 package: descriptionPackage,
                 outputDirectory: outputDir,

--- a/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
@@ -36,7 +36,9 @@ struct BuildParametersGenerator {
     }
 
     func generate(for sdk: SDK, buildParameters: BuildParameters, destinationDir: AbsolutePath) throws -> AbsolutePath {
-        #if swift(>=5.10)
+        #if compiler(>=6.0)
+        let targetArchitecture = buildParameters.triple.arch?.rawValue ?? "arm64"
+        #elseif swift(>=5.10)
         let targetArchitecture = buildParameters.targetTriple.arch?.rawValue ?? "arm64"
         #elseif swift(>=5.9)
         let targetArchitecture = buildParameters.triple.arch?.rawValue ?? "arm64"

--- a/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
@@ -147,13 +147,13 @@ struct FrameworkComponentsCollector {
 
     /// Collects public headers of clangTarget
     private func collectPublicHeader() throws -> Set<AbsolutePath>? {
-        guard let clangTarget = buildProduct.target.underlyingTarget as? ClangTarget else {
+        guard let clangModule = buildProduct.target.underlying as? ScipioClangModule else {
             return nil
         }
 
-        let publicHeaders = clangTarget
+        let publicHeaders = clangModule
             .headers
-            .filter { $0.isDescendant(of: clangTarget.includeDir) }
+            .filter { $0.isDescendant(of: clangModule.includeDir) }
         let notSymlinks = publicHeaders.filter { !fileSystem.isSymlink($0) }
             .map { $0.scipioAbsolutePath }
         let symlinks = publicHeaders.filter { fileSystem.isSymlink($0) }

--- a/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
@@ -5,7 +5,7 @@ import PackageModel
 
 struct ModuleMapGenerator {
     private struct Context {
-        var resolvedTarget: ResolvedTarget
+        var resolvedTarget: ScipioResolvedModule
         var sdk: SDK
         var configuration: BuildConfiguration
     }
@@ -27,12 +27,12 @@ struct ModuleMapGenerator {
     init(descriptionPackage: DescriptionPackage, fileSystem: any FileSystem) {
         self.descriptionPackage = descriptionPackage
         self.fileSystem = fileSystem
-    }
+    } 
 
-    func generate(resolvedTarget: ResolvedTarget, sdk: SDK, buildConfiguration: BuildConfiguration) throws -> AbsolutePath? {
+    func generate(resolvedTarget: ScipioResolvedModule, sdk: SDK, buildConfiguration: BuildConfiguration) throws -> AbsolutePath? {
         let context = Context(resolvedTarget: resolvedTarget, sdk: sdk, configuration: buildConfiguration)
 
-        if let clangTarget = resolvedTarget.underlyingTarget as? ClangTarget {
+        if let clangTarget = resolvedTarget.underlying as? ScipioClangModule {
             switch clangTarget.moduleMapType {
             case .custom, .umbrellaHeader, .umbrellaDirectory:
                 let path = try constructGeneratedModuleMapPath(context: context)
@@ -49,7 +49,7 @@ struct ModuleMapGenerator {
     }
 
     private func generateModuleMapContents(context: Context) throws -> String {
-        if let clangTarget = context.resolvedTarget.underlyingTarget as? ClangTarget {
+        if let clangTarget = context.resolvedTarget.underlying as? ScipioClangModule {
             switch clangTarget.moduleMapType {
             case .custom(let customModuleMap):
                 return try convertCustomModuleMapForFramework(customModuleMap.scipioAbsolutePath)
@@ -104,7 +104,7 @@ struct ModuleMapGenerator {
 
     private func generateLinkSection(context: Context) -> [String] {
         context.resolvedTarget.dependencies
-            .compactMap(\.target?.c99name)
+            .compactMap(\.module?.c99name)
             .map { "    link framework \"\($0)\"" }
     }
 

--- a/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
@@ -27,7 +27,7 @@ struct ModuleMapGenerator {
     init(descriptionPackage: DescriptionPackage, fileSystem: any FileSystem) {
         self.descriptionPackage = descriptionPackage
         self.fileSystem = fileSystem
-    } 
+    }
 
     func generate(resolvedTarget: ScipioResolvedModule, sdk: SDK, buildConfiguration: BuildConfiguration) throws -> AbsolutePath? {
         let context = Context(resolvedTarget: resolvedTarget, sdk: sdk, configuration: buildConfiguration)

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -114,7 +114,17 @@ struct PIFCompiler: Compiler {
     }
 
     private func makeBuildParameters(toolchain: UserToolchain) throws -> BuildParameters {
-        #if swift(>=5.10)
+        #if compiler(>=6.0)
+        try .init(
+            destination: .target,
+            dataPath: descriptionPackage.buildDirectory.spmAbsolutePath,
+            configuration: buildOptions.buildConfiguration.spmConfiguration,
+            toolchain: toolchain,
+            flags: .init(),
+            isXcodeBuildSystemEnabled: true,
+            driverParameters: BuildParameters.Driver(enableParseableModuleInterfaces: buildOptions.enableLibraryEvolution)
+        )
+        #elseif swift(>=5.10)
         try .init(
             dataPath: descriptionPackage.buildDirectory.spmAbsolutePath,
             configuration: buildOptions.buildConfiguration.spmConfiguration,

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -169,9 +169,15 @@ private struct PIFLibraryTargetModifier {
 
         let c99Name = pifTarget.name.spm_mangledToC99ExtendedIdentifier()
 
+        #if compiler(>=6.0)
+        guard let resolvedTarget = descriptionPackage.graph.allModules.first(where: { $0.c99name == c99Name }) else {
+            fatalError("Resolved Target named \(c99Name) is not found.")
+        }
+        #else
         guard let resolvedTarget = descriptionPackage.graph.allTargets.first(where: { $0.c99name == c99Name }) else {
             fatalError("Resolved Target named \(c99Name) is not found.")
         }
+        #endif
 
         guard let resolvedPackage = descriptionPackage.graph.package(for: resolvedTarget) else {
             fatalError("Could not find a package")
@@ -294,7 +300,7 @@ private struct PIFLibraryTargetModifier {
     }
 }
 
-extension PIF.TopLevelObject: Decodable {
+extension PIF.TopLevelObject: @retroactive Decodable {
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
         self.init(workspace: try container.decode(PIF.Workspace.self))

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -300,12 +300,25 @@ private struct PIFLibraryTargetModifier {
     }
 }
 
+#if compiler(>=6.0)
+
 extension PIF.TopLevelObject: @retroactive Decodable {
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
         self.init(workspace: try container.decode(PIF.Workspace.self))
     }
 }
+
+#else
+
+extension PIF.TopLevelObject: Decodable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.init(workspace: try container.decode(PIF.Workspace.self))
+    }
+}
+
+#endif
 
 extension AbsolutePath {
     fileprivate var moduleEscapedPathString: String {

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -144,7 +144,7 @@ private struct PIFLibraryTargetModifier {
     private let sdk: SDK
 
     private let resolvedPackage: ResolvedPackage
-    private let resolvedTarget: ResolvedTarget
+    private let resolvedTarget: ScipioResolvedModule
 
     init(
         descriptionPackage: DescriptionPackage,
@@ -256,7 +256,7 @@ private struct PIFLibraryTargetModifier {
         // However, this PIFGenerator modified productType to framework.
         // So a bridging header will be generated in frameworks bundle even if `SWIFT_OBJC_INTERFACE_HEADER_DIR` was specified.
         // So it's need to replace `MODULEMAP_FILE_CONTENTS` to an absolute path.
-        if let swiftTarget = resolvedTarget.underlyingTarget as? SwiftTarget {
+        if let swiftTarget = resolvedTarget.underlying as? ScipioSwiftModule {
             // Bridging Headers will be generated inside generated frameworks
             let productsDirectory = descriptionPackage.productsDirectory(
                 buildConfiguration: buildOptions.buildConfiguration,

--- a/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
@@ -1,6 +1,10 @@
 import Foundation
 import TSCUtility
+#if compiler(>=6.0)
+@_spi(SwiftPMInternal) import PackageModel
+#else
 import PackageModel
+#endif
 import TSCBasic
 import struct Basics.Triple
 
@@ -45,7 +49,15 @@ struct ToolchainGenerator {
         extraSwiftCFlags += ["-L", sdkPaths.lib.pathString]
 
         let buildFlags = BuildFlags(cCompilerFlags: extraCCFlags, swiftCompilerFlags: extraSwiftCFlags)
-        #if swift(>=5.10)
+        #if compiler(>=6.0)
+        return SwiftSDK(
+            hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+            targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
+            toolset: .init(toolchainBinDir: toolchainDirPath.spmAbsolutePath, buildFlags: buildFlags),
+            pathsConfiguration: .init(sdkRootPath: sdkPath.spmAbsolutePath),
+            xctestSupport: .supported
+        )
+        #elseif swift(>=5.10)
         return SwiftSDK(
             hostTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),
             targetTriple: try? Triple("arm64-apple-\(sdk.settingValue)"),

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -97,7 +97,7 @@ struct XCBuildClient {
         try assembler.assemble()
     }
 
-    private func assembledFrameworkPath(target: ResolvedTarget, of sdk: SDK) throws -> AbsolutePath {
+    private func assembledFrameworkPath(target: ScipioResolvedModule, of sdk: SDK) throws -> AbsolutePath {
         let assembledFrameworkDir = descriptionPackage.assembledFrameworksDirectory(
             buildConfiguration: buildOptions.buildConfiguration,
             sdk: sdk

--- a/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
@@ -13,7 +13,7 @@ struct XCBuildExecutor {
         configuration: BuildConfiguration,
         derivedDataPath: AbsolutePath,
         buildParametersPath: AbsolutePath,
-        target: ResolvedTarget
+        target: ScipioResolvedModule
     ) async throws {
         let executor = _Executor(args: [
             xcbuildPath.pathString,

--- a/Sources/ScipioKit/SwiftPM+Compatibility.swift
+++ b/Sources/ScipioKit/SwiftPM+Compatibility.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PackageGraph
 import TSCBasic
 import Basics
 import PackageModel
@@ -40,3 +41,48 @@ extension SwiftPMAbsolutePath {
         try! ScipioAbsolutePath(validating: pathString)
     }
 }
+
+// Since 6.0, all `~Target` has been renamed to `~Module`
+#if compiler(>=6.0)
+
+typealias ScipioResolvedModule = ResolvedModule
+typealias ScipioSwiftModule = SwiftModule
+typealias ScipioClangModule = ClangModule
+typealias ScipioBinaryModule = BinaryModule
+
+#else
+
+typealias ScipioResolvedModule = ResolvedTarget
+typealias ScipioSwiftModule = SwiftTarget
+typealias ScipioClangModule = ClangTarget
+typealias ScipioBinaryModule = BinaryTarget
+
+#endif
+
+#if compiler(<6.0)
+
+extension ResolvedPackage {
+    var modules: IdentifiableSet<ScipioResolvedModule> {
+        targets
+    }
+}
+
+extension ResolvedModule {
+    var modules: IdentifiableSet<ScipioResolvedModule> {
+        targets
+    }
+}
+
+extension ResolvedModule {
+    var underlying: Module {
+        underlyingTarget
+    }
+}
+
+extension ResolvedModule.Dependency {
+    var module: ScipioResolvedModule {
+        target
+    }
+}
+
+#endif

--- a/Sources/ScipioKit/SwiftPM+Compatibility.swift
+++ b/Sources/ScipioKit/SwiftPM+Compatibility.swift
@@ -86,3 +86,9 @@ extension ScipioResolvedModule.Dependency {
 }
 
 #endif
+
+#if compiler(<6.0)
+
+typealias ModulesGraph = PackageGraph
+
+#endif

--- a/Sources/ScipioKit/SwiftPM+Compatibility.swift
+++ b/Sources/ScipioKit/SwiftPM+Compatibility.swift
@@ -61,26 +61,26 @@ typealias ScipioBinaryModule = BinaryTarget
 
 #if compiler(<6.0)
 
+extension ResolvedProduct {
+    var modules: [ResolvedTarget] {
+        targets
+    }
+}
+
 extension ResolvedPackage {
-    var modules: IdentifiableSet<ScipioResolvedModule> {
+    var modules: [ScipioResolvedModule] {
         targets
     }
 }
 
-extension ResolvedModule {
-    var modules: IdentifiableSet<ScipioResolvedModule> {
-        targets
-    }
-}
-
-extension ResolvedModule {
-    var underlying: Module {
+extension ScipioResolvedModule {
+    var underlying: Target {
         underlyingTarget
     }
 }
 
-extension ResolvedModule.Dependency {
-    var module: ScipioResolvedModule {
+extension ScipioResolvedModule.Dependency {
+    var module: ScipioResolvedModule? {
         target
     }
 }

--- a/Sources/scipio/Arguments.swift
+++ b/Sources/scipio/Arguments.swift
@@ -2,6 +2,8 @@ import Foundation
 import ArgumentParser
 import ScipioKit
 
+#if compiler(>=6.0)
+
 extension URL: @retroactive ExpressibleByArgument {
     public init?(argument: String) {
         self.init(fileURLWithPath: argument)
@@ -20,3 +22,26 @@ extension BuildConfiguration: @retroactive ExpressibleByArgument {
         }
     }
 }
+
+#else
+
+extension URL: ExpressibleByArgument {
+    public init?(argument: String) {
+        self.init(fileURLWithPath: argument)
+    }
+}
+
+extension BuildConfiguration: ExpressibleByArgument {
+    public init?(argument: String) {
+        switch argument.lowercased() {
+        case "debug":
+            self = .debug
+        case "release":
+            self = .release
+        default:
+            return nil
+        }
+    }
+}
+
+#endif

--- a/Sources/scipio/Arguments.swift
+++ b/Sources/scipio/Arguments.swift
@@ -2,13 +2,13 @@ import Foundation
 import ArgumentParser
 import ScipioKit
 
-extension URL: ExpressibleByArgument {
+extension URL: @retroactive ExpressibleByArgument {
     public init?(argument: String) {
         self.init(fileURLWithPath: argument)
     }
 }
 
-extension BuildConfiguration: ExpressibleByArgument {
+extension BuildConfiguration: @retroactive ExpressibleByArgument {
     public init?(argument: String) {
         switch argument.lowercased() {
         case "debug":

--- a/Sources/scipio/CreateCommands.swift
+++ b/Sources/scipio/CreateCommands.swift
@@ -1,11 +1,11 @@
 import Foundation
 import ScipioKit
-import ArgumentParser
+@preconcurrency import ArgumentParser
 import Logging
 
 extension Scipio {
     struct Create: AsyncParsableCommand {
-        static var configuration: CommandConfiguration = .init(
+        static let configuration: CommandConfiguration = .init(
             abstract: "Create XCFramework for a single package."
         )
 

--- a/Sources/scipio/CreateCommands.swift
+++ b/Sources/scipio/CreateCommands.swift
@@ -52,4 +52,4 @@ extension Scipio {
 
 private let availablePlatforms: Set<SDK> = [.iOS, .macOS, .tvOS, .watchOS]
 
-extension Runner.Options.Platform: ExpressibleByArgument { }
+extension Runner.Options.Platform: @retroactive ExpressibleByArgument { }

--- a/Sources/scipio/CreateCommands.swift
+++ b/Sources/scipio/CreateCommands.swift
@@ -52,4 +52,12 @@ extension Scipio {
 
 private let availablePlatforms: Set<SDK> = [.iOS, .macOS, .tvOS, .watchOS]
 
+#if compiler(>=6.0)
+
 extension Runner.Options.Platform: @retroactive ExpressibleByArgument { }
+
+#else
+
+extension Runner.Options.Platform: ExpressibleByArgument { }
+
+#endif

--- a/Sources/scipio/DumpCacheKey.swift
+++ b/Sources/scipio/DumpCacheKey.swift
@@ -1,10 +1,10 @@
 import Foundation
 import ScipioKit
-import ArgumentParser
+@preconcurrency import ArgumentParser
 
 extension Scipio {
     struct DumpCacheKey: AsyncParsableCommand {
-        static var configuration: CommandConfiguration = .init(
+        static let configuration: CommandConfiguration = .init(
             abstract: "Dump cache key of a VersionFile"
         )
 

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -47,4 +47,12 @@ struct BuildOptionGroup: ParsableArguments {
     var overwrite: Bool = false
 }
 
+#if compiler(>=6.0)
+
 extension FrameworkType: @retroactive ExpressibleByArgument { }
+
+#else
+
+extension FrameworkType: ExpressibleByArgument { }
+
+#endif

--- a/Sources/scipio/Options.swift
+++ b/Sources/scipio/Options.swift
@@ -47,4 +47,4 @@ struct BuildOptionGroup: ParsableArguments {
     var overwrite: Bool = false
 }
 
-extension FrameworkType: ExpressibleByArgument { }
+extension FrameworkType: @retroactive ExpressibleByArgument { }

--- a/Sources/scipio/PrepareCommands.swift
+++ b/Sources/scipio/PrepareCommands.swift
@@ -1,6 +1,6 @@
 import Foundation
 import ScipioKit
-import ArgumentParser
+@preconcurrency import ArgumentParser
 import Logging
 
 extension Scipio {
@@ -11,7 +11,7 @@ extension Scipio {
             case local
         }
 
-        static var configuration: CommandConfiguration = .init(
+        static let configuration: CommandConfiguration = .init(
             abstract: "Prepare all dependencies in a specific manifest."
         )
 

--- a/Sources/scipio/Scipio.swift
+++ b/Sources/scipio/Scipio.swift
@@ -1,9 +1,9 @@
 import Foundation
-import ArgumentParser
+@preconcurrency import ArgumentParser
 
 @main
 struct Scipio: AsyncParsableCommand {
-    static var configuration = CommandConfiguration(
+    static let configuration = CommandConfiguration(
         abstract: "A build tool to create XCFrameworks from Swift packages.",
         subcommands: [Create.self, Prepare.self, DumpCacheKey.self],
         defaultSubcommand: Prepare.self)

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import ScipioKit
 import XCTest
 
-private let fixturePath = URL(fileURLWithPath: #file)
+private let fixturePath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .appendingPathComponent("Resources")
     .appendingPathComponent("Fixtures")
@@ -18,7 +18,7 @@ final class DescriptionPackageTests: XCTestCase {
         XCTAssertEqual(package.name, "TestingPackage")
 
         let packageNames = package.graph.packages.map(\.manifest.displayName)
-        XCTAssertEqual(packageNames, ["TestingPackage", "swift-log"])
+        XCTAssertEqual(packageNames.sorted(), ["TestingPackage", "swift-log"].sorted())
 
         XCTAssertEqual(
             package.workspaceDirectory.pathString,

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import ScipioKit
 import Logging
 
-private let fixturePath = URL(fileURLWithPath: #file)
+private let fixturePath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .appendingPathComponent("Resources")
     .appendingPathComponent("Fixtures")

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -221,7 +221,7 @@ final class RunnerTests: XCTestCase {
 
         let allTargets = packages
             .flatMap { package in
-                package.targets.map { BuildProduct(package: package, target: $0) }
+                package.modules.map { BuildProduct(package: package, target: $0) }
             }
             .map {
                 CacheSystem.CacheTarget(buildProduct: $0, buildOptions: .default)
@@ -380,7 +380,7 @@ final class RunnerTests: XCTestCase {
 
         let allTargets = packages
             .flatMap { package in
-                package.targets.map { BuildProduct(package: package, target: $0) }
+                package.modules.map { BuildProduct(package: package, target: $0) }
             }
             .map {
                 CacheSystem.CacheTarget(buildProduct: $0, buildOptions: .default)

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import ScipioKit
 import Logging
 
-private let fixturePath = URL(fileURLWithPath: #file)
+private let fixturePath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .appendingPathComponent("Resources")
     .appendingPathComponent("Fixtures")


### PR DESCRIPTION
This PR is implemented based on `swift6` branch.

This PR replaces the default stack with Swift6 Snapshot while keeping Swift 5.10 compatibility.