### PR TITLE
[CI] Use macos-15 for Xcode 16 due to GitHub Actions's macOS image support policy changes

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -8,7 +8,7 @@ env:
   DEVELOPER_DIR: "/Applications/Xcode_16.0.app/Contents/Developer"
 jobs:
   DocC:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Build DocC

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         xcode_version: ["16.0"]
     env: 
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - name: Install SwiftLint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   release:
     name: Build and Upload Artifact Bundle
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Resolve Dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
           - "16.0" # 6.0
     env: 
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - name: Get swift version
       run: swift --version


### PR DESCRIPTION
ref: https://github.com/actions/runner-images/issues/10703