### PR TITLE
Bump `swift-nio` & `swift-nio-ssl` in integration test fixtures and update tests

### DIFF
--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -47,8 +47,10 @@ final class DescriptionPackageTests: XCTestCase {
                 "CNIOAtomics",
                 "CNIODarwin",
                 "CNIOLinux",
+                "CNIOWASI",
                 "CNIOWindows",
                 "DequeModule",
+                "InternalCollectionsUtilities",
                 "Logging",
                 "NIO",
                 "NIOConcurrencyHelpers",
@@ -59,6 +61,7 @@ final class DescriptionPackageTests: XCTestCase {
                 "SDWebImage",
                 "SDWebImageMapKit",
                 "_AtomicsShims",
+                "_NIOBase64",
                 "_NIODataStructures",
             ]
         )

--- a/Tests/ScipioKitTests/IntegrationTests.swift
+++ b/Tests/ScipioKitTests/IntegrationTests.swift
@@ -59,6 +59,9 @@ final class IntegrationTests: XCTestCase {
                 ("CNIOLinux", .static, [.iOS], true),
                 ("CNIODarwin", .static, [.iOS], true),
                 ("CNIOWindows", .static, [.iOS], true),
+                ("CNIOWASI", .static, [.iOS], true),
+                ("InternalCollectionsUtilities", .static, [.iOS], false),
+                ("_NIOBase64", .static, [.iOS], false),
             ]
         )
     }
@@ -85,6 +88,9 @@ final class IntegrationTests: XCTestCase {
                 ("NIOTLS", .static, [.macOS], false),
                 ("_AtomicsShims", .static, [.macOS], true),
                 ("_NIODataStructures", .static, [.macOS], false),
+                ("CNIOWASI", .static, [.macOS], true),
+                ("InternalCollectionsUtilities", .static, [.macOS], false),
+                ("_NIOBase64", .static, [.macOS], false),
             ]
         )
     }

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Package.resolved
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "a2e487b77f17edbce9a65f2b7415f2f479dc8e48",
-        "version" : "2.57.0"
+        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
+        "version" : "2.83.0"
       }
     },
     {
@@ -32,8 +32,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl",
       "state" : {
-        "revision" : "e866a626e105042a6a72a870c88b4c531ba05f83",
-        "version" : "2.24.0"
+        "revision" : "36b48956eb6c0569215dc15a587b491d2bb36122",
+        "version" : "2.32.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
       }
     }
   ],

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationMacTestPackage/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["IntegrationMacTestPackage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.24.0")
+        .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.32.0")
     ],
     targets: [
         .target(

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.resolved
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
       }
     },
     {
@@ -41,8 +41,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "a2e487b77f17edbce9a65f2b7415f2f479dc8e48",
-        "version" : "2.57.0"
+        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
+        "version" : "2.83.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
       }
     }
   ],

--- a/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/IntegrationTestPackage/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.3"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.83.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.15.0"),


### PR DESCRIPTION
This PR updates the test fixtures used in ScipioKit’s integration tests to use the latest versions of swift-nio and swift-nio-ssl.
Originally, the fixtures specified swift-nio with from: 2.0.0, but when version 2.83.0 was used locally, some tests failed due to API changes.
To fix this, the fixtures are now updated to 2.83.0, and the test code has been modified to match the updated APIs.