### PR TITLE
[Refactor] Move dwarfPath construction to DwarfExtractor and remove DebugSymbol type

### DIFF
--- a/Sources/ScipioKit/Producer/Compiler.swift
+++ b/Sources/ScipioKit/Producer/Compiler.swift
@@ -22,32 +22,36 @@ extension Compiler {
         var result = [SDK: [TSCAbsolutePath]]()
 
         for sdk in sdks {
-            let dsymPath = descriptionPackage.buildDebugSymbolPath(buildConfiguration: buildConfiguration, sdk: sdk, target: target)
-            guard fileSystem.exists(dsymPath) else { continue }
-            let debugSymbol = DebugSymbol(
-                dSYMPath: dsymPath,
-                target: target,
+            let dsymPath = descriptionPackage.buildDebugSymbolPath(
+                buildConfiguration: buildConfiguration,
                 sdk: sdk,
-                buildConfiguration: buildConfiguration
+                target: target
             )
-            let dumpedDSYMsMaps = try await extractor.dump(dwarfPath: debugSymbol.dwarfPath)
+            guard fileSystem.exists(dsymPath) else { continue }
+
+            let dwarfPath = extractor.dwarfPath(for: target, dSYMPath: dsymPath)
+            let dumpedDSYMsMaps = try await extractor.dump(dwarfPath: dwarfPath)
             let bcSymbolMapPaths: [TSCAbsolutePath] = dumpedDSYMsMaps.values.compactMap { uuid in
                 let path = descriptionPackage.productsDirectory(
-                    buildConfiguration: debugSymbol.buildConfiguration,
-                    sdk: debugSymbol.sdk
+                    buildConfiguration: buildConfiguration,
+                    sdk: sdk
                 )
                     .appending(component: "\(uuid.uuidString).bcsymbolmap")
                 guard fileSystem.exists(path) else { return nil }
                 return path
             }
-            result[sdk] = [debugSymbol.dSYMPath] + bcSymbolMapPaths
+            result[sdk] = [dsymPath] + bcSymbolMapPaths
         }
         return result
     }
 }
 
 extension DescriptionPackage {
-    fileprivate func buildDebugSymbolPath(buildConfiguration: BuildConfiguration, sdk: SDK, target: ScipioResolvedModule) -> TSCAbsolutePath {
+    fileprivate func buildDebugSymbolPath(
+        buildConfiguration: BuildConfiguration,
+        sdk: SDK,
+        target: ScipioResolvedModule
+    ) -> TSCAbsolutePath {
         productsDirectory(buildConfiguration: buildConfiguration, sdk: sdk)
             .appending(component: "\(target.name).framework.dSYM")
     }

--- a/Sources/ScipioKit/Producer/DwarfExtractor.swift
+++ b/Sources/ScipioKit/Producer/DwarfExtractor.swift
@@ -2,17 +2,6 @@ import Foundation
 import PackageGraph
 import Basics
 
-struct DebugSymbol {
-    var dSYMPath: TSCAbsolutePath
-    var target: ScipioResolvedModule
-    var sdk: SDK
-    var buildConfiguration: BuildConfiguration
-
-    var dwarfPath: TSCAbsolutePath {
-        dSYMPath.appending(components: "Contents", "Resources", "DWARF", target.name)
-    }
-}
-
 struct DwarfExtractor<E: Executor> {
     private let executor: E
 
@@ -21,6 +10,10 @@ struct DwarfExtractor<E: Executor> {
     }
 
     typealias Arch = String
+
+    func dwarfPath(for target: ScipioResolvedModule, dSYMPath: TSCAbsolutePath) -> TSCAbsolutePath {
+        dSYMPath.appending(components: "Contents", "Resources", "DWARF", target.name)
+    }
 
     func dump(dwarfPath: TSCAbsolutePath) async throws -> [Arch: UUID] {
         let result = try await executor.execute("/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.pathString)


### PR DESCRIPTION
This simplifies `Compiler.extractDebugSymbolPaths` implementation (by removing an unnecessary type).