### PR TITLE
Respect excluded files for modulemap generation

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -80,6 +80,11 @@ struct DescriptionPackage {
             .appending(component: intermediateDirName)
     }
 
+    /// Returns a target description in the package manifest of the given target
+    func targetDescription(of targetName: String) -> TargetDescription? {
+        manifest.targets.first { $0.name == targetName }
+    }
+
     /// Returns an intermediate directory name in the Products dir.
     /// e.g. `Debug` / `Debug-iphoneos`
     private func productDirectoryName(buildConfiguration: BuildConfiguration, sdk: SDK) -> String {

--- a/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
@@ -48,7 +48,7 @@ struct FrameworkComponentsCollector {
     }
 
     func collectComponents(sdk: SDK) throws -> FrameworkComponents {
-        let modulemapGenerator = ModuleMapGenerator(
+        let modulemapGenerator = FrameworkModuleMapGenerator(
             descriptionPackage: descriptionPackage,
             fileSystem: fileSystem
         )

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -69,7 +69,7 @@ struct FrameworkModuleMapGenerator {
 
                 let targetDescription = descriptionPackage.targetDescription(of: clangTarget.name)
 
-                let includingHeaders = if let targetDescription {
+                let includingHeaders: Set<AbsolutePath> = if let targetDescription {
                     try Self.excludePaths(
                         from: allHeaders,
                         excludedFiles: Set(targetDescription.exclude.map { try RelativePath(validating: $0) }),

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -105,6 +105,7 @@ struct FrameworkModuleMapGenerator {
         }
     }
 
+    /// Search all headers(*.h) under the given directory. Directories in that also be searched recursively
     private func headers(under directoryPath: AbsolutePath) throws -> Set<AbsolutePath> {
         try fileSystem.getDirectoryContents(directoryPath).reduce(into: Set<AbsolutePath>()) { foundHeaders, file in
             let path = directoryPath.appending(component: file)

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -117,7 +117,7 @@ struct FrameworkModuleMapGenerator {
         }
     }
 
-    /// Exclude ignored files defined in the target description from the passed headers set
+    /// Exclude ignored files defined in the excludedFiles from the passed files set
     /// - Parameter files: A file path list. They should be absolute paths
     /// - Parameter excludedFiles: A exclude files list. They should be a relative path form the target root
     /// - Parameter targetRoot: An absolute path of the target root

--- a/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
+++ b/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import XCTest
+import TSCBasic
+@testable import ScipioKit
+
+final class FrameworkModuleMapGeneratorTests: XCTestCase {
+    func testExcludePaths() throws {
+        let targetRootDir = try ScipioAbsolutePath(validating: "/tmp/path/to/package")
+
+        let files = Set([
+            targetRootDir.appending(component: "a.c"),
+            targetRootDir.appending(component: "ignored.c"),
+            targetRootDir.appending(components: ["include", "a.h"]),
+            targetRootDir.appending(components: ["include", "ignored", "b.h"]),
+            targetRootDir.appending(components: ["include", "not_ignored", "c.h"]),
+        ])
+
+        let excludeFilesPathString = Set([
+            "./ignored.c",
+            "./include/ignored/",
+        ])
+        let excludeFiles = Set(try excludeFilesPathString.compactMap { try RelativePath(validating: $0) })
+
+        let result = FrameworkModuleMapGenerator.excludePaths(
+            from: files,
+            excludedFiles: excludeFiles,
+            targetRoot: targetRootDir
+        )
+        XCTAssertEqual(result, Set([
+            targetRootDir.appending(component: "a.c"),
+            targetRootDir.appending(components: ["include", "a.h"]),
+            targetRootDir.appending(components: ["include", "not_ignored", "c.h"]),
+        ]), "The filtered paths are not included exclude files")
+    }
+}


### PR DESCRIPTION
ModuleMapGenerator generates modulemap for distributed frameworks.
However, currently, it ignores `excludes` settings on the package manifest.

This change make that it respects `excludes` settings of the package manifest to generate modulemap.

Currently, it's difficult to write test for `ModuleMapGenerator`, so this should be refactored.