### PR TITLE
Support swift-package-manager `release/6.1` branch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-package-manager.git",
-                 branch: "release/6.0"),
+                 branch: "release/6.1"),
         .package(url: "https://github.com/apple/swift-log.git",
                  from: "1.5.2"),
         .package(url: "https://github.com/apple/swift-collections",

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -86,7 +86,7 @@ struct DescriptionPackage: PackageLocator {
 
         let workspace = try Self.makeWorkspace(toolchain: toolchain, packagePath: packageDirectory)
         let scope = makeObservabilitySystem().topScope
-        self.graph = try workspace.loadPackageGraph(
+        self.graph = try await workspace.loadPackageGraph(
             rootInput: PackageGraphRootInput(packages: [packageDirectory.spmAbsolutePath]),
             // This option is same with resolver option `--disable-automatic-resolution`
             // Never update Package.resolved of the package

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -207,9 +207,8 @@ private struct PIFLibraryTargetModifier {
 
         let toolchainLibDir = (try? buildParameters.toolchain.toolchainLibDir) ?? .root
 
-        settings[.PRODUCT_NAME] = "$(EXECUTABLE_NAME:c99extidentifier)"
-        settings[.PRODUCT_MODULE_NAME] = "$(EXECUTABLE_NAME:c99extidentifier)"
-        settings[.EXECUTABLE_NAME] = c99Name
+        settings[.PRODUCT_NAME] = c99Name
+        settings[.PRODUCT_MODULE_NAME] = c99Name
         settings[.TARGET_NAME] = name
         settings[.PRODUCT_BUNDLE_IDENTIFIER] = name.spm_mangledToBundleIdentifier()
         settings[.CLANG_ENABLE_MODULES] = "YES"


### PR DESCRIPTION
The branch can be built by Swift 6.0 compiler and works as expected (All tests are passed).