### PR TITLE
Use TSCRelativePath typealias included in Basics and reduce TSCBasic imports

### DIFF
--- a/Sources/ScipioKit/PackageLocator.swift
+++ b/Sources/ScipioKit/PackageLocator.swift
@@ -1,5 +1,4 @@
 import Basics
-import TSCBasic
 import PackageModel
 
 /// Holds the packageDirectory Scipio works on, and defines some path-related functionalities.
@@ -21,7 +20,7 @@ extension PackageLocator {
     }
 
     func generatedModuleMapPath(of target: ScipioResolvedModule, sdk: SDK) throws -> TSCAbsolutePath {
-        let relativePath = try TSCBasic.RelativePath(validating: "ModuleMapsForFramework/\(sdk.settingValue)")
+        let relativePath = try TSCRelativePath(validating: "ModuleMapsForFramework/\(sdk.settingValue)")
         return workspaceDirectory
             .appending(relativePath)
             .appending(component: target.modulemapName)

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -2,7 +2,8 @@ import Foundation
 import PackageModel
 import SPMBuildCore
 import PackageGraph
-import TSCBasic
+import Basics
+import var TSCBasic.localFileSystem
 
 struct PIFCompiler: Compiler {
     let descriptionPackage: DescriptionPackage
@@ -31,11 +32,11 @@ struct PIFCompiler: Compiler {
         self.buildParametersGenerator = .init(buildOptions: buildOptions, fileSystem: fileSystem)
     }
 
-    private func fetchDefaultToolchainBinPath() async throws -> AbsolutePath {
+    private func fetchDefaultToolchainBinPath() async throws -> TSCAbsolutePath {
         let result = try await executor.execute("/usr/bin/xcrun", "xcode-select", "-p")
         let rawString = try result.unwrapOutput().trimmingCharacters(in: .whitespacesAndNewlines)
-        let developerDirPath = try AbsolutePath(validating: rawString)
-        let toolchainPath = try RelativePath(validating: "./Toolchains/XcodeDefault.xctoolchain/usr/bin")
+        let developerDirPath = try TSCAbsolutePath(validating: rawString)
+        let toolchainPath = try TSCRelativePath(validating: "./Toolchains/XcodeDefault.xctoolchain/usr/bin")
         return developerDirPath.appending(toolchainPath)
     }
 
@@ -93,13 +94,13 @@ struct PIFCompiler: Compiler {
 
         // If there is existing framework, remove it
         let frameworkName = target.xcFrameworkName
-        let outputXCFrameworkPath = try AbsolutePath(validating: outputDirectory.path).appending(component: frameworkName)
+        let outputXCFrameworkPath = try TSCAbsolutePath(validating: outputDirectory.path).appending(component: frameworkName)
         if fileSystem.exists(outputXCFrameworkPath) && overwrite {
             logger.info("💥 Delete \(frameworkName)", metadata: .color(.red))
             try fileSystem.removeFileTree(outputXCFrameworkPath)
         }
 
-        let debugSymbolPaths: [SDK: [AbsolutePath]]?
+        let debugSymbolPaths: [SDK: [TSCAbsolutePath]]?
         if buildOptions.isDebugSymbolsEmbedded {
             debugSymbolPaths = try await extractDebugSymbolPaths(target: target,
                                                                  buildConfiguration: buildOptions.buildConfiguration,


### PR DESCRIPTION
ref:
- #166
- https://github.com/swiftlang/swift-package-manager/blob/bc689418acad746af6f2e24e6bef640e411d9bd7/Sources/Basics/FileSystem/RelativePath.swift#L15-L16