### PR TITLE
Add multiple cache storages feature

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -8,7 +8,7 @@ env:
   DEVELOPER_DIR: "/Applications/Xcode_16.0.app/Contents/Developer"
 jobs:
   DocC:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Build DocC

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         xcode_version: ["16.0"]
     env: 
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - name: Install SwiftLint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   release:
     name: Build and Upload Artifact Bundle
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Resolve Dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
           - "16.0" # 6.0
     env: 
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - name: Get swift version
       run: swift --version

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -145,13 +145,7 @@ struct CacheSystem: Sendable {
         self.fileSystem = fileSystem
     }
 
-    func cacheFrameworks(_ targets: Set<CacheTarget>, storages: [any CacheStorage]?) async {
-        guard let storages, !storages.isEmpty else {
-            // About `CacheMode.project` which is not tied to any (external) storages, we don't need to do anything.
-            // The built frameworks under the project themselves are treated as valid caches.
-            return
-        }
-
+    func cacheFrameworks(_ targets: Set<CacheTarget>, storages: [any CacheStorage]) async {
         for storage in storages {
             await cacheFrameworks(targets, storage: storage)
         }

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -245,7 +245,10 @@ struct CacheSystem: Sendable {
             buildOptions: buildOptions,
             clangVersion: clangVersion,
             xcodeVersion: xcodeVersion,
-            scipioVersion: "578ce98d236e79dad3e473cb11153e867be07174" // TODO: revert
+            // Making the cache key compatible with 0.24.0 temporarily for easier debugging.
+            //
+            // TODO: revert this before merging
+            scipioVersion: "578ce98d236e79dad3e473cb11153e867be07174"
         )
     }
 

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -154,6 +154,7 @@ struct CacheSystem: Sendable {
     private func cacheFrameworks(_ targets: Set<CacheTarget>, storage: any CacheStorage) async {
         let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParalellNumber)
 
+        let storageType = type(of: storage)
         for chunk in chunked {
             await withTaskGroup(of: Void.self) { group in
                 for target in chunk {
@@ -162,7 +163,7 @@ struct CacheSystem: Sendable {
                         let frameworkPath = outputDirectory.appendingPathComponent(frameworkName)
                         do {
                             logger.info(
-                                "🚀 Cache \(frameworkName) to cache storage: \(storage)",
+                                "🚀 Cache \(frameworkName) to cache storage: \(storageType)",
                                 metadata: .color(.green)
                             )
                             try await cacheFramework(target, at: frameworkPath, storage: storage)

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -145,13 +145,13 @@ struct CacheSystem: Sendable {
         self.fileSystem = fileSystem
     }
 
-    func cacheFrameworks(_ targets: Set<CacheTarget>, storages: [any CacheStorage]) async {
+    func cacheFrameworks(_ targets: Set<CacheTarget>, to storages: [any CacheStorage]) async {
         for storage in storages {
-            await cacheFrameworks(targets, storage: storage)
+            await cacheFrameworks(targets, to: storage)
         }
     }
 
-    private func cacheFrameworks(_ targets: Set<CacheTarget>, storage: any CacheStorage) async {
+    private func cacheFrameworks(_ targets: Set<CacheTarget>, to storage: any CacheStorage) async {
         let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParalellNumber)
 
         let storageType = type(of: storage)
@@ -166,7 +166,7 @@ struct CacheSystem: Sendable {
                                 "🚀 Cache \(frameworkName) to cache storage: \(storageType)",
                                 metadata: .color(.green)
                             )
-                            try await cacheFramework(target, at: frameworkPath, storage: storage)
+                            try await cacheFramework(target, at: frameworkPath, to: storage)
                         } catch {
                             logger.warning("⚠️ Can't create caches for \(frameworkPath.path)")
                         }
@@ -177,7 +177,7 @@ struct CacheSystem: Sendable {
         }
     }
 
-    private func cacheFramework(_ target: CacheTarget, at frameworkPath: URL, storage: any CacheStorage) async throws {
+    private func cacheFramework(_ target: CacheTarget, at frameworkPath: URL, to storage: any CacheStorage) async throws {
         let cacheKey = try await calculateCacheKey(of: target)
 
         try await storage.cacheFramework(frameworkPath, for: cacheKey)

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -245,7 +245,7 @@ struct CacheSystem: Sendable {
             buildOptions: buildOptions,
             clangVersion: clangVersion,
             xcodeVersion: xcodeVersion,
-            scipioVersion: currentScipioVersion
+            scipioVersion: "578ce98d236e79dad3e473cb11153e867be07174" // TODO: revert
         )
     }
 

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -108,7 +108,6 @@ struct CacheSystem: Sendable {
     static let defaultParalellNumber = 8
     private let pinsStore: PinsStore
     private let outputDirectory: URL
-    private let writableStorages: [any CacheStorage]
     private let fileSystem: any FileSystem
 
     struct CacheTarget: Hashable, Sendable {
@@ -139,23 +138,21 @@ struct CacheSystem: Sendable {
     init(
         pinsStore: PinsStore,
         outputDirectory: URL,
-        writableStorages: [any CacheStorage],
         fileSystem: any FileSystem = localFileSystem
     ) {
         self.pinsStore = pinsStore
         self.outputDirectory = outputDirectory
-        self.writableStorages = writableStorages
         self.fileSystem = fileSystem
     }
 
-    func cacheFrameworks(_ targets: Set<CacheTarget>) async {
-        guard !writableStorages.isEmpty else {
-            // About `CacheMode.project` which does not have any writableStorages, we don't need to do anything.
+    func cacheFrameworks(_ targets: Set<CacheTarget>, storages: [any CacheStorage]?) async {
+        guard let storages, !storages.isEmpty else {
+            // About `CacheMode.project` which is not tied to any (external) storages, we don't need to do anything.
             // The built frameworks under the project themselves are treated as valid caches.
             return
         }
 
-        for storage in writableStorages {
+        for storage in storages {
             await cacheFrameworks(targets, storage: storage)
         }
     }

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -151,7 +151,7 @@ struct CacheSystem: Sendable {
         }
     }
 
-    private func cacheFrameworks(_ targets: Set<CacheTarget>, to storage: any CacheStorage) async {
+    private func cacheFrameworks(_ targets: Set<CacheTarget>, to storage: some CacheStorage) async {
         let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParalellNumber)
 
         let storageName = storage.displayName
@@ -215,7 +215,7 @@ struct CacheSystem: Sendable {
         case noCache
     }
 
-    func restoreCacheIfPossible(target: CacheTarget, storage: any CacheStorage) async -> RestoreResult {
+    func restoreCacheIfPossible(target: CacheTarget, storage: some CacheStorage) async -> RestoreResult {
         do {
             let cacheKey = try await calculateCacheKey(of: target)
             if try await storage.existsValidCache(for: cacheKey) {

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -154,7 +154,7 @@ struct CacheSystem: Sendable {
     private func cacheFrameworks(_ targets: Set<CacheTarget>, to storage: any CacheStorage) async {
         let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParalellNumber)
 
-        let storageType = type(of: storage)
+        let storageName = storage.displayName
         for chunk in chunked {
             await withTaskGroup(of: Void.self) { group in
                 for target in chunk {
@@ -163,7 +163,7 @@ struct CacheSystem: Sendable {
                         let frameworkPath = outputDirectory.appendingPathComponent(frameworkName)
                         do {
                             logger.info(
-                                "🚀 Cache \(frameworkName) to cache storage: \(storageType)",
+                                "🚀 Cache \(frameworkName) to cache storage: \(storageName)",
                                 metadata: .color(.green)
                             )
                             try await cacheFramework(target, at: frameworkPath, to: storage)

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -245,10 +245,7 @@ struct CacheSystem: Sendable {
             buildOptions: buildOptions,
             clangVersion: clangVersion,
             xcodeVersion: xcodeVersion,
-            // Making the cache key compatible with 0.24.0 temporarily for easier debugging.
-            //
-            // TODO: revert this before merging
-            scipioVersion: "578ce98d236e79dad3e473cb11153e867be07174"
+            scipioVersion: currentScipioVersion
         )
     }
 

--- a/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
+++ b/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
@@ -16,7 +16,7 @@ struct LocalDiskCacheStorage: CacheStorage {
 
     /// - Parameters:
     ///   - baseURL: The base url for the local disk cache. When it is nil, the system cache directory (`~/Library/Caches`) will be used.
-    init(baseURL: URL?, fileSystem: FileSystem = localFileSystem) {
+    init(baseURL: URL? = nil, fileSystem: FileSystem = localFileSystem) {
         self.baseURL = baseURL
         self.fileSystem = fileSystem
     }

--- a/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
+++ b/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
@@ -13,7 +13,7 @@ struct LocalDiskCacheStorage: CacheStorage {
     }
 
     private let baseURL: URL?
-    
+
     /// - Parameters:
     ///   - baseURL: The base url for the local disk cache. When it is nil, the system cache directory (`~/Library/Caches`) will be used.
     init(baseURL: URL? = nil, fileSystem: FileSystem = localFileSystem) {

--- a/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
+++ b/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
@@ -3,37 +3,33 @@ import ScipioStorage
 import PackageGraph
 import TSCBasic
 
-public struct LocalDiskCacheStorage: CacheStorage {
+struct LocalDiskCacheStorage: CacheStorage {
     private let fileSystem: any FileSystem
 
-    public var parallelNumber: Int? { nil }
+    var parallelNumber: Int? { nil }
 
     enum Error: Swift.Error {
         case cacheDirectoryIsNotFound
     }
 
-    public enum CacheDirectory: Sendable {
-        case system
-        case custom(URL)
-    }
-
-    private let cacheDirectroy: CacheDirectory
-
-    public init(cacheDirectory: CacheDirectory = .system, fileSystem: FileSystem = localFileSystem) {
-        self.cacheDirectroy = cacheDirectory
+    private let baseURL: URL?
+    
+    /// - Parameters:
+    ///   - baseURL: The base url for the local disk cache. When it is nil, the system cache directory (`~/Library/Caches`) will be used.
+    init(baseURL: URL? = nil, fileSystem: FileSystem = localFileSystem) {
+        self.baseURL = baseURL
         self.fileSystem = fileSystem
     }
 
     private func buildBaseDirectoryPath() throws -> URL {
         let cacheDir: URL
-        switch cacheDirectroy {
-        case .system:
+        if let baseURL {
+            cacheDir = baseURL
+        } else {
             guard let systemCacheDir = fileSystem.cachesDirectory else {
                 throw Error.cacheDirectoryIsNotFound
             }
             cacheDir = systemCacheDir.asURL
-        case .custom(let customPath):
-            cacheDir = customPath
         }
         return cacheDir.appendingPathComponent("Scipio")
     }
@@ -51,7 +47,7 @@ public struct LocalDiskCacheStorage: CacheStorage {
             .appendingPathComponent(xcFrameworkFileName(for: cacheKey))
     }
 
-    public func existsValidCache(for cacheKey: some CacheKey) async -> Bool {
+    func existsValidCache(for cacheKey: some CacheKey) async -> Bool {
         do {
             let xcFrameworkPath = try cacheFrameworkPath(for: cacheKey)
             return fileSystem.exists(xcFrameworkPath.absolutePath)
@@ -60,7 +56,7 @@ public struct LocalDiskCacheStorage: CacheStorage {
         }
     }
 
-    public func cacheFramework(_ frameworkPath: URL, for cacheKey: some CacheKey) async {
+    func cacheFramework(_ frameworkPath: URL, for cacheKey: some CacheKey) async {
         do {
             let destination = try cacheFrameworkPath(for: cacheKey)
             let directoryPath = destination.deletingLastPathComponent()
@@ -72,7 +68,7 @@ public struct LocalDiskCacheStorage: CacheStorage {
         }
     }
 
-    public func fetchArtifacts(for cacheKey: some CacheKey, to destinationDir: URL) async throws {
+    func fetchArtifacts(for cacheKey: some CacheKey, to destinationDir: URL) async throws {
         let source = try cacheFrameworkPath(for: cacheKey)
         let destination = destinationDir.appendingPathComponent(xcFrameworkFileName(for: cacheKey))
         try fileSystem.copy(from: source.absolutePath, to: destination.absolutePath)

--- a/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
+++ b/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
@@ -3,7 +3,7 @@ import ScipioStorage
 import PackageGraph
 import TSCBasic
 
-public struct LocalCacheStorage: CacheStorage {
+public struct LocalDiskCacheStorage: CacheStorage {
     private let fileSystem: any FileSystem
 
     public var parallelNumber: Int? { nil }

--- a/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
+++ b/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
@@ -16,7 +16,7 @@ struct LocalDiskCacheStorage: CacheStorage {
 
     /// - Parameters:
     ///   - baseURL: The base url for the local disk cache. When it is nil, the system cache directory (`~/Library/Caches`) will be used.
-    init(baseURL: URL? = nil, fileSystem: FileSystem = localFileSystem) {
+    init(baseURL: URL?, fileSystem: FileSystem = localFileSystem) {
         self.baseURL = baseURL
         self.fileSystem = fileSystem
     }

--- a/Sources/ScipioKit/Producer/Cache/ProjectCacheStorage.swift
+++ b/Sources/ScipioKit/Producer/Cache/ProjectCacheStorage.swift
@@ -1,0 +1,10 @@
+import Foundation
+import ScipioStorage
+
+/// The pseudo cache storage for "project cache policy", which treats built frameworks under the project's output directory (e.g. `XCFrameworks`)
+/// as valid caches but does not saving / restoring anything.
+public struct ProjectCacheStorage: CacheStorage {
+    public func existsValidCache(for cacheKey: some ScipioStorage.CacheKey) async throws -> Bool { false }
+    public func fetchArtifacts(for cacheKey: some ScipioStorage.CacheKey, to destinationDir: URL) async throws {}
+    public func cacheFramework(_ frameworkPath: URL, for cacheKey: some ScipioStorage.CacheKey) async throws {}
+}

--- a/Sources/ScipioKit/Producer/Cache/ProjectCacheStorage.swift
+++ b/Sources/ScipioKit/Producer/Cache/ProjectCacheStorage.swift
@@ -3,8 +3,8 @@ import ScipioStorage
 
 /// The pseudo cache storage for "project cache policy", which treats built frameworks under the project's output directory (e.g. `XCFrameworks`)
 /// as valid caches but does not saving / restoring anything.
-public struct ProjectCacheStorage: CacheStorage {
-    public func existsValidCache(for cacheKey: some ScipioStorage.CacheKey) async throws -> Bool { false }
-    public func fetchArtifacts(for cacheKey: some ScipioStorage.CacheKey, to destinationDir: URL) async throws {}
-    public func cacheFramework(_ frameworkPath: URL, for cacheKey: some ScipioStorage.CacheKey) async throws {}
+struct ProjectCacheStorage: CacheStorage {
+    func existsValidCache(for cacheKey: some ScipioStorage.CacheKey) async throws -> Bool { false }
+    func fetchArtifacts(for cacheKey: some ScipioStorage.CacheKey, to destinationDir: URL) async throws {}
+    func cacheFramework(_ frameworkPath: URL, for cacheKey: some ScipioStorage.CacheKey) async throws {}
 }

--- a/Sources/ScipioKit/Producer/CacheStorage+DisplayName.swift
+++ b/Sources/ScipioKit/Producer/CacheStorage+DisplayName.swift
@@ -1,0 +1,9 @@
+import ScipioStorage
+
+extension CacheStorage {
+    /// The display name of the cache storage used for logging purpose
+    var displayName: String {
+        // TODO: Define the property as CacheStorage's requirement in scipio-cache-storage
+        "\(type(of: self))"
+    }
+}

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -97,13 +97,6 @@ struct FrameworkProducer {
 
         let targetsToBuild: OrderedSet<CacheSystem.CacheTarget>
         switch cacheMode {
-        case .project:
-            let valid = await validateExistingFrameworks(
-                availableTargets: Set(allTargets),
-                cacheSystem: cacheSystem
-            )
-            targetsToBuild = allTargets.subtracting(valid)
-
         case .storages(let configs):
             if configs.isEmpty {
                 // no-op because cache is disabled
@@ -208,9 +201,6 @@ struct FrameworkProducer {
         let cacheStorages: [any CacheStorage]
 
         switch cacheMode {
-        case .project:
-            // For `.project`, there is nothing to restore from external locations.
-            return []
         case .storages(let configs):
             guard !configs.isEmpty else { return [] }
 
@@ -368,10 +358,6 @@ struct FrameworkProducer {
 
     private func cacheFrameworksIfNeeded(_ targets: Set<CacheSystem.CacheTarget>, cacheSystem: CacheSystem) async {
         switch cacheMode {
-        case .project:
-            // For `.project` which is not tied to any (external) storages, we don't need to do anything.
-            // The built frameworks under the project themselves are treated as valid caches.
-            break
         case .storages(let configs):
             guard !configs.isEmpty else { return }
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -226,6 +226,7 @@ struct FrameworkProducer {
             )
 
             remainingTargets.subtract(restoredPerStorage)
+            // If all frameworks are successfully restored, we don't need to proceed to next cache storage.
             if remainingTargets.isEmpty {
                 break
             }

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -137,12 +137,12 @@ struct FrameworkProducer {
                 cacheSystem: cacheSystem,
                 cacheStorage: nil
             )
-        case .storage(let storage, let actors):
-            guard actors.contains(.consumer) else { return [] }
-            cacheStorages = [storage]
-        case .storages(let storages):
-            let storagesWithConsumer = storages.compactMap { storage, actors in
-                actors.contains(.consumer) ? storage : nil
+        case .storage(let config):
+            guard config.actors.contains(.consumer) else { return [] }
+            cacheStorages = [config.storage]
+        case .storages(let configs):
+            let storagesWithConsumer = configs.compactMap { cachePolicy in
+                cachePolicy.actors.contains(.consumer) ? cachePolicy.storage : nil
             }
             guard !storagesWithConsumer.isEmpty else { return [] }
             cacheStorages = storagesWithConsumer
@@ -322,13 +322,13 @@ struct FrameworkProducer {
             // For `.project` which is not tied to any (external) storages, we don't need to do anything.
             // The built frameworks under the project themselves are treated as valid caches.
             break
-        case .storage(let storage, let actors):
-            if actors.contains(.producer) {
-                await cacheSystem.cacheFrameworks(targets, storages: [storage])
+        case .storage(let config):
+            if config.actors.contains(.producer) {
+                await cacheSystem.cacheFrameworks(targets, storages: [config.storage])
             }
-        case .storages(let storages):
-            let storagesWithProducer = storages.compactMap { storage, actors in
-                actors.contains(.producer) ? storage : nil
+        case .storages(let configs):
+            let storagesWithProducer = configs.compactMap { cachePolicy in
+                cachePolicy.actors.contains(.producer) ? cachePolicy.storage : nil
             }
             if !storagesWithProducer.isEmpty {
                 await cacheSystem.cacheFrameworks(targets, storages: storagesWithProducer)

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -154,8 +154,17 @@ struct FrameworkProducer {
         for index in cacheStorages.indices {
             let storage = cacheStorages[index]
 
-            if index != cacheStorages.startIndex {
-                logger.info("Falling back to \(storage)", metadata: .color(.green))
+            let logSuffix = "[\(index)] \(type(of: storage))"
+            if index == cacheStorages.startIndex {
+                logger.info(
+                    "▶️ Starting restoration with cache storage: \(logSuffix)",
+                    metadata: .color(.green)
+                )
+            } else {
+                logger.info(
+                    "⏭️ Falling back to next cache storage: \(logSuffix)",
+                    metadata: .color(.green)
+                )
             }
 
             let restoredPerStorage = await restoreCachesForTargets(
@@ -165,12 +174,18 @@ struct FrameworkProducer {
             )
             restored.formUnion(restoredPerStorage)
 
+            logger.info(
+                "⏸️ Restoration finished with cache storage: \(logSuffix)",
+                metadata: .color(.green)
+            )
+
             remainingTargets.subtract(restoredPerStorage)
             if remainingTargets.isEmpty {
                 break
             }
         }
 
+        logger.info("⏹️ Restoration finished", metadata: .color(.green))
         return restored
     }
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -200,7 +200,7 @@ struct FrameworkProducer {
         for index in storages.indices {
             let storage = storages[index]
 
-            let logSuffix = "[\(index)] \(type(of: storage))"
+            let logSuffix = "[\(index)] \(storage.displayName)"
             if index == storages.startIndex {
                 logger.info(
                     "▶️ Starting restoration with cache storage: \(logSuffix)",

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -137,9 +137,6 @@ struct FrameworkProducer {
                 from: nil,
                 cacheSystem: cacheSystem
             )
-        case .storage(let config):
-            guard config.actors.contains(.consumer) else { return [] }
-            cacheStorages = [config.storage]
         case .storages(let configs):
             let storagesWithConsumer = configs.compactMap { cachePolicy in
                 cachePolicy.actors.contains(.consumer) ? cachePolicy.storage : nil
@@ -322,10 +319,6 @@ struct FrameworkProducer {
             // For `.project` which is not tied to any (external) storages, we don't need to do anything.
             // The built frameworks under the project themselves are treated as valid caches.
             break
-        case .storage(let config):
-            if config.actors.contains(.producer) {
-                await cacheSystem.cacheFrameworks(targets, to: [config.storage])
-            }
         case .storages(let configs):
             let storagesWithProducer = configs.compactMap { cachePolicy in
                 cachePolicy.actors.contains(.producer) ? cachePolicy.storage : nil

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -297,6 +297,7 @@ struct FrameworkProducer {
                 }
                 return false
             case .noCache:
+                logger.info("ℹ️ Cache not found for \(frameworkName) (\(expectedCacheKeyHash)) from cache storage.", metadata: .color(.green))
                 return false
             }
         }

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -116,8 +116,7 @@ struct FrameworkProducer {
 
         let cacheSystem = CacheSystem(
             pinsStore: pinsStore,
-            outputDirectory: outputDir,
-            writableStorages: cacheStorages(for: .producer) ?? []
+            outputDirectory: outputDir
         )
         let cacheEnabledTargets: Set<CacheSystem.CacheTarget>
         if cacheMode.isConsumingCacheEnabled {
@@ -141,7 +140,10 @@ struct FrameworkProducer {
         }
 
         if isProducingCacheEnabled {
-            await cacheSystem.cacheFrameworks(Set(targetsToBuild))
+            await cacheSystem.cacheFrameworks(
+                Set(targetsToBuild),
+                storages: cacheStorages(for: .producer)
+            )
         }
 
         if shouldGenerateVersionFile {

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -397,3 +397,7 @@ extension Runner.Options.BuildOptionsContainer {
         }
     }
 }
+
+extension [Runner.Options.CachePolicy] {
+    public static let disabled: Self = []
+}

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -232,14 +232,13 @@ extension Runner {
             )
 
             /// The cache policy for saving to and restoring from the system cache directory `~/Library/Caches/Scipio`.
-            public static let localDisk: Self = _localDisk(baseURL: nil)
+            public static let localDisk: Self = Self(
+                storage: LocalDiskCacheStorage(baseURL: nil),
+                actors: [.producer, .consumer]
+            )
 
             /// The cache policy for saving to and restoring from the custom cache directory `baseURL.appendingPath("Scipio")`.
             public static func localDisk(baseURL: URL) -> Self {
-                _localDisk(baseURL: baseURL)
-            }
-
-            private static func _localDisk(baseURL: URL?) -> Self {
                 Self(
                     storage: LocalDiskCacheStorage(baseURL: baseURL),
                     actors: [.producer, .consumer]

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -219,7 +219,7 @@ extension Runner {
             public let storage: any CacheStorage
             public let actors: Set<CacheActorKind>
 
-            public init(storage: any CacheStorage, actors: Set<CacheActorKind>) {
+            public init(storage: some CacheStorage, actors: Set<CacheActorKind>) {
                 self.storage = storage
                 self.actors = actors
             }

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -209,6 +209,16 @@ extension Runner {
         }
 
         public enum CacheMode: Sendable {
+            public struct StorageConfig: Sendable {
+                public let storage: any CacheStorage
+                public let actors: Set<CacheActorKind>
+
+                public init(storage: any CacheStorage, actors: Set<CacheActorKind>) {
+                    self.storage = storage
+                    self.actors = actors
+                }
+            }
+
             public enum CacheActorKind: Sendable {
                 // Save built product to cacheStorage
                 case producer
@@ -218,8 +228,8 @@ extension Runner {
 
             case disabled
             case project
-            case storage(any CacheStorage, Set<CacheActorKind>)
-            case storages([(storage: any CacheStorage, actors: Set<CacheActorKind>)])
+            case storage(StorageConfig)
+            case storages([StorageConfig])
         }
 
         public enum PlatformSpecifier: Equatable {

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -219,6 +219,7 @@ extension Runner {
             case disabled
             case project
             case storage(any CacheStorage, Set<CacheActorKind>)
+            case storages([(storage: any CacheStorage, actors: Set<CacheActorKind>)])
         }
 
         public enum PlatformSpecifier: Equatable {

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -224,6 +224,10 @@ extension Runner {
                 self.actors = actors
             }
 
+            private init(_ storage: LocalDiskCacheStorage) {
+                self.init(storage: storage, actors: [.producer, .consumer])
+            }
+
             /// The cache policy which treats built frameworks under the project's output directory (e.g. `XCFrameworks`)
             /// as valid caches, but does not saving to / restoring from any external locations.
             public static let project: Self = Self(
@@ -232,17 +236,11 @@ extension Runner {
             )
 
             /// The cache policy for saving to and restoring from the system cache directory `~/Library/Caches/Scipio`.
-            public static let localDisk: Self = Self(
-                storage: LocalDiskCacheStorage(baseURL: nil),
-                actors: [.producer, .consumer]
-            )
+            public static let localDisk: Self = Self(LocalDiskCacheStorage(baseURL: nil))
 
             /// The cache policy for saving to and restoring from the custom cache directory `baseURL.appendingPath("Scipio")`.
             public static func localDisk(baseURL: URL) -> Self {
-                Self(
-                    storage: LocalDiskCacheStorage(baseURL: baseURL),
-                    actors: [.producer, .consumer]
-                )
+                Self(LocalDiskCacheStorage(baseURL: baseURL))
             }
         }
 

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -224,15 +224,26 @@ extension Runner {
                 self.actors = actors
             }
 
-            public static let project = Self(
+            /// The cache policy which treats built frameworks under the project's output directory (e.g. `XCFrameworks`)
+            /// as valid caches, but does not saving to / restoring from any external locations.
+            public static let project: Self = Self(
                 storage: ProjectCacheStorage(),
                 actors: [.producer]
             )
 
-            public static let localDisk = Self(
-                storage: LocalDiskCacheStorage(),
+            /// The cache policy for saving to and restoring from the system cache directory `~/Library/Caches/Scipio`.
+            public static let localDisk: Self = Self(
+                storage: LocalDiskCacheStorage(baseURL: nil),
                 actors: [.producer, .consumer]
             )
+
+            /// The cache policy for saving to and restoring from the custom cache directory `baseURL.appendingPath("Scipio")`.
+            public static func localDisk(baseURL: URL) -> Self {
+                Self(
+                    storage: LocalDiskCacheStorage(baseURL: baseURL),
+                    actors: [.producer, .consumer]
+                )
+            }
         }
 
         public enum PlatformSpecifier: Equatable {

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -228,8 +228,11 @@ extension Runner {
 
             case disabled
             case project
-            case storage(StorageConfig)
             case storages([StorageConfig])
+
+            public static func storage(_ config: StorageConfig) -> Self {
+                .storages([config])
+            }
         }
 
         public enum PlatformSpecifier: Equatable {

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -226,10 +226,10 @@ extension Runner {
                 case consumer
             }
 
-            case disabled
             case project
             case storages([StorageConfig])
 
+            public static let disabled: Self = .storages([])
             public static func storage(_ config: StorageConfig) -> Self {
                 .storages([config])
             }

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -226,10 +226,14 @@ extension Runner {
                 case consumer
             }
 
-            case project
             case storages([StorageConfig])
 
             public static let disabled: Self = .storages([])
+
+            public static let project: Self = .storages([
+                .init(storage: ProjectCacheStorage(), actors: [.producer]),
+            ])
+
             public static func storage(_ config: StorageConfig) -> Self {
                 .storages([config])
             }

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -232,13 +232,14 @@ extension Runner {
             )
 
             /// The cache policy for saving to and restoring from the system cache directory `~/Library/Caches/Scipio`.
-            public static let localDisk: Self = Self(
-                storage: LocalDiskCacheStorage(baseURL: nil),
-                actors: [.producer, .consumer]
-            )
+            public static let localDisk: Self = _localDisk(baseURL: nil)
 
             /// The cache policy for saving to and restoring from the custom cache directory `baseURL.appendingPath("Scipio")`.
             public static func localDisk(baseURL: URL) -> Self {
+                _localDisk(baseURL: baseURL)
+            }
+
+            private static func _localDisk(baseURL: URL?) -> Self {
                 Self(
                     storage: LocalDiskCacheStorage(baseURL: baseURL),
                     actors: [.producer, .consumer]

--- a/Sources/scipio/CommandType.swift
+++ b/Sources/scipio/CommandType.swift
@@ -26,7 +26,7 @@ enum CommandType {
     var cachePolicies: [Runner.Options.CachePolicy] {
         switch self {
         case .create:
-            return []
+            return .disabled
         case .prepare(let cachePolicies):
             return cachePolicies
         }
@@ -61,7 +61,7 @@ extension Runner {
     private static func cachePolicies(from commandType: CommandType) -> [Runner.Options.CachePolicy] {
         switch commandType {
         case .create:
-            return []
+            return .disabled
         case .prepare(let cachePolicies):
             return cachePolicies
         }

--- a/Sources/scipio/CommandType.swift
+++ b/Sources/scipio/CommandType.swift
@@ -3,7 +3,7 @@ import ScipioKit
 
 enum CommandType {
     case create(platformSpecifier: Runner.Options.PlatformSpecifier)
-    case prepare(cacheMode: Runner.Options.CacheMode)
+    case prepare(cachePolicies: [Runner.Options.CachePolicy])
 
     var mode: Runner.Mode {
         switch self {
@@ -23,12 +23,12 @@ enum CommandType {
         }
     }
 
-    var cacheMode: Runner.Options.CacheMode {
+    var cachePolicies: [Runner.Options.CachePolicy] {
         switch self {
         case .create:
-            return .disabled
-        case .prepare(let cacheMode):
-            return cacheMode
+            return []
+        case .prepare(let cachePolicies):
+            return cachePolicies
         }
     }
 }
@@ -51,19 +51,19 @@ extension Runner {
         let runnerOptions = Runner.Options(
             baseBuildOptions: baseBuildOptions,
             shouldOnlyUseVersionsFromResolvedFile: buildOptions.shouldOnlyUseVersionsFromResolvedFile,
-            cacheMode: Self.cacheMode(from: commandType),
+            cachePolicies: Self.cachePolicies(from: commandType),
             overwrite: buildOptions.overwrite,
             verbose: globalOptions.verbose
         )
         self.init(mode: commandType.mode, options: runnerOptions)
     }
 
-    private static func cacheMode(from commandType: CommandType) -> Runner.Options.CacheMode {
+    private static func cachePolicies(from commandType: CommandType) -> [Runner.Options.CachePolicy] {
         switch commandType {
         case .create:
-            return .disabled
-        case .prepare(let cacheMode):
-            return cacheMode
+            return []
+        case .prepare(let cachePolicies):
+            return cachePolicies
         }
     }
 

--- a/Sources/scipio/PrepareCommands.swift
+++ b/Sources/scipio/PrepareCommands.swift
@@ -34,7 +34,7 @@ extension Scipio {
             let runnerCachePolicies: [Runner.Options.CachePolicy]
             switch cachePolicy {
             case .disabled:
-                runnerCachePolicies = []
+                runnerCachePolicies = .disabled
             case .project:
                 runnerCachePolicies = [.project]
             case .local:

--- a/Sources/scipio/PrepareCommands.swift
+++ b/Sources/scipio/PrepareCommands.swift
@@ -38,7 +38,10 @@ extension Scipio {
             case .project:
                 runnerCacheMode = .project
             case .local:
-                runnerCacheMode = .storage(LocalCacheStorage(), [.consumer, .producer])
+                runnerCacheMode = .storage(.init(
+                    storage: LocalCacheStorage(),
+                    actors: [.consumer, .producer]
+                ))
             }
 
             let runner = Runner(

--- a/Sources/scipio/PrepareCommands.swift
+++ b/Sources/scipio/PrepareCommands.swift
@@ -31,21 +31,18 @@ extension Scipio {
             let logLevel: Logger.Level = globalOptions.verbose ? .trace : .info
             LoggingSystem.bootstrap(logLevel: logLevel)
 
-            let runnerCacheMode: Runner.Options.CacheMode
+            let runnerCachePolicies: [Runner.Options.CachePolicy]
             switch cachePolicy {
             case .disabled:
-                runnerCacheMode = .disabled
+                runnerCachePolicies = []
             case .project:
-                runnerCacheMode = .project
+                runnerCachePolicies = [.project]
             case .local:
-                runnerCacheMode = .storage(.init(
-                    storage: LocalDiskCacheStorage(),
-                    actors: [.consumer, .producer]
-                ))
+                runnerCachePolicies = [.localDisk]
             }
 
             let runner = Runner(
-                commandType: .prepare(cacheMode: runnerCacheMode),
+                commandType: .prepare(cachePolicies: runnerCachePolicies),
                 buildOptions: buildOptions,
                 globalOptions: globalOptions
             )

--- a/Sources/scipio/PrepareCommands.swift
+++ b/Sources/scipio/PrepareCommands.swift
@@ -39,7 +39,7 @@ extension Scipio {
                 runnerCacheMode = .project
             case .local:
                 runnerCacheMode = .storage(.init(
-                    storage: LocalCacheStorage(),
+                    storage: LocalDiskCacheStorage(),
                     actors: [.consumer, .producer]
                 ))
             }

--- a/Sources/scipio/scipio.docc/build-pipeline.md
+++ b/Sources/scipio/scipio.docc/build-pipeline.md
@@ -264,7 +264,6 @@ You can also use multiple cache policies, which accepts multiple cache storages 
 import ScipioS3Storage
 
 let s3Storage: some CacheStorage = ScipioS3Storage.S3Storage(config: ...)
-let localCacheStorage: some CacheStorage = LocalCacheStorage()
 let runner = Runner(
     mode: .prepareDependencies,
     options: .init(
@@ -274,11 +273,11 @@ let runner = Runner(
         ),
         cachePolicies: [
             .init(storage: s3Storage, actors: [.consumer]),
-            .init(storage: localCacheStorage, actors: [.producer, .consumer]),
+            .localDisk,
         ]
     )
 )
 ```
 
-In the sample above, if some frameworks' caches are not found on `s3Storage`, those are tried to be fetched from the next `localCacheStorage` then. The frameworks not found on `localCacheStorage` will be built and cached into it (since the storage is tied to `.producer` actor as well).
+In the sample above, if some frameworks' caches are not found on `s3Storage`, those are tried to be fetched from the next `.localDisk` cache policie's storage then. The frameworks not found on the storage of `.localDisk` cache policy will be built and cached into it (since the storage is tied to `.producer` actor).
  

--- a/Sources/scipio/scipio.docc/build-pipeline.md
+++ b/Sources/scipio/scipio.docc/build-pipeline.md
@@ -253,3 +253,30 @@ You can specify it by a second argument of `.storage` cache mode.
 `producer` is an actor who attempt to save cache to the cache storage.
 
 When build artifacts are built, then it try to save them.
+
+### Use multiple cache storages at the same time
+
+You can also use the `.storages` cache mode, which accepts multiple cache storages with different sets of cache actors:
+
+```swift
+import ScipioS3Storage
+
+let s3Storage: some CacheStorage = ScipioS3Storage.S3Storage(config: ...)
+let localCacheStorage: some CacheStorage = LocalCacheStorage()
+let runner = Runner(
+    mode: .prepareDependencies,
+    options: .init(
+        baseBuildOptions: .init(
+            buildConfiguration: .release,
+            isSimulatorSupported: true
+        ),
+        cacheMode: .storages([
+            (s3Storage, [.consumer] as Set),
+            (localCacheStorage, [.producer, .consumer] as Set),
+        ])
+    )
+)
+```
+
+In the sample above, if some frameworks' caches are not found on `s3Storage`, those are tried to be fetched from the next `localCacheStorage` then. The frameworks not found on `localCacheStorage` will be built and cached into it (since the storage is tied to `.producer` actor as well).
+ 

--- a/Sources/scipio/scipio.docc/build-pipeline.md
+++ b/Sources/scipio/scipio.docc/build-pipeline.md
@@ -153,7 +153,7 @@ let runner = Runner(
         ],
         enableLibraryEvolution: false
         ),
-    cacheMode: .project,
+    cachePolicies: [.project],
     overwrite: true,
     verbose: true
 )
@@ -230,7 +230,9 @@ let runner = Runner(
             buildConfiguration: .release,
             isSimulatorSupported: true
         ),
-        cacheMode: .storage(s3Storage, [.consumer])
+        cachePolicies: [
+            .init(storage: s3Storage, actors: [.consumer]),
+        ]
     )
 )
 ```
@@ -246,7 +248,7 @@ You can also implement your custom cache storage by implementing `CacheStorage` 
 
 There are two cache actors `consumer` and `producer`.
 
-You can specify it by a second argument of `.storage` cache mode.
+You can specify it by `Runner.Options.CachePolicy.actors`.
 
 `consumer` is an actor who can fetch cache from the cache storage.
 
@@ -254,9 +256,9 @@ You can specify it by a second argument of `.storage` cache mode.
 
 When build artifacts are built, then it try to save them.
 
-### Use multiple cache storages at the same time
+### Use multiple cache policies at the same time
 
-You can also use the `.storages` cache mode, which accepts multiple cache storages with different sets of cache actors:
+You can also use multiple cache policies, which accepts multiple cache storages with different sets of cache actors:
 
 ```swift
 import ScipioS3Storage
@@ -270,10 +272,10 @@ let runner = Runner(
             buildConfiguration: .release,
             isSimulatorSupported: true
         ),
-        cacheMode: .storages([
-            (s3Storage, [.consumer] as Set),
-            (localCacheStorage, [.producer, .consumer] as Set),
-        ])
+        cachePolicies: [
+            .init(storage: s3Storage, actors: [.consumer]),
+            .init(storage: localCacheStorage, actors: [.producer, .consumer]),
+        ]
     )
 )
 ```

--- a/Sources/scipio/scipio.docc/using-s3-storage.md
+++ b/Sources/scipio/scipio.docc/using-s3-storage.md
@@ -39,7 +39,9 @@ let runner = Runner(
             buildConfiguration: .release,
             isSimulatorSupported: true
         ),
-        cacheMode: .storage(s3Storage, [.consumer, .producer])
+        cachePolicies: [
+            .init(storage: s3Storage, actors: [.consumer, .producer]),
+        ]
     )
 )
 ```

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -95,8 +95,7 @@ final class CacheSystemTests: XCTestCase {
         )
         let cacheSystem = CacheSystem(
             pinsStore: try descriptionPackage.workspace.pinsStore.load(),
-            outputDirectory: FileManager.default.temporaryDirectory.appendingPathComponent("XCFrameworks"),
-            writableStorages: []
+            outputDirectory: FileManager.default.temporaryDirectory.appendingPathComponent("XCFrameworks")
         )
         let testingPackage = descriptionPackage
             .graph

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -96,7 +96,7 @@ final class CacheSystemTests: XCTestCase {
         let cacheSystem = CacheSystem(
             pinsStore: try descriptionPackage.workspace.pinsStore.load(),
             outputDirectory: FileManager.default.temporaryDirectory.appendingPathComponent("XCFrameworks"),
-            storage: nil
+            writableStorages: []
         )
         let testingPackage = descriptionPackage
             .graph

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -108,7 +108,7 @@ final class IntegrationTests: XCTestCase {
                 ),
                 buildOptionsMatrix: buildOptionsMatrix,
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cachePolicies: [],
+                cachePolicies: .disabled,
                 overwrite: true,
                 verbose: false
             )

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -108,7 +108,7 @@ final class IntegrationTests: XCTestCase {
                 ),
                 buildOptionsMatrix: buildOptionsMatrix,
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .disabled,
+                cachePolicies: [],
                 overwrite: true,
                 verbose: false
             )

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -277,8 +277,7 @@ final class RunnerTests: XCTestCase {
         let pinsStore = try descriptionPackage.workspace.pinsStore.load()
         let cacheSystem = CacheSystem(
             pinsStore: pinsStore,
-            outputDirectory: frameworkOutputDir,
-            writableStorages: []
+            outputDirectory: frameworkOutputDir
         )
         let packages = descriptionPackage.graph.packages
             .filter { $0.manifest.displayName != descriptionPackage.manifest.displayName }
@@ -436,8 +435,7 @@ final class RunnerTests: XCTestCase {
         let pinsStore = try descriptionPackage.workspace.pinsStore.load()
         let cacheSystem = CacheSystem(
             pinsStore: pinsStore,
-            outputDirectory: frameworkOutputDir,
-            writableStorages: []
+            outputDirectory: frameworkOutputDir
         )
         let packages = descriptionPackage.graph.packages
             .filter { $0.manifest.displayName != descriptionPackage.manifest.displayName }

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -329,7 +329,7 @@ final class RunnerTests: XCTestCase {
     }
 
     func testLocalDiskCacheStorage() async throws {
-        let storage = LocalDiskCacheStorage(cacheDirectory: .custom(tempDir))
+        let storage = LocalDiskCacheStorage(baseURL: tempDir)
         let storageDir = tempDir.appendingPathComponent("Scipio")
 
         let runner = Runner(
@@ -374,11 +374,11 @@ final class RunnerTests: XCTestCase {
 
     func testMultipleCachePolicies() async throws {
         let storage1CacheDir = tempDir.appending(path: "storage1", directoryHint: .isDirectory)
-        let storage1 = LocalDiskCacheStorage(cacheDirectory: .custom(storage1CacheDir))
+        let storage1 = LocalDiskCacheStorage(baseURL: storage1CacheDir)
         let storage1Dir = storage1CacheDir.appendingPathComponent("Scipio")
 
         let storage2CacheDir = tempDir.appending(path: "storage2", directoryHint: .isDirectory)
-        let storage2 = LocalDiskCacheStorage(cacheDirectory: .custom(storage2CacheDir))
+        let storage2 = LocalDiskCacheStorage(baseURL: storage2CacheDir)
         let storage2Dir = storage2CacheDir.appendingPathComponent("Scipio")
 
         let runner = Runner(

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -612,7 +612,7 @@ final class RunnerTests: XCTestCase {
                     isSimulatorSupported: true
                 ),
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cachePolicies: []
+                cachePolicies: .disabled
             )
         )
 
@@ -655,7 +655,7 @@ final class RunnerTests: XCTestCase {
                     frameworkType: .mergeable
                 ),
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cachePolicies: []
+                cachePolicies: .disabled
             )
         )
 

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -328,8 +328,8 @@ final class RunnerTests: XCTestCase {
         }
     }
 
-    func testLocalStorage() async throws {
-        let storage = LocalCacheStorage(cacheDirectory: .custom(tempDir))
+    func testLocalDiskCacheStorage() async throws {
+        let storage = LocalDiskCacheStorage(cacheDirectory: .custom(tempDir))
         let storageDir = tempDir.appendingPathComponent("Scipio")
 
         let runner = Runner(
@@ -375,11 +375,11 @@ final class RunnerTests: XCTestCase {
 
     func testCacheModeMultipleStorages() async throws {
         let storage1CacheDir = tempDir.appending(path: "storage1", directoryHint: .isDirectory)
-        let storage1 = LocalCacheStorage(cacheDirectory: .custom(storage1CacheDir))
+        let storage1 = LocalDiskCacheStorage(cacheDirectory: .custom(storage1CacheDir))
         let storage1Dir = storage1CacheDir.appendingPathComponent("Scipio")
 
         let storage2CacheDir = tempDir.appending(path: "storage2", directoryHint: .isDirectory)
-        let storage2 = LocalCacheStorage(cacheDirectory: .custom(storage2CacheDir))
+        let storage2 = LocalDiskCacheStorage(cacheDirectory: .custom(storage2CacheDir))
         let storage2Dir = storage2CacheDir.appendingPathComponent("Scipio")
 
         let runner = Runner(

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -278,7 +278,7 @@ final class RunnerTests: XCTestCase {
         let cacheSystem = CacheSystem(
             pinsStore: pinsStore,
             outputDirectory: frameworkOutputDir,
-            storage: nil
+            writableStorages: []
         )
         let packages = descriptionPackage.graph.packages
             .filter { $0.manifest.displayName != descriptionPackage.manifest.displayName }
@@ -437,7 +437,7 @@ final class RunnerTests: XCTestCase {
         let cacheSystem = CacheSystem(
             pinsStore: pinsStore,
             outputDirectory: frameworkOutputDir,
-            storage: nil
+            writableStorages: []
         )
         let packages = descriptionPackage.graph.packages
             .filter { $0.manifest.displayName != descriptionPackage.manifest.displayName }

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -336,7 +336,10 @@ final class RunnerTests: XCTestCase {
             mode: .prepareDependencies,
             options: .init(
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .storage(storage, [.consumer, .producer])
+                cacheMode: .storage(.init(
+                    storage: storage,
+                    actors: [.consumer, .producer]
+                ))
             )
         )
         do {
@@ -384,8 +387,8 @@ final class RunnerTests: XCTestCase {
             options: .init(
                 shouldOnlyUseVersionsFromResolvedFile: true,
                 cacheMode: .storages([
-                    (storage1, [.consumer, .producer] as Set),
-                    (storage2, [.consumer, .producer] as Set),
+                    .init(storage: storage1, actors: [.consumer, .producer]),
+                    .init(storage: storage2, actors: [.consumer, .producer]),
                 ])
             )
         )

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -306,7 +306,7 @@ final class RunnerTests: XCTestCase {
             options: .init(
                 baseBuildOptions: .init(enableLibraryEvolution: true),
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .project
+                cachePolicies: [.project]
             )
         )
         do {
@@ -336,10 +336,9 @@ final class RunnerTests: XCTestCase {
             mode: .prepareDependencies,
             options: .init(
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .storage(.init(
-                    storage: storage,
-                    actors: [.consumer, .producer]
-                ))
+                cachePolicies: [
+                    .init(storage: storage, actors: [.consumer, .producer]),
+                ]
             )
         )
         do {
@@ -373,7 +372,7 @@ final class RunnerTests: XCTestCase {
         try fileManager.removeItem(at: storageDir)
     }
 
-    func testCacheModeMultipleStorages() async throws {
+    func testMultipleCachePolicies() async throws {
         let storage1CacheDir = tempDir.appending(path: "storage1", directoryHint: .isDirectory)
         let storage1 = LocalDiskCacheStorage(cacheDirectory: .custom(storage1CacheDir))
         let storage1Dir = storage1CacheDir.appendingPathComponent("Scipio")
@@ -386,10 +385,10 @@ final class RunnerTests: XCTestCase {
             mode: .prepareDependencies,
             options: .init(
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .storages([
+                cachePolicies: [
                     .init(storage: storage1, actors: [.consumer, .producer]),
                     .init(storage: storage2, actors: [.consumer, .producer]),
-                ])
+                ]
             )
         )
         do {
@@ -441,7 +440,7 @@ final class RunnerTests: XCTestCase {
                     frameworkType: .dynamic
                 ),
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .project,
+                cachePolicies: [.project],
                 overwrite: false,
                 verbose: false)
         )
@@ -468,7 +467,7 @@ final class RunnerTests: XCTestCase {
                     frameworkType: .dynamic
                 ),
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .project,
+                cachePolicies: [.project],
                 overwrite: false,
                 verbose: false)
         )
@@ -539,7 +538,7 @@ final class RunnerTests: XCTestCase {
                     enableLibraryEvolution: true
                 ),
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .project,
+                cachePolicies: [.project],
                 overwrite: false,
                 verbose: false)
         )
@@ -575,7 +574,7 @@ final class RunnerTests: XCTestCase {
                     ),
                 ],
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .project,
+                cachePolicies: [.project],
                 overwrite: false,
                 verbose: false)
         )
@@ -613,7 +612,7 @@ final class RunnerTests: XCTestCase {
                     isSimulatorSupported: true
                 ),
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .disabled
+                cachePolicies: []
             )
         )
 
@@ -656,7 +655,7 @@ final class RunnerTests: XCTestCase {
                     frameworkType: .mergeable
                 ),
                 shouldOnlyUseVersionsFromResolvedFile: true,
-                cacheMode: .disabled
+                cachePolicies: []
             )
         )
 


### PR DESCRIPTION
Resolves #148.

- `Runner.Options.CacheMode` is replaced with `[Runner.Options.CachePolicy]`
  - `cacheMode: .disabled` -> `cachePolicies: []`
  - `cacheMode: .project` -> `cachePolicies: [.project]`
  - `cacheMode: .storage(storage, actors)` -> `cachePolicies: [.init(storage: storage, actors: actors)]`
- When saving, cache frameworks into all storages with `CacheActorKind.producer`
- When restoring, storages with `CacheActorKind.consumer` are used in order
  - If first storage failed to restore some caches, the failed ones are tried to be fetched from second (next) storage