### PR TITLE
Add a file that will help Swift Package Index to host the documentation of Scipio

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [scipio]
+      platform: macOS

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 [![License](https://img.shields.io/badge/License-MIT-darkgray?style=flat-square)
 ](https://github.com/giginet/Scipio/blob/main/LICENSE.md)
 
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fgiginet%2FScipio%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/giginet/Scipio)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fgiginet%2FScipio%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/giginet/Scipio)
+
 ## Carthago delenda est
 
 Scipio proposes a new workflow to integrate dependencies into your applications.


### PR DESCRIPTION
I did take the liberty to [add Scipio](https://github.com/SwiftPackageIndex/PackageList/issues/8446#event-15279386179) to [Swift Package Index](https://swiftpackageindex.com).
In order to have them host your documentation too we need to add this file that will allow their ci to build your documentation.
This PR contain the SwiftPackageIndex badges on the README.md file too.