### PR TITLE
Leave cache of frameworks that are successfully built

### DIFF
--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -141,7 +141,7 @@ struct FrameworkProducer {
             }
         }
 
-        if case .interrupted(_, error) = targetBuildResult {
+        if case .interrupted(_, let error) = targetBuildResult {
             throw error
         }
     }

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -127,8 +127,8 @@ struct FrameworkProducer {
         let targetBuildResult = await buildTargets(targetsToBuild)
 
         let builtTargets: OrderedSet<CacheSystem.CacheTarget> = switch targetBuildResult {
-            case .completed(builtTargets: let builtTargets),
-                 .interrupted(builtTargets: let builtTargets, error: _):
+            case .completed(let builtTargets),
+                 .interrupted(let builtTargets, _):
                 builtTargets
             }
 
@@ -141,7 +141,7 @@ struct FrameworkProducer {
             }
         }
 
-        if case .interrupted(builtTargets: _, error: let error) = targetBuildResult {
+        if case .interrupted(_, error) = targetBuildResult {
             throw error
         }
     }

--- a/Tests/ScipioKitTests/DebugSymbolTests.swift
+++ b/Tests/ScipioKitTests/DebugSymbolTests.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import ScipioKit
 import Testing
 
+@Suite(.serialized)
 struct DwarfExtractorTests {
     @Test(arguments: [
         (

--- a/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
@@ -8,6 +8,7 @@ private let fixturesPath = URL(fileURLWithPath: #filePath)
     .appendingPathComponent("Resources")
     .appendingPathComponent("Fixtures")
 
+@Suite(.serialized)
 struct FrameworkBundleAssemblerTests {
     let fileSystem = localFileSystem
     let temporaryDirectory: TSCAbsolutePath

--- a/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
+++ b/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
@@ -13,6 +13,7 @@ private struct PackageLocatorMock: PackageLocator {
     let packageDirectory: TSCAbsolutePath
 }
 
+@Suite(.serialized)
 struct FrameworkModuleMapGeneratorTests {
     let fileSystem = localFileSystem
     let temporaryDirectory: TSCAbsolutePath

--- a/Tests/ScipioKitTests/PartialCacheTests.swift
+++ b/Tests/ScipioKitTests/PartialCacheTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Testing
 @testable import ScipioKit
-import Logging
 
 private let fixturePath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
@@ -14,8 +13,6 @@ struct PartialCacheTests {
     private let frameworkOutputDir: URL
 
     init() throws {
-        LoggingSystem.bootstrap { _ in SwiftLogNoOpLogHandler() }
-
         tempDir = fileManager.temporaryDirectory
         frameworkOutputDir = tempDir.appendingPathComponent("XCFrameworks")
         try fileManager.createDirectory(at: frameworkOutputDir, withIntermediateDirectories: true)

--- a/Tests/ScipioKitTests/PartialCacheTests.swift
+++ b/Tests/ScipioKitTests/PartialCacheTests.swift
@@ -7,6 +7,7 @@ private let fixturePath = URL(fileURLWithPath: #filePath)
     .appendingPathComponent("Resources")
     .appendingPathComponent("Fixtures")
 
+@Suite(.serialized)
 struct PartialCacheTests {
     private let fileManager: FileManager = .default
     private let tempDir: URL

--- a/Tests/ScipioKitTests/PartialCacheTests.swift
+++ b/Tests/ScipioKitTests/PartialCacheTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import ScipioKit
+import Logging
+
+private let fixturePath = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .appendingPathComponent("Resources")
+    .appendingPathComponent("Fixtures")
+
+struct PartialCacheTests {
+    private let fileManager: FileManager = .default
+    private let tempDir: URL
+    private let frameworkOutputDir: URL
+
+    init() throws {
+        LoggingSystem.bootstrap { _ in SwiftLogNoOpLogHandler() }
+
+        tempDir = fileManager.temporaryDirectory
+        frameworkOutputDir = tempDir.appendingPathComponent("XCFrameworks")
+        try fileManager.createDirectory(at: frameworkOutputDir, withIntermediateDirectories: true)
+    }
+
+    @Test
+    func dependencyRelationship() async throws {
+        let testingPackagePath = fixturePath.appendingPathComponent("PartialCacheTestPackage")
+
+        let runner = Runner(
+            mode: .createPackage,
+            options: .init(
+                baseBuildOptions: .init(isSimulatorSupported: false),
+                shouldOnlyUseVersionsFromResolvedFile: true
+            )
+        )
+        do {
+            try await runner.run(
+                packageDirectory: testingPackagePath,
+                frameworkOutputDir: .custom(frameworkOutputDir)
+            )
+            Issue.record("The runner must raise an error.")
+        } catch {
+            guard case let .compilerError(details) = error as? Runner.Error,
+                  case .terminated = details as? ProcessExecutorError else {
+                Issue.record("Unexpected error occurred.")
+                return
+            }
+
+            let baseLibraryPath = frameworkOutputDir.appendingPathComponent("Base.xcframework")
+            #expect(fileManager.fileExists(atPath: baseLibraryPath.path))
+
+            let badLibraryPath = frameworkOutputDir.appendingPathComponent("Bad.xcframework")
+            #expect(!fileManager.fileExists(atPath: badLibraryPath.path))
+
+            try fileManager.removeItem(atPath: baseLibraryPath.path)
+        }
+    }
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/PartialCacheTestPackage/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PartialCacheTestPackage/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/ScipioKitTests/Resources/Fixtures/PartialCacheTestPackage/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PartialCacheTestPackage/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "PartialCacheTestPackage",
+    platforms: [.iOS(.v18)],
+    products: [
+        .library(name: "Base", targets: ["Base"]),
+        .library(name: "Bad", targets: ["Bad"]),
+    ],
+    targets: [
+        .target(name: "Base"),
+        .target(name: "Bad", dependencies: ["Base"]),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/PartialCacheTestPackage/Sources/Bad/Bad.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PartialCacheTestPackage/Sources/Bad/Bad.swift
@@ -1,0 +1,4 @@
+import Base
+
+// Expressions are not allowed at the top level
+sample()

--- a/Tests/ScipioKitTests/Resources/Fixtures/PartialCacheTestPackage/Sources/Base/Base.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PartialCacheTestPackage/Sources/Base/Base.swift
@@ -1,0 +1,1 @@
+public func sample() {}


### PR DESCRIPTION
Closes #153 

This PR will fix the issue reported by #153.

# Changes

## FrameworkProducer

`processAllTargets(buildProducts:)` will cache XCFrameworks that are successfully built.
Scipio users won't have to rebuild all frameworks even if Scipio fails to build some frameworks.

## PartialCacheTests

`PartialCacheTests` checks that `processAllTargets(buildProducts:)` works well.

Tests/ScipioKitTests/Resources/Fixtures/PartialCacheTestPackage provides two libraries, `Base` and `Bad.`
`Bad` depends on `Base` and cannot be compiled.