### PR TITLE
Add x86_64 binary to an artifact bundle in a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
           swift package resolve
       - name: Build Binary
         run: |
-          # Scipio can't build for x86_64 on Apple Silicon because it uses build tools plugin
           swift build --disable-sandbox -c release --arch arm64
+          swift build --disable-sandbox -c release --arch x86_64
       - name: Get Current Tag
         run: echo "TAG_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Make Artifact Bundle


### PR DESCRIPTION
I noticed that we can add x86_64 binary to an artifact bundle by build the project twice.

When scipio is built for arm64, the binary is generated at `./.build/arm64-apple-macosx/release/scipio`.
And when it is built for x86_64, the binary is generated at `./.build/x86_64-apple-macosx/release/scipio`.

[ArtifactBundleGen](https://github.com/freddi-kit/ArtifactBundleGen) used by scipio can combines both binaries into an artifact bundle when they exist.

This is the artifact bundle that I made in my forked repository.
https://github.com/mtj0928/Scipio/releases/download/0.21.0/scipio.artifactbundle.zip
