### PR TITLE
Suppress swiftlint warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,7 @@ disabled_rules:
   - force_try
   - todo
   - cyclomatic_complexity
+  - optional_data_string_conversion
 line_length: 150
 file_length: 600
 nesting:


### PR DESCRIPTION
In #142, I found there were codes violating `optional_data_string_conversion`.
In this PR, I addressed the warnings.