### PR TITLE
Replace package manifest parsing with PackageManifestKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,8 @@ let package = Package(
                  from: "4.0.1"),
         .package(url: "https://github.com/giginet/scipio-cache-storage.git",
                  from: "1.0.0"),
+        .package(url: "https://github.com/giginet/PackageManifestKit",
+                 branch: "main")
     ],
     targets: [
         .executableTarget(
@@ -63,6 +65,7 @@ let package = Package(
                 .product(name: "Algorithms", package: "swift-algorithms"),
                 .product(name: "Rainbow", package: "Rainbow"),
                 .product(name: "ScipioStorage", package: "scipio-cache-storage"),
+                .product(name: "PackageManifestKit", package: "PackageManifestKit")
             ],
             swiftSettings: swiftSettings,
             plugins: [

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         .package(url: "https://github.com/giginet/scipio-cache-storage.git",
                  from: "1.0.0"),
         .package(url: "https://github.com/giginet/PackageManifestKit",
-                 branch: "main")
+                 from: "0.1.0")
     ],
     targets: [
         .executableTarget(

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -5,6 +5,7 @@ import PackageModel
 import PackageLoading
 // We may drop this annotation in SwiftPM's future release
 @preconcurrency import PackageGraph
+import PackageManifestKit
 
 struct DescriptionPackage: PackageLocator {
     let mode: Runner.Mode
@@ -12,7 +13,7 @@ struct DescriptionPackage: PackageLocator {
     private let toolchain: UserToolchain
     let workspace: Workspace
     let graph: ModulesGraph
-    let manifest: Manifest
+    let manifest: PackageManifestKit.Manifest
 
     enum Error: LocalizedError {
         case packageNotDefined
@@ -31,11 +32,11 @@ struct DescriptionPackage: PackageLocator {
     // MARK: Properties
 
     var name: String {
-        manifest.displayName
+        manifest.name
     }
 
     var supportedSDKs: Set<SDK> {
-        Set(manifest.platforms.map(\.platformName).compactMap(SDK.init(platformName:)))
+        Set(manifest.platforms?.map(\.platformName).compactMap(SDK.init(platformName:)) ?? [])
     }
 
     // MARK: Initializer
@@ -58,6 +59,25 @@ struct DescriptionPackage: PackageLocator {
         return workspace
     }
 
+    private static func makeManifest(
+        packageDirectory: TSCAbsolutePath,
+        executor: some Executor
+    ) async throws -> PackageManifestKit.Manifest {
+        let commands = [
+            "/usr/bin/xcrun",
+            "swift",
+            "package",
+            "dump-package",
+            "--package-path",
+            packageDirectory.pathString,
+        ]
+
+        let manifestString = try await executor.execute(commands).unwrapOutput()
+        let manifest = try JSONDecoder().decode(PackageManifestKit.Manifest.self, from: manifestString)
+
+        return manifest
+    }
+
     /// Make DescriptionPackage from a passed package directory
     /// - Parameter packageDirectory: A path for the Swift package to build
     /// - Parameter mode: A Scipio running mode
@@ -69,7 +89,8 @@ struct DescriptionPackage: PackageLocator {
         packageDirectory: TSCAbsolutePath,
         mode: Runner.Mode,
         onlyUseVersionsFromResolvedFile: Bool,
-        toolchainEnvironment: ToolchainEnvironment? = nil
+        toolchainEnvironment: ToolchainEnvironment? = nil,
+        executor: some Executor = ProcessExecutor(decoder: StandardOutputDecoder())
     ) async throws {
         self.packageDirectory = packageDirectory
         self.mode = mode
@@ -100,9 +121,9 @@ struct DescriptionPackage: PackageLocator {
             observabilityScope: scope
         )
 #endif
-        self.manifest = try await workspace.loadRootManifest(
-            at: packageDirectory.spmAbsolutePath,
-            observabilityScope: scope
+        self.manifest = try await Self.makeManifest(
+            packageDirectory: packageDirectory,
+            executor: executor
         )
         self.workspace = workspace
     }

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -14,6 +14,7 @@ struct DescriptionPackage: PackageLocator {
     let workspace: Workspace
     let graph: ModulesGraph
     let manifest: PackageManifestKit.Manifest
+    let jsonDecoder = JSONDecoder()
 
     enum Error: LocalizedError {
         case packageNotDefined
@@ -61,6 +62,7 @@ struct DescriptionPackage: PackageLocator {
 
     private static func makeManifest(
         packageDirectory: TSCAbsolutePath,
+        jsonDecoder: JSONDecoder,
         executor: some Executor
     ) async throws -> PackageManifestKit.Manifest {
         let commands = [
@@ -73,7 +75,7 @@ struct DescriptionPackage: PackageLocator {
         ]
 
         let manifestString = try await executor.execute(commands).unwrapOutput()
-        let manifest = try JSONDecoder().decode(PackageManifestKit.Manifest.self, from: manifestString)
+        let manifest = try jsonDecoder.decode(PackageManifestKit.Manifest.self, from: manifestString)
 
         return manifest
     }
@@ -123,6 +125,7 @@ struct DescriptionPackage: PackageLocator {
 #endif
         self.manifest = try await Self.makeManifest(
             packageDirectory: packageDirectory,
+            jsonDecoder: jsonDecoder,
             executor: executor
         )
         self.workspace = workspace

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -182,7 +182,7 @@ final class CacheSystemTests: XCTestCase {
         let testingPackage = descriptionPackage
             .graph
             .packages
-            .first { $0.manifest.displayName == descriptionPackage.manifest.displayName }!
+            .first { $0.manifest.displayName == descriptionPackage.manifest.name }!
 
         let myTarget = testingPackage.modules.first { $0.name == "MyTarget" }!
         let cacheTarget = CacheSystem.CacheTarget(

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -280,7 +280,7 @@ final class RunnerTests: XCTestCase {
             outputDirectory: frameworkOutputDir
         )
         let packages = descriptionPackage.graph.packages
-            .filter { $0.manifest.displayName != descriptionPackage.manifest.displayName }
+            .filter { $0.manifest.displayName != descriptionPackage.manifest.name }
 
         let allTargets = packages
             .flatMap { package in
@@ -508,7 +508,7 @@ final class RunnerTests: XCTestCase {
             outputDirectory: frameworkOutputDir
         )
         let packages = descriptionPackage.graph.packages
-            .filter { $0.manifest.displayName != descriptionPackage.manifest.displayName }
+            .filter { $0.manifest.displayName != descriptionPackage.manifest.name }
 
         let allTargets = packages
             .flatMap { package in


### PR DESCRIPTION
We used to get the manifest information directly via SPM.
Now, I’ve migrated to parsing the JSON output from the `swift package dump-package` command using `PackageManifestKit`.