### PR TITLE
Make release workflow enable to trigger manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 on: 
   release:
     types: [published]
+  # Use with only Tags
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to build and upload artifact bundle for'
-        required: true
-        default: ${{ github.ref_name }}
 
 name: Upload Artifact Bundle to Release
 env: 
@@ -27,7 +23,7 @@ jobs:
           swift build --disable-sandbox -c release --arch arm64
           swift build --disable-sandbox -c release --arch x86_64
       - name: Get Current Tag
-        run: echo "TAG_NAME=${{ inputs.tag || github.ref_name }}" >> $GITHUB_ENV
+        run: echo "TAG_NAME=${{ github.event.release.tag_name || github.ref_name }}" >> $GITHUB_ENV
       - name: Make Artifact Bundle
         run: |
           swift package --allow-writing-to-package-directory generate-artifact-bundle \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on: 
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 on: 
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build and upload artifact bundle for'
+        required: true
+        default: ${{ github.ref_name }}
 
 name: Upload Artifact Bundle to Release
 env: 
@@ -21,7 +27,7 @@ jobs:
           swift build --disable-sandbox -c release --arch arm64
           swift build --disable-sandbox -c release --arch x86_64
       - name: Get Current Tag
-        run: echo "TAG_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: echo "TAG_NAME=${{ inputs.tag || github.ref_name }}" >> $GITHUB_ENV
       - name: Make Artifact Bundle
         run: |
           swift package --allow-writing-to-package-directory generate-artifact-bundle \


### PR DESCRIPTION
I'm not sure why but the release workflow for [0.27.0](https://github.com/giginet/Scipio/releases/tag/0.27.0) didn't ran. I added workflow_dispatch trigger for the workflow and would like to trigger that manually.