### PR TITLE
Reduce TSCBasic usages

### DIFF
--- a/Sources/ScipioKit/Producer/BinaryExtractor.swift
+++ b/Sources/ScipioKit/Producer/BinaryExtractor.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PackageGraph
 import PackageModel
-import TSCBasic
+import Basics
 
 struct BinaryExtractor {
     var package: DescriptionPackage

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -1,6 +1,6 @@
 import Foundation
 import ScipioStorage
-import TSCBasic
+import Basics
 import struct TSCUtility.Version
 import Algorithms
 // We may drop this annotation in SwiftPM's future release

--- a/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
+++ b/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ScipioStorage
 import PackageGraph
-import TSCBasic
+import Basics
 
 struct LocalDiskCacheStorage: CacheStorage {
     private let fileSystem: any FileSystem

--- a/Sources/ScipioKit/Producer/Compiler.swift
+++ b/Sources/ScipioKit/Producer/Compiler.swift
@@ -1,6 +1,6 @@
 import Foundation
 import PackageGraph
-import TSCBasic
+import Basics
 
 protocol Compiler {
     var descriptionPackage: DescriptionPackage { get }
@@ -16,20 +16,22 @@ extension Compiler {
         buildConfiguration: BuildConfiguration,
         sdks: Set<SDK>,
         fileSystem: FileSystem = localFileSystem
-    ) async throws -> [SDK: [AbsolutePath]] {
+    ) async throws -> [SDK: [TSCAbsolutePath]] {
         let extractor = DwarfExtractor()
 
-        var result = [SDK: [AbsolutePath]]()
+        var result = [SDK: [TSCAbsolutePath]]()
 
         for sdk in sdks {
             let dsymPath = descriptionPackage.buildDebugSymbolPath(buildConfiguration: buildConfiguration, sdk: sdk, target: target)
             guard fileSystem.exists(dsymPath) else { continue }
-            let debugSymbol = DebugSymbol(dSYMPath: dsymPath,
-                                          target: target,
-                                          sdk: sdk,
-                                          buildConfiguration: buildConfiguration)
+            let debugSymbol = DebugSymbol(
+                dSYMPath: dsymPath,
+                target: target,
+                sdk: sdk,
+                buildConfiguration: buildConfiguration
+            )
             let dumpedDSYMsMaps = try await extractor.dump(dwarfPath: debugSymbol.dwarfPath)
-            let bcSymbolMapPaths: [AbsolutePath] = dumpedDSYMsMaps.values.compactMap { uuid in
+            let bcSymbolMapPaths: [TSCAbsolutePath] = dumpedDSYMsMaps.values.compactMap { uuid in
                 let path = descriptionPackage.productsDirectory(
                     buildConfiguration: debugSymbol.buildConfiguration,
                     sdk: debugSymbol.sdk
@@ -45,7 +47,7 @@ extension Compiler {
 }
 
 extension DescriptionPackage {
-    fileprivate func buildDebugSymbolPath(buildConfiguration: BuildConfiguration, sdk: SDK, target: ScipioResolvedModule) -> AbsolutePath {
+    fileprivate func buildDebugSymbolPath(buildConfiguration: BuildConfiguration, sdk: SDK, target: ScipioResolvedModule) -> TSCAbsolutePath {
         productsDirectory(buildConfiguration: buildConfiguration, sdk: sdk)
             .appending(component: "\(target.name).framework.dSYM")
     }

--- a/Sources/ScipioKit/Producer/DebugSymbol.swift
+++ b/Sources/ScipioKit/Producer/DebugSymbol.swift
@@ -1,14 +1,14 @@
 import Foundation
 import PackageGraph
-import TSCBasic
+import Basics
 
 struct DebugSymbol {
-    var dSYMPath: AbsolutePath
+    var dSYMPath: TSCAbsolutePath
     var target: ScipioResolvedModule
     var sdk: SDK
     var buildConfiguration: BuildConfiguration
 
-    var dwarfPath: AbsolutePath {
+    var dwarfPath: TSCAbsolutePath {
         dSYMPath.appending(components: "Contents", "Resources", "DWARF", target.name)
     }
 }
@@ -21,7 +21,8 @@ struct DwarfExtractor<E: Executor> {
     }
 
     typealias Arch = String
-    func dump(dwarfPath: AbsolutePath) async throws -> [Arch: UUID] {
+
+    func dump(dwarfPath: TSCAbsolutePath) async throws -> [Arch: UUID] {
         let result = try await executor.execute("/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.pathString)
 
         let output = try result.unwrapOutput()

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -4,7 +4,7 @@ import PackageGraph
 import PackageModel
 import Collections
 import protocol TSCBasic.FileSystem
-import var TSCBasic.localFileSystem
+import Basics
 
 struct FrameworkProducer {
     private let descriptionPackage: DescriptionPackage

--- a/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
+++ b/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
@@ -1,5 +1,5 @@
 import Foundation
-import TSCBasic
+import Basics
 
 struct InfoPlistGenerator {
     private let fileSystem: any FileSystem
@@ -8,7 +8,7 @@ struct InfoPlistGenerator {
         self.fileSystem = fileSystem
     }
 
-    func generateForResourceBundle(at path: AbsolutePath) throws {
+    func generateForResourceBundle(at path: TSCAbsolutePath) throws {
         let body = resourceBundleBody
         try fileSystem.writeFileContents(path.spmAbsolutePath, string: body)
     }

--- a/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
@@ -1,5 +1,6 @@
 import Foundation
-import TSCBasic
+import Basics
+import struct TSCBasic.ByteString
 import XCBuildSupport
 import SPMBuildCore
 
@@ -30,12 +31,12 @@ struct BuildParametersGenerator {
     private let buildOptions: BuildOptions
     private let fileSystem: any FileSystem
 
-    init(buildOptions: BuildOptions, fileSystem: any FileSystem = TSCBasic.localFileSystem) {
+    init(buildOptions: BuildOptions, fileSystem: any FileSystem = localFileSystem) {
         self.buildOptions = buildOptions
         self.fileSystem = fileSystem
     }
 
-    func generate(for sdk: SDK, buildParameters: BuildParameters, destinationDir: AbsolutePath) throws -> AbsolutePath {
+    func generate(for sdk: SDK, buildParameters: BuildParameters, destinationDir: TSCAbsolutePath) throws -> TSCAbsolutePath {
         let targetArchitecture = buildParameters.triple.arch?.rawValue ?? "arm64"
 
         // Generate the run destination parameters.

--- a/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
@@ -1,22 +1,22 @@
 import Foundation
-import TSCBasic
+import Basics
 
 /// A assembler to generate framework bundle
 /// This assembler just relocates framework components into the framework structure
 struct FrameworkBundleAssembler {
     private let frameworkComponents: FrameworkComponents
     private let keepPublicHeadersStructure: Bool
-    private let outputDirectory: AbsolutePath
+    private let outputDirectory: TSCAbsolutePath
     private let fileSystem: any FileSystem
 
-    private var frameworkBundlePath: AbsolutePath {
+    private var frameworkBundlePath: TSCAbsolutePath {
         outputDirectory.appending(component: "\(frameworkComponents.frameworkName).framework")
     }
 
     init(
         frameworkComponents: FrameworkComponents,
         keepPublicHeadersStructure: Bool,
-        outputDirectory: AbsolutePath,
+        outputDirectory: TSCAbsolutePath,
         fileSystem: some FileSystem
     ) {
         self.frameworkComponents = frameworkComponents
@@ -26,7 +26,7 @@ struct FrameworkBundleAssembler {
     }
 
     @discardableResult
-    func assemble() throws -> AbsolutePath {
+    func assemble() throws -> TSCAbsolutePath {
         try fileSystem.createDirectory(frameworkBundlePath, recursive: true)
 
         try copyInfoPlist()
@@ -96,9 +96,9 @@ struct FrameworkBundleAssembler {
     }
 
     private func copyHeaderKeepingStructure(
-        header: AbsolutePath,
-        includeDir: AbsolutePath,
-        into headerDir: AbsolutePath
+        header: TSCAbsolutePath,
+        includeDir: TSCAbsolutePath,
+        into headerDir: TSCAbsolutePath
     ) throws {
         let subdirectoryComponents: [String] = if header.dirname.hasPrefix(includeDir.pathString) {
             header.dirname.dropFirst(includeDir.pathString.count)

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -1,5 +1,5 @@
 import Foundation
-import TSCBasic
+import Basics
 import PackageGraph
 import PackageModel
 
@@ -15,7 +15,7 @@ struct FrameworkModuleMapGenerator {
     private var fileSystem: any FileSystem
 
     enum Error: LocalizedError {
-        case unableToLoadCustomModuleMap(AbsolutePath)
+        case unableToLoadCustomModuleMap(TSCAbsolutePath)
 
         var errorDescription: String? {
             switch self {
@@ -34,7 +34,7 @@ struct FrameworkModuleMapGenerator {
         resolvedTarget: ScipioResolvedModule,
         sdk: SDK,
         keepPublicHeadersStructure: Bool
-    ) throws -> AbsolutePath? {
+    ) throws -> TSCAbsolutePath? {
         let context = Context(
             resolvedTarget: resolvedTarget,
             sdk: sdk,
@@ -106,7 +106,7 @@ struct FrameworkModuleMapGenerator {
         }
     }
 
-    private func walkDirectoryContents(of directoryPath: AbsolutePath) throws -> Set<AbsolutePath> {
+    private func walkDirectoryContents(of directoryPath: TSCAbsolutePath) throws -> Set<TSCAbsolutePath> {
         try fileSystem.getDirectoryContents(directoryPath).reduce(into: Set()) { headers, file in
             let path = directoryPath.appending(component: file)
             if fileSystem.isDirectory(path) {
@@ -118,8 +118,8 @@ struct FrameworkModuleMapGenerator {
     }
 
     private func generateHeaderEntry(
-        for header: AbsolutePath,
-        of directoryPath: AbsolutePath,
+        for header: TSCAbsolutePath,
+        of directoryPath: TSCAbsolutePath,
         keepPublicHeadersStructure: Bool
     ) -> String {
         if keepPublicHeadersStructure {
@@ -144,7 +144,7 @@ struct FrameworkModuleMapGenerator {
             .map { "    link framework \"\($0)\"" }
     }
 
-    private func generateModuleMapFile(context: Context, outputPath: AbsolutePath) throws {
+    private func generateModuleMapFile(context: Context, outputPath: TSCAbsolutePath) throws {
         let dirPath = outputPath.parentDirectory
         try fileSystem.createDirectory(dirPath, recursive: true)
 
@@ -152,12 +152,12 @@ struct FrameworkModuleMapGenerator {
         try fileSystem.writeFileContents(outputPath.spmAbsolutePath, string: contents)
     }
 
-    private func constructGeneratedModuleMapPath(context: Context) throws -> AbsolutePath {
+    private func constructGeneratedModuleMapPath(context: Context) throws -> TSCAbsolutePath {
         let generatedModuleMapPath = try packageLocator.generatedModuleMapPath(of: context.resolvedTarget, sdk: context.sdk)
         return generatedModuleMapPath
     }
 
-    private func convertCustomModuleMapForFramework(_ customModuleMap: AbsolutePath) throws -> String {
+    private func convertCustomModuleMapForFramework(_ customModuleMap: TSCAbsolutePath) throws -> String {
         // Sometimes, targets have their custom modulemaps.
         // However, these are not for frameworks
         // This process converts them to modulemaps for frameworks

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -3,7 +3,6 @@ import PackageModel
 import SPMBuildCore
 import PackageGraph
 import Basics
-import var TSCBasic.localFileSystem
 
 struct PIFCompiler: Compiler {
     let descriptionPackage: DescriptionPackage
@@ -20,7 +19,7 @@ struct PIFCompiler: Compiler {
         buildOptions: BuildOptions,
         buildOptionsMatrix: [String: BuildOptions],
         toolchainEnvironment: ToolchainEnvironment? = nil,
-        fileSystem: any FileSystem = TSCBasic.localFileSystem,
+        fileSystem: any FileSystem = localFileSystem,
         executor: any Executor = ProcessExecutor()
     ) {
         self.descriptionPackage = descriptionPackage

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -1,5 +1,5 @@
 import Foundation
-import TSCBasic
+import Basics
 import SPMBuildCore
 import PackageModel
 import PackageGraph
@@ -35,7 +35,7 @@ struct PIFGenerator {
         buildParameters: BuildParameters,
         buildOptions: BuildOptions,
         buildOptionsMatrix: [String: BuildOptions],
-        fileSystem: any FileSystem = TSCBasic.localFileSystem
+        fileSystem: any FileSystem = localFileSystem
     ) throws {
         self.descriptionPackage = package
         self.buildParameters = buildParameters
@@ -58,7 +58,7 @@ struct PIFGenerator {
         return try jsonDecoder.decode(PIF.TopLevelObject.self, from: data)
     }
 
-    func generateJSON(for sdk: SDK) throws -> AbsolutePath {
+    func generateJSON(for sdk: SDK) throws -> TSCAbsolutePath {
         let topLevelObject = modify(try generatePIF(), for: sdk)
 
         try PIF.sign(topLevelObject.workspace)

--- a/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
@@ -2,16 +2,15 @@ import Foundation
 import TSCUtility
 @_spi(SwiftPMInternal) import PackageModel
 @_spi(SwiftPMInternal) import struct Basics.Environment
-import TSCBasic
-import struct Basics.Triple
+import Basics
 
 struct ToolchainGenerator {
-    private let toolchainDirPath: AbsolutePath
+    private let toolchainDirPath: TSCAbsolutePath
     private let environment: [String: String]?
     private let executor: any Executor
 
     init(
-        toolchainDirPath: AbsolutePath,
+        toolchainDirPath: TSCAbsolutePath,
         environment: [String: String]? = nil,
         executor: any Executor = ProcessExecutor()
     ) {
@@ -39,7 +38,7 @@ struct ToolchainGenerator {
         )
             .unwrapOutput()
             .spm_chomp()
-        let sdkPath = try AbsolutePath(validating: sdkPathString)
+        let sdkPath = try TSCAbsolutePath(validating: sdkPathString)
 
         // Compute common arguments for clang and swift.
         var extraCCFlags: [String] = []

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Basics
-import var TSCBasic.localFileSystem
 import PackageGraph
 import PackageModel
 
@@ -17,7 +16,7 @@ struct XCBuildClient {
         buildOptions: BuildOptions,
         configuration: BuildConfiguration,
         packageLocator: some PackageLocator,
-        fileSystem: any FileSystem = TSCBasic.localFileSystem,
+        fileSystem: any FileSystem = localFileSystem,
         executor: some Executor = ProcessExecutor(decoder: StandardOutputDecoder())
     ) {
         self.buildProduct = buildProduct

--- a/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
@@ -1,18 +1,18 @@
 import Logging
-import TSCBasic
+import Basics
 import PackageGraph
 import XCBuildSupport
 import Algorithms
 
 struct XCBuildExecutor {
 
-    var xcbuildPath: AbsolutePath
+    var xcbuildPath: TSCAbsolutePath
 
     func build(
-        pifPath: AbsolutePath,
+        pifPath: TSCAbsolutePath,
         configuration: BuildConfiguration,
-        derivedDataPath: AbsolutePath,
-        buildParametersPath: AbsolutePath,
+        derivedDataPath: TSCAbsolutePath,
+        buildParametersPath: TSCAbsolutePath,
         target: ScipioResolvedModule
     ) async throws {
         let executor = _Executor(args: [

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -2,7 +2,6 @@ import Foundation
 import ScipioStorage
 import Basics
 import protocol TSCBasic.FileSystem
-import var TSCBasic.localFileSystem
 
 public typealias PlatformMatrix = [String: Set<SDK>]
 
@@ -71,7 +70,7 @@ public struct Runner {
 
         logger.info("🔁 Resolving Dependencies...")
         do {
-            descriptionPackage = try DescriptionPackage(
+            descriptionPackage = try await DescriptionPackage(
                 packageDirectory: packagePath,
                 mode: mode,
                 onlyUseVersionsFromResolvedFile: false,

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -1,9 +1,9 @@
 import Foundation
-import TSCBasic
+import Basics
 
 extension URL {
-    var absolutePath: AbsolutePath {
+    var absolutePath: TSCAbsolutePath {
         precondition(absoluteURL.isFileURL)
-        return try! AbsolutePath(validating: path)
+        return try! TSCAbsolutePath(validating: path)
     }
 }

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -110,7 +110,7 @@ final class CacheSystemTests: XCTestCase {
         ])
 
         func scipioTestingCacheKey(fixture: String) async throws -> SwiftPMCacheKey {
-            let descriptionPackage = try DescriptionPackage(
+            let descriptionPackage = try await DescriptionPackage(
                 packageDirectory: tempCacheKeyTestsDir.appending(component: fixture),
                 mode: .createPackage,
                 onlyUseVersionsFromResolvedFile: false
@@ -167,7 +167,7 @@ final class CacheSystemTests: XCTestCase {
 
         defer { try? fileSystem.removeFileTree(tempTestingPackagePath) }
 
-        let descriptionPackage = try DescriptionPackage(
+        let descriptionPackage = try await DescriptionPackage(
             packageDirectory: tempTestingPackagePath,
             mode: .createPackage,
             onlyUseVersionsFromResolvedFile: false

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -8,13 +8,13 @@ private let fixturePath = URL(fileURLWithPath: #filePath)
     .appendingPathComponent("Fixtures")
 
 final class DescriptionPackageTests: XCTestCase {
-    func testDescriptionPackage() throws {
+    func testDescriptionPackage() async throws {
         let rootPath = fixturePath.appendingPathComponent("TestingPackage")
-        let package = try XCTUnwrap(try DescriptionPackage(
+        let package = try await DescriptionPackage(
             packageDirectory: rootPath.absolutePath,
             mode: .prepareDependencies,
             onlyUseVersionsFromResolvedFile: false
-        ))
+        )
         XCTAssertEqual(package.name, "TestingPackage")
 
         let packageNames = package.graph.packages.map(\.manifest.displayName)
@@ -31,13 +31,13 @@ final class DescriptionPackageTests: XCTestCase {
         )
     }
 
-    func testBuildProductsInPrepareMode() throws {
+    func testBuildProductsInPrepareMode() async throws {
         let rootPath = fixturePath.appendingPathComponent("IntegrationTestPackage")
-        let package = try XCTUnwrap(try DescriptionPackage(
+        let package = try await DescriptionPackage(
             packageDirectory: rootPath.absolutePath,
             mode: .prepareDependencies,
             onlyUseVersionsFromResolvedFile: false
-        ))
+        )
         XCTAssertEqual(package.name, "IntegrationTestPackage")
 
         XCTAssertEqual(
@@ -64,13 +64,13 @@ final class DescriptionPackageTests: XCTestCase {
         )
     }
 
-    func testBuildProductsInCreateMode() throws {
+    func testBuildProductsInCreateMode() async throws {
         let rootPath = fixturePath.appendingPathComponent("TestingPackage")
-        let package = try XCTUnwrap(try DescriptionPackage(
+        let package = try await DescriptionPackage(
             packageDirectory: rootPath.absolutePath,
             mode: .createPackage,
             onlyUseVersionsFromResolvedFile: false
-        ))
+        )
         XCTAssertEqual(package.name, "TestingPackage")
 
         XCTAssertEqual(
@@ -85,13 +85,13 @@ final class DescriptionPackageTests: XCTestCase {
         )
     }
 
-    func testBinaryBuildProductsInCreateMode() throws {
+    func testBinaryBuildProductsInCreateMode() async throws {
         let rootPath = fixturePath.appendingPathComponent("BinaryPackage")
-        let package = try XCTUnwrap(try DescriptionPackage(
+        let package = try await DescriptionPackage(
             packageDirectory: rootPath.absolutePath,
             mode: .createPackage,
             onlyUseVersionsFromResolvedFile: false
-        ))
+        )
         XCTAssertEqual(package.name, "BinaryPackage")
         XCTAssertEqual(
             Set(try package.resolveBuildProducts().map(\.target.name)),

--- a/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import ScipioKit
 import Testing
-import TSCBasic
+import Basics
 
 private let fixturesPath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
@@ -10,7 +10,7 @@ private let fixturesPath = URL(fileURLWithPath: #filePath)
 
 struct FrameworkBundleAssemblerTests {
     let fileSystem = localFileSystem
-    let temporaryDirectory: AbsolutePath
+    let temporaryDirectory: TSCAbsolutePath
 
     init() throws {
         self.temporaryDirectory = try fileSystem
@@ -42,7 +42,7 @@ struct FrameworkBundleAssemblerTests {
         #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath.appending(component: "bar"))) == ["bar.h"])
     }
 
-    private func assembleFramework(keepPublicHeadersStructure: Bool, outputDirectory: AbsolutePath) throws {
+    private func assembleFramework(keepPublicHeadersStructure: Bool, outputDirectory: TSCAbsolutePath) throws {
         let fixture = fixturesPath.appendingPathComponent("FrameworkBundleAssemblerTests").absolutePath
         let frameworkComponents = FrameworkComponents(
             frameworkName: "Foo",

--- a/Tests/ScipioKitTests/InfoPlistGeneratorTests.swift
+++ b/Tests/ScipioKitTests/InfoPlistGeneratorTests.swift
@@ -1,12 +1,12 @@
 import Foundation
 import XCTest
 @testable import ScipioKit
-import TSCBasic
+import Basics
 
 final class InfoPlistGeneratorTests: XCTestCase {
     let fileSystem = localFileSystem
     lazy var generator = InfoPlistGenerator(fileSystem: fileSystem)
-    var temporaryPath: AbsolutePath!
+    var temporaryPath: TSCAbsolutePath!
 
     override func setUp() async throws {
         try await super.setUp()

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -269,7 +269,7 @@ final class RunnerTests: XCTestCase {
     }
 
     func testCacheIsValid() async throws {
-        let descriptionPackage = try DescriptionPackage(
+        let descriptionPackage = try await DescriptionPackage(
             packageDirectory: testPackagePath.absolutePath,
             mode: .prepareDependencies,
             onlyUseVersionsFromResolvedFile: false
@@ -491,7 +491,7 @@ final class RunnerTests: XCTestCase {
 
     func testBinaryHasValidCache() async throws {
         // Generate VersionFile
-        let descriptionPackage = try DescriptionPackage(
+        let descriptionPackage = try await DescriptionPackage(
             packageDirectory: usingBinaryPackagePath.absolutePath,
             mode: .prepareDependencies,
             onlyUseVersionsFromResolvedFile: false


### PR DESCRIPTION
- Use `TSCAbsolutePath` typealias
- Use `Basics.localFileSystem` which is an alias to `TSCBasic.localFileSystem`
- Make `DescriptionPackage.init` async and remove `tsc_await` usage

refs:
- #166
- #167