### PR TITLE
Improve `ModuleTypeResolver.resolveTargetFullPath` to support case-insensitive matching of default module directories

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -33,26 +33,6 @@ struct DescriptionPackage: PackageLocator {
         Set(manifest.platforms?.map(\.platformName).compactMap(SDK.init(platformName:)) ?? [])
     }
 
-    private static func makeManifest(
-        packageDirectory: TSCAbsolutePath,
-        jsonDecoder: JSONDecoder,
-        executor: some Executor
-    ) async throws -> PackageManifestKit.Manifest {
-        let commands = [
-            "/usr/bin/xcrun",
-            "swift",
-            "package",
-            "dump-package",
-            "--package-path",
-            packageDirectory.pathString,
-        ]
-
-        let manifestString = try await executor.execute(commands).unwrapOutput()
-        let manifest = try jsonDecoder.decode(PackageManifestKit.Manifest.self, from: manifestString)
-
-        return manifest
-    }
-
     /// Make DescriptionPackage from a passed package directory
     /// - Parameter packageDirectory: A path for the Swift package to build
     /// - Parameter mode: A Scipio running mode

--- a/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
+++ b/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
@@ -116,6 +116,7 @@ extension PackageResolver {
             // - "Sources/<target name>"
             // - "Source/<target name>"
             // - "src/<target name>".
+            // - "srcs/<target name>".
             let defaultRoots = Set(["sources", "source", "src", "srcs"])
             let entries = (try? fileSystem.getDirectoryContents(packageURL.absolutePath)) ?? []
 

--- a/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
+++ b/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
@@ -116,7 +116,7 @@ extension PackageResolver {
             // - "Source/<target name>"
             // - "src/<target name>".
             // - "srcs/<target name>".
-            let defaultRoots = Set(["sources", "source", "src", "srcs"])
+            let defaultRoots = ["sources", "source", "src", "srcs"]
             let entries = (try? fileSystem.getDirectoryContents(packageURL.absolutePath)) ?? []
 
             // Match using lowercase comparison since SwiftPM treats these names case-insensitively

--- a/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
+++ b/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
@@ -103,20 +103,35 @@ extension PackageResolver {
             of target: Target,
             dependencyPackage: DependencyPackage
         ) -> URL {
-            let packagePath = dependencyPackage.path
-            // In SwiftPM, if target does not specify a path,
-            // it is assumed to be located at 'Sources/<target name>' by default.
-            // For Clang modules, the default is 'src/<target name>'.
-            let defaultSwiftModulePath = "Sources/\(target.name)"
-            let defaultClangModulePath = "src/\(target.name)"
-            let swiftModuleRelativePath = target.path ?? defaultSwiftModulePath
-            let swiftModuleFullPath = URL(filePath: packagePath).appending(component: swiftModuleRelativePath)
-            let clangModuleFullPath = URL(filePath: packagePath).appending(component: defaultClangModulePath)
+            let packageURL = URL(filePath: dependencyPackage.path)
 
-            return if fileSystem.exists(swiftModuleFullPath.spmAbsolutePath) {
-                swiftModuleFullPath
-            } else if fileSystem.exists(clangModuleFullPath.spmAbsolutePath) {
-                clangModuleFullPath
+            // If an explicit path is provided, use it first.
+            if let explicitURL = target.path.map({ packageURL.appending(component: $0) }),
+                fileSystem.exists(explicitURL.absolutePath)
+            {
+                return explicitURL
+            }
+
+            // In SwiftPM, if target does not specify a path, it is assumed to be located at one of:
+            // - "Sources/<target name>"
+            // - "Source/<target name>"
+            // - "src/<target name>".
+            let defaultRoots = Set(["sources", "source", "src", "srcs"])
+            let entries = (try? fileSystem.getDirectoryContents(packageURL.absolutePath)) ?? []
+
+            // Match using lowercase comparison since SwiftPM treats these names case-insensitively
+            let sourcesURLs = entries.lazy
+                .filter { defaultRoots.contains($0.lowercased()) }
+                .map { packageURL.appending(component: $0) }
+            let moduleURLs = sourcesURLs.map { $0.appending(component: target.name) }
+
+            return if let moduleURL = moduleURLs.first(where: { fileSystem.exists($0.absolutePath) }) {
+                moduleURL
+            }
+            // If no nested module directory is found but exactly one default root exists
+            // (e.g. only Source/xxx.swift in the package), allow that root itself as the module path.
+            else if let sourceURL = sourcesURLs.first(where: { fileSystem.exists($0.absolutePath) }) {
+                sourceURL
             } else {
                 preconditionFailure("Cannot find module directory for target '\(target.name)'")
             }

--- a/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
+++ b/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
@@ -107,8 +107,7 @@ extension PackageResolver {
 
             // If an explicit path is provided, use it first.
             if let explicitURL = target.path.map({ packageURL.appending(component: $0) }),
-                fileSystem.exists(explicitURL.absolutePath)
-            {
+                fileSystem.exists(explicitURL.absolutePath) {
                 return explicitURL
             }
 

--- a/Sources/ScipioKit/Resolver/ResolvedModels.swift
+++ b/Sources/ScipioKit/Resolver/ResolvedModels.swift
@@ -1,8 +1,6 @@
 import Foundation
 import PackageManifestKit
 
-typealias Pins = [PackageID: Pin.State]
-
 struct ModulesGraph {
     var rootPackage: ResolvedPackage
     var allPackages: [PackageID: ResolvedPackage]

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithExplicitPath/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithExplicitPath/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithExplicitPath/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithExplicitPath/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WithExplicitPath",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "WithExplicitPath",
+            targets: ["WithExplicitPath"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "WithExplicitPath",
+            path: "path/WithExplicitPath"
+        ),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithExplicitPath/path/WithExplicitPath/WithExplicitPath.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithExplicitPath/path/WithExplicitPath/WithExplicitPath.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_source/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_source/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_source/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_source/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WithoutPath_LowercaseDir_source",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "WithoutPath_LowercaseDir_source",
+            targets: ["WithoutPath_LowercaseDir_source"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "WithoutPath_LowercaseDir_source"
+        ),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_source/source/WithoutPath_LowercaseDir_source/WithoutPath_LowercaseDir_source.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_source/source/WithoutPath_LowercaseDir_source/WithoutPath_LowercaseDir_source.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_sources/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_sources/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_sources/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_sources/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WithoutPath_LowercaseDir_sources",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "WithoutPath_LowercaseDir_sources",
+            targets: ["WithoutPath_LowercaseDir_sources"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "WithoutPath_LowercaseDir_sources"
+        ),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_sources/sources/WithoutPath_LowercaseDir_sources/WithoutPath_LowercaseDir_sources.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_sources/sources/WithoutPath_LowercaseDir_sources/WithoutPath_LowercaseDir_sources.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_src/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_src/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_src/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_src/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WithoutPath_LowercaseDir_src",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "WithoutPath_LowercaseDir_src",
+            targets: ["WithoutPath_LowercaseDir_src"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "WithoutPath_LowercaseDir_src"),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_src/src/WithoutPath_LowercaseDir_src/WithoutPath_LowercaseDir_src.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_src/src/WithoutPath_LowercaseDir_src/WithoutPath_LowercaseDir_src.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_srcs/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_srcs/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_srcs/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_srcs/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WithoutPath_LowercaseDir_srcs",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "WithoutPath_LowercaseDir_srcs",
+            targets: ["WithoutPath_LowercaseDir_srcs"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "WithoutPath_LowercaseDir_srcs"),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_srcs/src/WithoutPath_LowercaseDir_srcs/WithoutPath_LowercaseDir_srcs.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_LowercaseDir_srcs/src/WithoutPath_LowercaseDir_srcs/WithoutPath_LowercaseDir_srcs.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_SingleModule/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_SingleModule/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_SingleModule/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_SingleModule/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WithoutPath_SingleModule",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "WithoutPath_SingleModule",
+            targets: ["WithoutPath_SingleModule"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "WithoutPath_SingleModule"
+        ),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_SingleModule/Source/WithoutPath_SingleModule.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_SingleModule/Source/WithoutPath_SingleModule.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_UppercaseMix/.gitignore
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_UppercaseMix/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_UppercaseMix/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_UppercaseMix/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WithoutPath_UppercaseMix",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "WithoutPath_UppercaseMix",
+            targets: ["WithoutPath_UppercaseMix"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "WithoutPath_UppercaseMix"),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_UppercaseMix/sOuRcEs/WithoutPath_UppercaseMix/WithoutPath_UppercaseMix.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/VariousModulePathsTests/WithoutPath_UppercaseMix/sOuRcEs/WithoutPath_UppercaseMix/WithoutPath_UppercaseMix.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/ScipioKitTests/VariousModulePathsTests.swift
+++ b/Tests/ScipioKitTests/VariousModulePathsTests.swift
@@ -5,7 +5,7 @@ import PackageManifestKit
 @testable import ScipioKit
 
 struct VariousModulePathsTests {
-    private static let fixturePath = URL(fileURLWithPath: #filePath)
+    private static let fixturePath = URL(filePath: #filePath)
         .deletingLastPathComponent()
         .appending(components: "Resources", "Fixtures", "VariousModulePathsTests")
 

--- a/Tests/ScipioKitTests/VariousModulePathsTests.swift
+++ b/Tests/ScipioKitTests/VariousModulePathsTests.swift
@@ -10,14 +10,14 @@ struct VariousModulePathsTests {
         .appending(components: "Resources", "Fixtures", "VariousModulePathsTests")
 
     private static let packages: [URL] = [
-        fixturePath.appending(components: "WithExplicitPath"),
-        fixturePath.appending(components: "WithoutPath_LowercaseDir_srcs"),
-        fixturePath.appending(components: "WithoutPath_LowercaseDir_source"),
-        fixturePath.appending(components: "WithoutPath_SingleModule"),
-        fixturePath.appending(components: "WithoutPath_LowercaseDir_sources"),
-        fixturePath.appending(components: "WithoutPath_UppercaseMix"),
-        fixturePath.appending(components: "WithoutPath_LowercaseDir_src"),
-    ]
+        "WithExplicitPath",
+        "WithoutPath_LowercaseDir_srcs",
+        "WithoutPath_LowercaseDir_source",
+        "WithoutPath_SingleModule",
+        "WithoutPath_LowercaseDir_sources",
+        "WithoutPath_UppercaseMix",
+        "WithoutPath_LowercaseDir_src",
+    ].map { fixturePath.appending(components: $0) }
 
     let fileSystem = TSCBasic.localFileSystem
     let manifestLoader = ManifestLoader(executor: ProcessExecutor())

--- a/Tests/ScipioKitTests/VariousModulePathsTests.swift
+++ b/Tests/ScipioKitTests/VariousModulePathsTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+import TSCBasic
+import PackageManifestKit
+@testable import ScipioKit
+
+struct VariousModulePathsTests {
+    private static let fixturePath = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .appending(components: "Resources", "Fixtures", "VariousModulePathsTests")
+
+    private static let packages: [URL] = [
+        fixturePath.appending(components: "WithExplicitPath"),
+        fixturePath.appending(components: "WithoutPath_LowercaseDir_srcs"),
+        fixturePath.appending(components: "WithoutPath_LowercaseDir_source"),
+        fixturePath.appending(components: "WithoutPath_SingleModule"),
+        fixturePath.appending(components: "WithoutPath_LowercaseDir_sources"),
+        fixturePath.appending(components: "WithoutPath_UppercaseMix"),
+        fixturePath.appending(components: "WithoutPath_LowercaseDir_src"),
+    ]
+
+    let fileSystem = TSCBasic.localFileSystem
+    let manifestLoader = ManifestLoader(executor: ProcessExecutor())
+
+    @Test(
+        "PackageResolver resolves modules for packages with explicit paths or default (case-insensitive) directory layouts",
+        arguments: packages
+    )
+    func resolve(for packageURL: URL) async throws {
+        let rootManifest = try await manifestLoader.loadManifest(for: packageURL)
+
+        let resolver = try await PackageResolver(
+            packageDirectory: packageURL,
+            rootManifest: rootManifest,
+            fileSystem: fileSystem
+        )
+        let modulesGraph = try await resolver.resolve()
+
+        modulesGraph.allModules.forEach { module in
+            #expect(module.name == packageURL.lastPathComponent)
+        }
+    }
+}


### PR DESCRIPTION
Previously, `ModuleTypeResolver` could only resolve modules located under the following directory structures:

* `Sources/<target name>`
* `src/<target name>`

However, SwiftPM treats these directory names in a case-insensitive manner. This means that modules placed under directories like `sources/` or `SRC/`, which are valid in SwiftPM, were not recognized by `ModuleTypeResolver`.

Additionally, in packages that contain only a single module, SwiftPM allows placing source files directly under `Sources/` (e.g. `Sources/main.swift`) without a subdirectory. The previous implementation did not account for this layout either.

This PR updates `resolveTargetFullPath` to handle:

* Case-insensitive matching of standard source directories (`sources`, `source`, `src`, `srcs`)
* Single-module packages where source files are placed directly under the root source directory

It also adds tests to cover various valid module directory layouts.