### PR TITLE
Use Swift.Regex to parse

### DIFF
--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -33,11 +33,11 @@ struct ClangChecker<E: Executor> {
     }
 
     private func parseClangVersion(from outputString: String) -> String? {
-        let regex = /Apple clang version .+ \((.+)\)/
+        let regex = /Apple clang version .+ \((?<version>.+)\)/
         guard let result = try? regex.firstMatch(in: outputString) else {
             return nil
         }
-        return String(result.output.1)
+        return String(result.output.version)
     }
 }
 

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -33,12 +33,11 @@ struct ClangChecker<E: Executor> {
     }
 
     private func parseClangVersion(from outputString: String) -> String? {
-        // TODO Use modern regex
-        let regex = try! NSRegularExpression(pattern: "Apple\\sclang\\sversion\\s.+\\s\\((?<version>.+)\\)")
-        return regex.matches(in: outputString, range: NSRange(location: 0, length: outputString.utf16.count)).compactMap { match -> String? in
-            guard let version = match.captured(by: "version", in: outputString) else { return nil }
-            return version
-        }.first
+        let regex = /Apple clang version .+ \((.+)\)/
+        guard let result = try? regex.firstMatch(in: outputString) else {
+            return nil
+        }
+        return String(result.output.1)
     }
 }
 

--- a/Sources/ScipioKit/Producer/DwarfExtractor.swift
+++ b/Sources/ScipioKit/Producer/DwarfExtractor.swift
@@ -36,13 +36,3 @@ struct DwarfExtractor<E: Executor> {
         }
     }
 }
-
-extension NSTextCheckingResult {
-    func captured(by name: String, in originalText: String) -> String? {
-        let range = range(withName: name)
-        guard let swiftyRange = Range(range, in: originalText) else {
-            return nil
-        }
-        return String(originalText[swiftyRange])
-    }
-}

--- a/Sources/ScipioKit/Producer/DwarfExtractor.swift
+++ b/Sources/ScipioKit/Producer/DwarfExtractor.swift
@@ -24,15 +24,15 @@ struct DwarfExtractor<E: Executor> {
     }
 
     private func parseUUIDs(from outputString: String) -> [Arch: UUID] {
-        let regex = /([0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}) \((.+)\)/
+        let regex = /(?<uuid>[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}) \((?<arch>.+)\)/
         let results = outputString.matches(of: regex)
 
-        return results.compactMap { result -> (String, UUID)? in
-            guard let uuid = UUID(uuidString: String(result.output.1)) else { return nil }
-            return (String(result.output.2), uuid)
+        return results.compactMap { result -> (arch: String, uuid: UUID)? in
+            guard let uuid = UUID(uuidString: String(result.output.uuid)) else { return nil }
+            return (String(result.output.arch), uuid)
         }
         .reduce(into: [:]) { dictionary, element in
-            dictionary[element.0] = element.1
+            dictionary[element.arch] = element.uuid
         }
     }
 }

--- a/Sources/ScipioKit/Producer/DwarfExtractor.swift
+++ b/Sources/ScipioKit/Producer/DwarfExtractor.swift
@@ -24,16 +24,16 @@ struct DwarfExtractor<E: Executor> {
     }
 
     private func parseUUIDs(from outputString: String) -> [Arch: UUID] {
-        // TODO Use modern Regex
-        let regex = try! NSRegularExpression(
-            pattern: "(?<uuid>[0-9A-F]{8}\\-[0-9A-F]{4}\\-[0-9A-F]{4}\\-[0-9A-F]{4}\\-[0-9A-F]{12})\\s\\((?<arch>.+)\\)"
-        )
-        return regex.matches(in: outputString, range: NSRange(location: 0, length: outputString.utf16.count)).compactMap { match -> (String, UUID)? in
-            guard let uuidString = match.captured(by: "uuid", in: outputString), let uuid = UUID(uuidString: uuidString) else { return nil }
-            guard let arch = match.captured(by: "arch", in: outputString) else { return nil }
-            return (arch, uuid)
+        let regex = /([0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}) \((.+)\)/
+        let results = outputString.matches(of: regex)
+
+        return results.compactMap { result -> (String, UUID)? in
+            guard let uuid = UUID(uuidString: String(result.output.1)) else { return nil }
+            return (String(result.output.2), uuid)
         }
-        .reduce(into: [:]) { (dict, element: (String, UUID)) in dict[element.0] = element.1 }
+        .reduce(into: [:]) { dictionary, element in
+            dictionary[element.0] = element.1
+        }
     }
 }
 

--- a/Tests/ScipioKitTests/DebugSymbolTests.swift
+++ b/Tests/ScipioKitTests/DebugSymbolTests.swift
@@ -19,7 +19,7 @@ struct DwarfExtractorTests {
                 "armv7": "AD019F0E-1318-3F9F-92B6-9F95FBEBBE6F",
                 "arm64": "BB59C973-06AC-388F-8EC1-FA3701C9E264",
             ]
-        )
+        ),
     ])
     func extractDwarfDump(argument: (fixture: String, expectedUUIDs: [String: String])) async throws {
         let executor = StubbableExecutor { arguments in

--- a/Tests/ScipioKitTests/DebugSymbolTests.swift
+++ b/Tests/ScipioKitTests/DebugSymbolTests.swift
@@ -1,22 +1,40 @@
 import Foundation
 @testable import ScipioKit
-import XCTest
+import Testing
 
-final class DwarfExtractorTests: XCTestCase {
-    let fixture = "UUID: 1B6B77A9-436C-3A55-884D-4E78EFCAC3ED (arm64) Delegate.framework.dSYM/Contents/Resources/DWARF/Delegate"
-
-    func testExtractDwarfDump() async throws {
+struct DwarfExtractorTests {
+    @Test(arguments: [
+        (
+            "UUID: 1B6B77A9-436C-3A55-884D-4E78EFCAC3ED (arm64) Delegate.framework.dSYM/Contents/Resources/DWARF/Delegate",
+            [
+                "arm64": "1B6B77A9-436C-3A55-884D-4E78EFCAC3ED"
+            ]
+        ),
+        (
+            """
+            UUID: AD019F0E-1318-3F9F-92B6-9F95FBEBBE6F (armv7) MySample.app/MySample
+            UUID: BB59C973-06AC-388F-8EC1-FA3701C9E264 (arm64) MySample.app/MySample
+            """,
+            [
+                "armv7": "AD019F0E-1318-3F9F-92B6-9F95FBEBBE6F",
+                "arm64": "BB59C973-06AC-388F-8EC1-FA3701C9E264",
+            ]
+        )
+    ])
+    func extractDwarfDump(argument: (fixture: String, expectedUUIDs: [String: String])) async throws {
         let executor = StubbableExecutor { arguments in
-            return StubbableExecutorResult(arguments: arguments, success: self.fixture)
+            return StubbableExecutorResult(arguments: arguments, success: argument.fixture)
         }
         let extractor = DwarfExtractor(executor: executor)
         let dwarfPath = URL(fileURLWithPath: "/dev/null")
         let uuids = try await extractor.dump(dwarfPath: dwarfPath.absolutePath)
 
-        let firstArguments = try XCTUnwrap(executor.calledArguments.first)
-        XCTAssertEqual(firstArguments, ["/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.path])
+        let firstArguments = try #require(executor.calledArguments.first)
+        #expect(firstArguments == ["/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.path])
 
-        XCTAssertEqual(uuids.count, 1)
-        XCTAssertEqual(uuids["arm64"], UUID(uuidString: "1B6B77A9-436C-3A55-884D-4E78EFCAC3ED"))
+        let expectedUUIDs = try argument.expectedUUIDs.mapValues {
+            try #require(UUID(uuidString: $0))
+        }
+        #expect(uuids == expectedUUIDs)
     }
 }


### PR DESCRIPTION
Hello, giginet san and collaborators.

# Overview

This PR will replace `NSRegularExpression` with modern regex, `Swift.Regex`.

# Changes

## Use `Swift.Regex`

I found two `TODO` comments, so I updated these methods:

- `parseClangVersion(from:)`: `xcrun clang --version` parser
- `parseUUIDs(from:)`: `xcrun dwarfdump --uuid <app>` parser

## Update `DwarfExtractorTests` 

This PR will

- apply swift-testing to `DwarfExtractorTests` 
- add a test case to `.testExtractDwarfDump()`

Background:

`parseUUIDs(from:)` seems to be able to parse output containing more than one UUID.

I found such an output in https://developer.apple.com/library/archive/technotes/tn2339/_index.html.

```sh
$ xcrun dwarfdump --uuid  MySample.app/MySample
--
UUID: AD019F0E-1318-3F9F-92B6-9F95FBEBBE6F (armv7) MySample.app/MySample
UUID: BB59C973-06AC-388F-8EC1-FA3701C9E264 (arm64) MySample.app/MySample
```