### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -10,7 +10,7 @@ jobs:
   DocC:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build DocC
         run: |
           swift package --allow-writing-to-directory ./docs generate-documentation \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
     runs-on: macos-14
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install SwiftLint
       run: brew install swiftlint
     - name: SwiftLint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and Upload Artifact Bundle
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Resolve Dependencies
         run: |
           swift package resolve

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - name: Get swift version
       run: swift --version
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Run Tests
       run: |
         swift test --verbose


### PR DESCRIPTION
To address node runtime deprecations:
- https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
- https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/