### PR TITLE
Factor out DescriptionPackage's path-related functions to PackageLocator protocol

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -7,7 +7,7 @@ import PackageLoading
 @preconcurrency import PackageGraph
 import Basics
 
-struct DescriptionPackage {
+struct DescriptionPackage: PackageLocator {
     let mode: Runner.Mode
     let packageDirectory: ScipioAbsolutePath
     private let toolchain: UserToolchain
@@ -35,59 +35,8 @@ struct DescriptionPackage {
         manifest.displayName
     }
 
-    var buildDirectory: ScipioAbsolutePath {
-        packageDirectory.appending(component: ".build")
-    }
-
-    var workspaceDirectory: ScipioAbsolutePath {
-        buildDirectory.appending(component: "scipio")
-    }
-
     var supportedSDKs: Set<SDK> {
         Set(manifest.platforms.map(\.platformName).compactMap(SDK.init(platformName:)))
-    }
-
-    var derivedDataPath: ScipioAbsolutePath {
-        workspaceDirectory.appending(component: "DerivedData")
-    }
-
-    func generatedModuleMapPath(of target: ScipioResolvedModule, sdk: SDK) throws -> ScipioAbsolutePath {
-        let relativePath = try TSCBasic.RelativePath(validating: "ModuleMapsForFramework/\(sdk.settingValue)")
-        return workspaceDirectory
-            .appending(relativePath)
-            .appending(component: target.modulemapName)
-    }
-
-    /// Returns an Products directory path
-    /// It should be the default setting of `TARGET_BUILD_DIR`
-    func productsDirectory(buildConfiguration: BuildConfiguration, sdk: SDK) -> ScipioAbsolutePath {
-        let intermediateDirectoryName = productDirectoryName(
-            buildConfiguration: buildConfiguration,
-            sdk: sdk
-        )
-        return derivedDataPath.appending(components: ["Products", intermediateDirectoryName])
-    }
-
-    /// Returns a directory path which contains assembled frameworks
-    var assembledFrameworksRootDirectory: ScipioAbsolutePath {
-        workspaceDirectory.appending(component: "AssembledFrameworks")
-    }
-
-    /// Returns a directory path of the assembled frameworks path for the specific Configuration/Platform
-    func assembledFrameworksDirectory(buildConfiguration: BuildConfiguration, sdk: SDK) -> ScipioAbsolutePath {
-        let intermediateDirName = productDirectoryName(buildConfiguration: buildConfiguration, sdk: sdk)
-        return assembledFrameworksRootDirectory
-            .appending(component: intermediateDirName)
-    }
-
-    /// Returns an intermediate directory name in the Products dir.
-    /// e.g. `Debug` / `Debug-iphoneos`
-    private func productDirectoryName(buildConfiguration: BuildConfiguration, sdk: SDK) -> String {
-        if sdk == .macOS {
-            return buildConfiguration.settingsValue
-        } else {
-            return "\(buildConfiguration.settingsValue)-\(sdk.settingValue)"
-        }
     }
 
     // MARK: Initializer

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -3,7 +3,7 @@ import Workspace
 import TSCBasic
 import PackageModel
 import PackageLoading
-// We can drop this annotation with SwiftPM release/6.0
+// We may drop this annotation in SwiftPM's future release
 @preconcurrency import PackageGraph
 import Basics
 

--- a/Sources/ScipioKit/PackageLocator.swift
+++ b/Sources/ScipioKit/PackageLocator.swift
@@ -1,0 +1,60 @@
+import TSCBasic
+import PackageModel
+
+/// Holds the packageDirectory Scipio works on, and defines some path-related functionalities.
+protocol PackageLocator {
+    var packageDirectory: ScipioAbsolutePath { get }
+}
+
+extension PackageLocator {
+    var buildDirectory: ScipioAbsolutePath {
+        packageDirectory.appending(component: ".build")
+    }
+
+    var workspaceDirectory: ScipioAbsolutePath {
+        buildDirectory.appending(component: "scipio")
+    }
+
+    var derivedDataPath: ScipioAbsolutePath {
+        workspaceDirectory.appending(component: "DerivedData")
+    }
+
+    func generatedModuleMapPath(of target: ScipioResolvedModule, sdk: SDK) throws -> ScipioAbsolutePath {
+        let relativePath = try TSCBasic.RelativePath(validating: "ModuleMapsForFramework/\(sdk.settingValue)")
+        return workspaceDirectory
+            .appending(relativePath)
+            .appending(component: target.modulemapName)
+    }
+
+    /// Returns an Products directory path
+    /// It should be the default setting of `TARGET_BUILD_DIR`
+    func productsDirectory(buildConfiguration: BuildConfiguration, sdk: SDK) -> ScipioAbsolutePath {
+        let intermediateDirectoryName = productDirectoryName(
+            buildConfiguration: buildConfiguration,
+            sdk: sdk
+        )
+        return derivedDataPath.appending(components: ["Products", intermediateDirectoryName])
+    }
+
+    /// Returns a directory path which contains assembled frameworks
+    var assembledFrameworksRootDirectory: ScipioAbsolutePath {
+        workspaceDirectory.appending(component: "AssembledFrameworks")
+    }
+
+    /// Returns a directory path of the assembled frameworks path for the specific Configuration/Platform
+    func assembledFrameworksDirectory(buildConfiguration: BuildConfiguration, sdk: SDK) -> ScipioAbsolutePath {
+        let intermediateDirName = productDirectoryName(buildConfiguration: buildConfiguration, sdk: sdk)
+        return assembledFrameworksRootDirectory
+            .appending(component: intermediateDirName)
+    }
+
+    /// Returns an intermediate directory name in the Products dir.
+    /// e.g. `Debug` / `Debug-iphoneos`
+    private func productDirectoryName(buildConfiguration: BuildConfiguration, sdk: SDK) -> String {
+        if sdk == .macOS {
+            return buildConfiguration.settingsValue
+        } else {
+            return "\(buildConfiguration.settingsValue)-\(sdk.settingValue)"
+        }
+    }
+}

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -3,6 +3,7 @@ import ScipioStorage
 import TSCBasic
 import struct TSCUtility.Version
 import Algorithms
+// We may drop this annotation in SwiftPM's future release
 @preconcurrency import PackageGraph
 import PackageModel
 import SourceControl

--- a/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
@@ -38,7 +38,7 @@ struct FrameworkComponentsCollector {
         sdk: SDK,
         buildOptions: BuildOptions,
         packageLocator: some PackageLocator,
-        fileSystem: any FileSystem
+        fileSystem: some FileSystem
     ) {
         self.buildProduct = buildProduct
         self.sdk = sdk

--- a/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
@@ -27,23 +27,23 @@ struct FrameworkComponentsCollector {
         }
     }
 
-    private let descriptionPackage: DescriptionPackage
     private let buildProduct: BuildProduct
     private let sdk: SDK
     private let buildOptions: BuildOptions
+    private let packageLocator: any PackageLocator
     private let fileSystem: any FileSystem
 
     init(
-        descriptionPackage: DescriptionPackage,
         buildProduct: BuildProduct,
         sdk: SDK,
         buildOptions: BuildOptions,
+        packageLocator: some PackageLocator,
         fileSystem: any FileSystem
     ) {
-        self.descriptionPackage = descriptionPackage
         self.buildProduct = buildProduct
         self.sdk = sdk
         self.buildOptions = buildOptions
+        self.packageLocator = packageLocator
         self.fileSystem = fileSystem
     }
 
@@ -95,7 +95,7 @@ struct FrameworkComponentsCollector {
 
     /// Copy content data to the build artifacts
     private func copyModuleMapContentsToBuildArtifacts(_ data: Data) throws -> ScipioAbsolutePath {
-        let generatedModuleMapPath = try descriptionPackage.generatedModuleMapPath(of: buildProduct.target, sdk: sdk)
+        let generatedModuleMapPath = try packageLocator.generatedModuleMapPath(of: buildProduct.target, sdk: sdk)
 
         try fileSystem.writeFileContents(generatedModuleMapPath.spmAbsolutePath, data: data)
         return generatedModuleMapPath
@@ -103,7 +103,7 @@ struct FrameworkComponentsCollector {
 
     private func generateFrameworkModuleMap() throws -> AbsolutePath? {
         let modulemapGenerator = FrameworkModuleMapGenerator(
-            descriptionPackage: descriptionPackage,
+            packageLocator: packageLocator,
             fileSystem: fileSystem
         )
 
@@ -119,7 +119,7 @@ struct FrameworkComponentsCollector {
     }
 
     private func generatedFrameworkPath() -> AbsolutePath {
-        descriptionPackage.productsDirectory(
+        packageLocator.productsDirectory(
             buildConfiguration: buildOptions.buildConfiguration,
             sdk: sdk
         )

--- a/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ModuleMapGenerator.swift
@@ -11,7 +11,7 @@ struct FrameworkModuleMapGenerator {
         var configuration: BuildConfiguration
     }
 
-    private var descriptionPackage: DescriptionPackage
+    private var packageLocator: any PackageLocator
     private var fileSystem: any FileSystem
 
     enum Error: LocalizedError {
@@ -25,8 +25,8 @@ struct FrameworkModuleMapGenerator {
         }
     }
 
-    init(descriptionPackage: DescriptionPackage, fileSystem: any FileSystem) {
-        self.descriptionPackage = descriptionPackage
+    init(packageLocator: some PackageLocator, fileSystem: some FileSystem) {
+        self.packageLocator = packageLocator
         self.fileSystem = fileSystem
     }
 
@@ -118,7 +118,7 @@ struct FrameworkModuleMapGenerator {
     }
 
     private func constructGeneratedModuleMapPath(context: Context) throws -> AbsolutePath {
-        let generatedModuleMapPath = try descriptionPackage.generatedModuleMapPath(of: context.resolvedTarget, sdk: context.sdk)
+        let generatedModuleMapPath = try packageLocator.generatedModuleMapPath(of: context.resolvedTarget, sdk: context.sdk)
         return generatedModuleMapPath
     }
 

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -54,10 +54,10 @@ struct PIFCompiler: Compiler {
         logger.info("📦 Building \(target.name) for \(sdkNames)")
 
         let xcBuildClient: XCBuildClient = .init(
-            package: descriptionPackage,
             buildProduct: buildProduct,
             buildOptions: buildOptions,
-            configuration: buildOptions.buildConfiguration
+            configuration: buildOptions.buildConfiguration,
+            packageLocator: descriptionPackage
         )
 
         for sdk in sdks {

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -17,7 +17,7 @@ struct XCBuildClient {
         configuration: BuildConfiguration,
         packageLocator: some PackageLocator,
         fileSystem: any FileSystem = localFileSystem,
-        executor: any Executor = ProcessExecutor(decoder: StandardOutputDecoder())
+        executor: some Executor = ProcessExecutor(decoder: StandardOutputDecoder())
     ) {
         self.buildProduct = buildProduct
         self.buildOptions = buildOptions


### PR DESCRIPTION
This would make it easy for testing FrameworkComponentsCollector and FrameworkModuleMapGenerator.