### PR TITLE
Use OrderedSet for resolving products

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -149,7 +149,7 @@ struct DescriptionPackage {
 }
 
 extension DescriptionPackage {
-    func resolveBuildProducts() throws -> [BuildProduct] {
+    func resolveBuildProducts() throws -> OrderedSet<BuildProduct> {
         let targetsToBuild = try targetsToBuild()
         var products = try targetsToBuild.flatMap(resolveBuildProduct(from:))
 
@@ -186,7 +186,7 @@ extension DescriptionPackage {
             }
         }
 
-        return products.reversed()
+        return OrderedSet(products.reversed())
     }
 
     private func targetsToBuild() throws -> [ScipioResolvedModule] {
@@ -265,6 +265,11 @@ struct BuildProduct: Hashable, Sendable {
 
     var binaryTarget: ScipioBinaryModule? {
         target.underlying as? ScipioBinaryModule
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.target.name == rhs.target.name &&
+        lhs.package.identity == rhs.package.identity
     }
 
     func hash(into hasher: inout Hasher) {


### PR DESCRIPTION
Fix CI for Xcode 16.

The test on the current main is broken with Xcode 16.
https://github.com/giginet/Scipio/actions/runs/9854164954/job/27206328940

```
2024-07-09T09:11:47.0455430Z /Users/runner/work/Scipio/Scipio/Tests/ScipioKitTests/DescriptionPackageTests.swift:76: error: -[ScipioKitTests.DescriptionPackageTests testBuildProductsInCreateMode] : XCTAssertEqual failed: ("["Logging", "MyTarget", "Logging", "MyTarget", "ExecutableTarget", "MyPlugin"]") is not equal to ("["Logging", "MyTarget", "ExecutableTarget", "MyPlugin"]") - Order of the resolved products should be correct
```

According to the build log, `resolveBuildProducts` returns duplicated `BuildProduct`.

It's better to use `OrderedSet` here to remove duplications and keep the order.

Strangely, this has not been produced with Swift 5.10.