### PR TITLE
Pass flags shouldOnlyUseVersionsFromResolvedFile

### DIFF
--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -73,7 +73,7 @@ public struct Runner {
             descriptionPackage = try await DescriptionPackage(
                 packageDirectory: packagePath,
                 mode: mode,
-                onlyUseVersionsFromResolvedFile: false,
+                onlyUseVersionsFromResolvedFile: options.shouldOnlyUseVersionsFromResolvedFile,
                 toolchainEnvironment: options.toolchainEnvironment
             )
         } catch {


### PR DESCRIPTION
🙈 

This pull request includes an update to the `Runner` struct in the `Sources/ScipioKit/Runner.swift` file to enhance configurability by using options from the `options` object.

* [`Sources/ScipioKit/Runner.swift`](diffhunk://#diff-ef410ed219f018d3487b31ad581e0a4ef813141371e708ca3c5c95c5a97f2657L76-R76): Modified the `onlyUseVersionsFromResolvedFile` parameter to use `options.shouldOnlyUseVersionsFromResolvedFile` for better configurability.