### PR TITLE
Follow-up / Making environment configurable

### DIFF
--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -237,7 +237,8 @@ struct FrameworkProducer {
             let compiler = PIFCompiler(
                 descriptionPackage: descriptionPackage,
                 buildOptions: buildOptions,
-                buildOptionsMatrix: buildOptionsMatrix
+                buildOptionsMatrix: buildOptionsMatrix,
+                toolchainEnvironment: toolchainEnvironment
             )
             try await compiler.createXCFramework(buildProduct: product,
                                                  outputDirectory: outputDir,

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -103,7 +103,8 @@ public struct Runner {
             buildOptionsMatrix: buildOptionsMatrix,
             cacheMode: options.cacheMode,
             overwrite: options.overwrite,
-            outputDir: outputDir
+            outputDir: outputDir,
+            toolchainEnvironment: options.toolchainEnvironment
         )
         do {
             try await producer.produce()


### PR DESCRIPTION
This PR is a follow-up built on https://github.com/giginet/Scipio/pull/140, where Runner became more environment-aware. This follow-up addresses two additional issues:

#### Issue 1:

It fixes an issue where the environment dictionary was not properly passed through to UserToolchain.

#### Issue 2:
It introduces a non-caching implementation of the [SwiftSDK.sdkPlatformFrameworkPaths(environment:)](https://github.com/swiftlang/swift-package-manager/blob/release/6.0/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift#L592-L595) function. The original function, although environment-aware, caches the resolved platform path unconditionally on the first call in a private static property, with no way to reset the cache. For Scipio to be fully environment-configurable, each environment (associated with a specific toolchain) requires a unique platform path, e.g.:
```
- /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
- /Applications/Xcode-15.4.app/Contents/Developer/Platforms/MacOSX.platform
- /Applications/Xcode-16.1.app/Contents/Developer/Platforms/MacOSX.platform"
```