### PR TITLE
Fix issue causing valid local cache to be discarded and external cache to be fetched

### DIFF
--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -85,6 +85,8 @@ struct FrameworkProducer {
             )
         }
 
+        let allTargets = targetGraph.allNodes.map(\.value)
+
         let pinsStore = try descriptionPackage.workspace.pinsStore.load()
         let cacheSystem = CacheSystem(
             pinsStore: pinsStore,
@@ -132,7 +134,7 @@ struct FrameworkProducer {
 
         if shouldGenerateVersionFile {
             // Versionfiles should be generate for all targets
-            for target in builtTargets {
+            for target in allTargets {
                 await generateVersionFile(for: target, using: cacheSystem)
             }
         }

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -353,8 +353,7 @@ final class RunnerTests: XCTestCase {
             "The framework should be cached to the cache storage"
         )
 
-        let outputFrameworkPath = frameworkOutputDir.appendingPathComponent("ScipioTesting.xcframework")
-        try self.fileManager.removeItem(atPath: outputFrameworkPath.path)
+        try self.fileManager.removeItem(atPath: frameworkOutputDir.path)
 
         // Fetch from local storage
         do {
@@ -364,9 +363,16 @@ final class RunnerTests: XCTestCase {
             XCTFail("Build should be succeeded.")
         }
 
+        let outputFrameworkPath = frameworkOutputDir.appendingPathComponent("ScipioTesting.xcframework")
+        let outputVersionFile = frameworkOutputDir.appendingPathComponent(".ScipioTesting.version")
+
         XCTAssertTrue(
             fileManager.fileExists(atPath: outputFrameworkPath.path),
             "The framework should be restored from the cache storage"
+        )
+        XCTAssertTrue(
+            fileManager.fileExists(atPath: outputVersionFile.path),
+            "The version file should exist when restored"
         )
 
         try fileManager.removeItem(at: storageDir)


### PR DESCRIPTION
In this PR, I fixed the issue causing valid local cache to be discarded and remote cache to be fetched.

The problem was that version files were created only for built targets, not for all targets. Previously, for caches obtained from local or remote sources, we did not generate version files. As a result, Scipio mistakenly marked valid local cache as invalid and fetched the remote cache unnecessarily.