### PR TITLE
Migrate AbsolutePath and RelativePath to URL

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -4,7 +4,7 @@ import PackageManifestKit
 
 struct DescriptionPackage: PackageLocator, Sendable {
     let mode: Runner.Mode
-    let packageDirectory: AbsolutePath
+    let packageDirectory: URL
     let graph: ModulesGraph
     let manifest: PackageManifestKit.Manifest
     let jsonDecoder = JSONDecoder()
@@ -41,7 +41,7 @@ struct DescriptionPackage: PackageLocator, Sendable {
     ///   If it is `true`, Package.resolved never be updated.
     ///   Instead, the resolving will fail if the Package.resolved is mis-matched with the workspace.
     init(
-        packageDirectory: AbsolutePath,
+        packageDirectory: URL,
         mode: Runner.Mode,
         onlyUseVersionsFromResolvedFile: Bool,
         executor: some Executor = ProcessExecutor(decoder: StandardOutputDecoder())
@@ -49,10 +49,10 @@ struct DescriptionPackage: PackageLocator, Sendable {
         self.packageDirectory = packageDirectory
         self.mode = mode
 
-        self.manifest = try await ScipioKit.ManifestLoader(executor: executor).loadManifest(for: packageDirectory.asURL)
+        self.manifest = try await ScipioKit.ManifestLoader(executor: executor).loadManifest(for: packageDirectory)
 
         self.graph = try await PackageResolver(
-            packageDirectory: packageDirectory.asURL,
+            packageDirectory: packageDirectory,
             rootManifest: self.manifest,
             fileSystem: LocalFileSystem.default
         ).resolve()

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 import PackageManifestKit
 
 struct DescriptionPackage: PackageLocator, Sendable {

--- a/Sources/ScipioKit/PackageLocator.swift
+++ b/Sources/ScipioKit/PackageLocator.swift
@@ -1,47 +1,46 @@
 import TSCBasic
+import Foundation
 
 /// Holds the packageDirectory Scipio works on, and defines some path-related functionalities.
 protocol PackageLocator: Sendable {
-    var packageDirectory: AbsolutePath { get }
+    var packageDirectory: URL { get }
 }
 
 extension PackageLocator {
-    var buildDirectory: AbsolutePath {
+    var buildDirectory: URL {
         packageDirectory.appending(component: ".build")
     }
 
-    var workspaceDirectory: AbsolutePath {
+    var workspaceDirectory: URL {
         buildDirectory.appending(component: "scipio")
     }
 
-    var derivedDataPath: AbsolutePath {
+    var derivedDataPath: URL {
         workspaceDirectory.appending(component: "DerivedData")
     }
 
-    func generatedModuleMapPath(of target: ResolvedModule, sdk: SDK) throws -> AbsolutePath {
-        let relativePath = try RelativePath(validating: "ModuleMapsForFramework/\(sdk.settingValue)")
-        return workspaceDirectory
-            .appending(relativePath)
-            .appending(component: target.modulemapName)
+    func generatedModuleMapPath(of target: ResolvedModule, sdk: SDK) throws -> URL {
+        workspaceDirectory
+            .appending(components: "ModuleMapsForFramework", sdk.settingValue, target.modulemapName)
     }
 
     /// Returns an Products directory path
     /// It should be the default setting of `TARGET_BUILD_DIR`
-    func productsDirectory(buildConfiguration: BuildConfiguration, sdk: SDK) -> AbsolutePath {
+    func productsDirectory(buildConfiguration: BuildConfiguration, sdk: SDK) -> URL {
         let intermediateDirectoryName = productDirectoryName(
             buildConfiguration: buildConfiguration,
             sdk: sdk
         )
-        return derivedDataPath.appending(components: ["Products", intermediateDirectoryName])
+        return derivedDataPath.appending(components: "Products", intermediateDirectoryName)
     }
 
     /// Returns a directory path which contains assembled frameworks
-    var assembledFrameworksRootDirectory: AbsolutePath {
+    var assembledFrameworksRootDirectory: URL {
         workspaceDirectory.appending(component: "AssembledFrameworks")
     }
 
     /// Returns a directory path of the assembled frameworks path for the specific Configuration/Platform
-    func assembledFrameworksDirectory(buildConfiguration: BuildConfiguration, sdk: SDK) -> AbsolutePath {
+    func assembledFrameworksDirectory(buildConfiguration: BuildConfiguration, sdk: SDK) -> URL {
         let intermediateDirName = productDirectoryName(buildConfiguration: buildConfiguration, sdk: sdk)
         return assembledFrameworksRootDirectory
             .appending(component: intermediateDirName)

--- a/Sources/ScipioKit/PackageLocator.swift
+++ b/Sources/ScipioKit/PackageLocator.swift
@@ -1,4 +1,3 @@
-import TSCBasic
 import Foundation
 
 /// Holds the packageDirectory Scipio works on, and defines some path-related functionalities.

--- a/Sources/ScipioKit/Producer/BinaryExtractor.swift
+++ b/Sources/ScipioKit/Producer/BinaryExtractor.swift
@@ -16,10 +16,10 @@ struct BinaryExtractor {
             )
         }
 
-        let artifactURL = binaryLocation.artifactURL(rootPackageDirectory: descriptionPackage.packageDirectory.asURL)
+        let artifactURL = binaryLocation.artifactURL(rootPackageDirectory: descriptionPackage.packageDirectory)
 
         let frameworkName = "\(binaryTarget.c99name).xcframework"
-        let fileName = artifactURL.absolutePath.basename
+        let fileName = artifactURL.lastPathComponent
         let destinationPath = outputDirectory.appendingPathComponent(fileName)
         if fileSystem.exists(destinationPath) && overwrite {
             logger.info("🗑️ Delete \(frameworkName)", metadata: .color(.red))

--- a/Sources/ScipioKit/Producer/Compiler.swift
+++ b/Sources/ScipioKit/Producer/Compiler.swift
@@ -1,6 +1,5 @@
 import Foundation
 import PIFKit
-import TSCBasic
 
 protocol Compiler {
     var descriptionPackage: DescriptionPackage { get }

--- a/Sources/ScipioKit/Producer/Compiler.swift
+++ b/Sources/ScipioKit/Producer/Compiler.swift
@@ -16,10 +16,10 @@ extension Compiler {
         buildConfiguration: BuildConfiguration,
         sdks: Set<SDK>,
         fileSystem: some FileSystem = LocalFileSystem.default
-    ) async throws -> [SDK: [AbsolutePath]] {
+    ) async throws -> [SDK: [URL]] {
         let extractor = DwarfExtractor()
 
-        var result = [SDK: [AbsolutePath]]()
+        var result = [SDK: [URL]]()
 
         for sdk in sdks {
             let dsymPath = descriptionPackage.buildDebugSymbolPath(
@@ -27,17 +27,17 @@ extension Compiler {
                 sdk: sdk,
                 target: target
             )
-            guard fileSystem.exists(dsymPath.asURL) else { continue }
+            guard fileSystem.exists(dsymPath) else { continue }
 
             let dwarfPath = extractor.dwarfPath(for: target, dSYMPath: dsymPath)
             let dumpedDSYMsMaps = try await extractor.dump(dwarfPath: dwarfPath)
-            let bcSymbolMapPaths: [AbsolutePath] = dumpedDSYMsMaps.values.compactMap { [descriptionPackage] uuid in
+            let bcSymbolMapPaths: [URL] = dumpedDSYMsMaps.values.compactMap { [descriptionPackage] uuid in
                 let path = descriptionPackage.productsDirectory(
                     buildConfiguration: buildConfiguration,
                     sdk: sdk
                 )
                     .appending(component: "\(uuid.uuidString).bcsymbolmap")
-                guard fileSystem.exists(path.asURL) else { return nil }
+                guard fileSystem.exists(path) else { return nil }
                 return path
             }
             result[sdk] = [dsymPath] + bcSymbolMapPaths
@@ -51,7 +51,7 @@ extension DescriptionPackage {
         buildConfiguration: BuildConfiguration,
         sdk: SDK,
         target: ResolvedModule
-    ) -> AbsolutePath {
+    ) -> URL {
         productsDirectory(buildConfiguration: buildConfiguration, sdk: sdk)
             .appending(component: "\(target.name).framework.dSYM")
     }

--- a/Sources/ScipioKit/Producer/DwarfExtractor.swift
+++ b/Sources/ScipioKit/Producer/DwarfExtractor.swift
@@ -10,12 +10,12 @@ struct DwarfExtractor<E: Executor> {
 
     typealias Arch = String
 
-    func dwarfPath(for target: ResolvedModule, dSYMPath: AbsolutePath) -> AbsolutePath {
+    func dwarfPath(for target: ResolvedModule, dSYMPath: URL) -> URL {
         dSYMPath.appending(components: "Contents", "Resources", "DWARF", target.name)
     }
 
-    func dump(dwarfPath: AbsolutePath) async throws -> [Arch: UUID] {
-        let result = try await executor.execute("/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.pathString)
+    func dump(dwarfPath: URL) async throws -> [Arch: UUID] {
+        let result = try await executor.execute("/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.path(percentEncoded: false))
 
         let output = try result.unwrapOutput()
 

--- a/Sources/ScipioKit/Producer/DwarfExtractor.swift
+++ b/Sources/ScipioKit/Producer/DwarfExtractor.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 
 struct DwarfExtractor<E: Executor> {
     private let executor: E

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -56,12 +56,12 @@ struct FrameworkProducer {
     }
 
     func clean() async throws {
-        if fileSystem.exists(descriptionPackage.derivedDataPath.asURL) {
-            try fileSystem.removeFileTree(descriptionPackage.derivedDataPath.asURL)
+        if fileSystem.exists(descriptionPackage.derivedDataPath) {
+            try fileSystem.removeFileTree(descriptionPackage.derivedDataPath)
         }
 
-        if fileSystem.exists(descriptionPackage.assembledFrameworksRootDirectory.asURL) {
-            try fileSystem.removeFileTree(descriptionPackage.assembledFrameworksRootDirectory.asURL)
+        if fileSystem.exists(descriptionPackage.assembledFrameworksRootDirectory) {
+            try fileSystem.removeFileTree(descriptionPackage.assembledFrameworksRootDirectory)
         }
     }
 

--- a/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
+++ b/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 
 struct InfoPlistGenerator {
     private let fileSystem: any FileSystem

--- a/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
+++ b/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
@@ -8,9 +8,9 @@ struct InfoPlistGenerator {
         self.fileSystem = fileSystem
     }
 
-    func generateForResourceBundle(at path: AbsolutePath) throws {
+    func generateForResourceBundle(at path: URL) throws {
         let body = resourceBundleBody
-        try fileSystem.writeFileContents(path.asURL, string: body)
+        try fileSystem.writeFileContents(path, string: body)
     }
 
     private var resourceBundleBody: String {

--- a/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
@@ -48,8 +48,8 @@ struct BuildParametersGenerator {
     func generate(
         for sdk: SDK,
         buildParameters: Parameters,
-        destinationDir: AbsolutePath
-    ) throws -> AbsolutePath {
+        destinationDir: URL
+    ) throws -> URL {
         let targetArchitecture = buildParameters.arch
 
         // Generate the run destination parameters.
@@ -101,7 +101,7 @@ struct BuildParametersGenerator {
         let filePath = destinationDir.appending(component: "build-parameters-\(sdk.settingValue).json")
 
         let data = try jsonEncoder.encode(params)
-        try self.fileSystem.writeFileContents(filePath.asURL, data: data)
+        try self.fileSystem.writeFileContents(filePath, data: data)
 
         return filePath
     }

--- a/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/BuildParametersGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 
 struct XCBBuildParameters: Encodable, Sendable {
     struct RunDestination: Encodable, Sendable {

--- a/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
@@ -116,10 +116,7 @@ struct FrameworkBundleAssembler {
         }
         try fileSystem.copy(
             from: header,
-            to: headerDir
-                .appending(components: subdirectoryComponents)
-                .appending(component: header.lastPathComponent)
-
+            to: headerDir.appending(components: subdirectoryComponents)
         )
     }
 

--- a/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
@@ -239,16 +239,12 @@ extension FrameworkBundleAssembler {
             from relativePrivacyInfoPathComponents: String...,
             in resourceBundlePath: URL,
         ) throws {
-            guard let privacyInfoLastPathComponent = relativePrivacyInfoPathComponents.last else {
-                preconditionFailure("relativePrivacyInfoPathComponents must not be empty")
-            }
-
             let privacyInfoPath = resourceBundlePath.appending(components: relativePrivacyInfoPathComponents)
             if fileSystem.exists(privacyInfoPath) {
                 try fileSystem.move(
                     from: privacyInfoPath,
                     to: resourceBundlePath.parentDirectory
-                        .appending(component: privacyInfoLastPathComponent)
+                        .appending(component: privacyInfoPath.lastPathComponent)
                 )
             }
         }

--- a/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
@@ -116,7 +116,9 @@ struct FrameworkBundleAssembler {
         }
         try fileSystem.copy(
             from: header,
-            to: headerDir.appending(components: subdirectoryComponents)
+            to: headerDir
+                .appending(components: subdirectoryComponents)
+                .appending(component: header.lastPathComponent)
         )
     }
 

--- a/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 
 /// A assembler to generate framework bundle
 /// This assembler just relocates framework components into the framework structure

--- a/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
@@ -248,8 +248,7 @@ extension FrameworkBundleAssembler {
             }
 
             let privacyInfoPath = resourceBundlePath.appending(components: relativePrivacyInfoPathComponents)
-            if fileSystem.exists(privacyInfoPath)
-            {
+            if fileSystem.exists(privacyInfoPath) {
                 try fileSystem.move(
                     from: privacyInfoPath,
                     to: resourceBundlePath.parentDirectory

--- a/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
@@ -6,17 +6,17 @@ import TSCBasic
 struct FrameworkBundleAssembler {
     private let frameworkComponents: FrameworkComponents
     private let keepPublicHeadersStructure: Bool
-    private let outputDirectory: AbsolutePath
+    private let outputDirectory: URL
     private let fileSystem: any FileSystem
 
-    private var frameworkBundlePath: AbsolutePath {
+    private var frameworkBundlePath: URL {
         outputDirectory.appending(component: "\(frameworkComponents.frameworkName).framework")
     }
 
     init(
         frameworkComponents: FrameworkComponents,
         keepPublicHeadersStructure: Bool,
-        outputDirectory: AbsolutePath,
+        outputDirectory: URL,
         fileSystem: some FileSystem
     ) {
         self.frameworkComponents = frameworkComponents
@@ -27,7 +27,7 @@ struct FrameworkBundleAssembler {
 
     @discardableResult
     func assemble() throws -> URL {
-        try fileSystem.createDirectory(frameworkBundlePath.asURL, recursive: true)
+        try fileSystem.createDirectory(frameworkBundlePath, recursive: true)
 
         try copyBinary()
 
@@ -46,24 +46,24 @@ struct FrameworkBundleAssembler {
             destinationFrameworkBundlePath: frameworkBundlePath
         )
 
-        return frameworkBundlePath.asURL
+        return frameworkBundlePath
     }
 
     private func copyBinary() throws {
         let sourcePath = frameworkComponents.binaryPath
         let destinationPath = frameworkBundlePath.appending(component: frameworkComponents.frameworkName)
-        if fileSystem.isSymlink(sourcePath.asURL) {
+        if fileSystem.isSymlink(sourcePath) {
             // Frameworks for macOS have Versions. So their binaries are symlinks
             // Follow symlink to copy a original binary
-            let sourceURL = sourcePath.asURL
+            let sourceURL = sourcePath
             try fileSystem.copy(
                 from: sourceURL.resolvingSymlinksInPath(),
-                to: destinationPath.asURL
+                to: destinationPath
             )
         } else {
             try fileSystem.copy(
-                from: frameworkComponents.binaryPath.asURL,
-                to: destinationPath.asURL
+                from: frameworkComponents.binaryPath,
+                to: destinationPath
             )
         }
     }
@@ -78,7 +78,7 @@ struct FrameworkBundleAssembler {
 
         let headerDir = frameworkBundlePath.appending(component: "Headers")
 
-        try fileSystem.createDirectory(headerDir.asURL)
+        try fileSystem.createDirectory(headerDir)
 
         for header in headers {
             if keepPublicHeadersStructure, let includeDir = frameworkComponents.includeDir {
@@ -89,20 +89,20 @@ struct FrameworkBundleAssembler {
                 )
             } else {
                 try fileSystem.copy(
-                    from: header.asURL,
-                    to: headerDir.appending(component: header.basename).asURL
+                    from: header,
+                    to: headerDir.appending(component: header.lastPathComponent)
                 )
             }
         }
     }
 
     private func copyHeaderKeepingStructure(
-        header: AbsolutePath,
-        includeDir: AbsolutePath,
-        into headerDir: AbsolutePath
+        header: URL,
+        includeDir: URL,
+        into headerDir: URL
     ) throws {
-        let subdirectoryComponents: [String] = if header.dirname.hasPrefix(includeDir.pathString) {
-            header.dirname.dropFirst(includeDir.pathString.count)
+        let subdirectoryComponents: [String] = if header.dirname.hasPrefix(includeDir.path(percentEncoded: false)) {
+            header.dirname.dropFirst(includeDir.path(percentEncoded: false).count)
                 .split(separator: "/")
                 .map(String.init)
         } else {
@@ -111,16 +111,16 @@ struct FrameworkBundleAssembler {
 
         if !subdirectoryComponents.isEmpty {
             try fileSystem.createDirectory(
-                headerDir.appending(components: subdirectoryComponents).asURL,
+                headerDir.appending(components: subdirectoryComponents),
                 recursive: true
             )
         }
         try fileSystem.copy(
-            from: header.asURL,
+            from: header,
             to: headerDir
                 .appending(components: subdirectoryComponents)
-                .appending(component: header.basename)
-                .asURL
+                .appending(component: header.lastPathComponent)
+
         )
     }
 
@@ -139,19 +139,19 @@ struct FrameworkBundleAssembler {
 
         let modulesDir = frameworkBundlePath.appending(component: "Modules")
 
-        try fileSystem.createDirectory(modulesDir.asURL)
+        try fileSystem.createDirectory(modulesDir)
 
         if let swiftModulesPath = frameworkComponents.swiftModulesPath {
             try fileSystem.copy(
-                from: swiftModulesPath.asURL,
-                to: modulesDir.appending(component: swiftModulesPath.basename).asURL
+                from: swiftModulesPath,
+                to: modulesDir.appending(component: swiftModulesPath.lastPathComponent)
             )
         }
 
         if let moduleMapPath = frameworkComponents.modulemapPath {
             try fileSystem.copy(
-                from: moduleMapPath.asURL,
-                to: modulesDir.appending(component: "module.modulemap").asURL
+                from: moduleMapPath,
+                to: modulesDir.appending(component: "module.modulemap")
             )
         }
     }
@@ -161,9 +161,9 @@ extension FrameworkBundleAssembler {
     struct ResourcesProcessor {
         struct SourceContext {
             let isFrameworkVersionedBundle: Bool
-            let frameworkBundlePath: AbsolutePath
-            let frameworkInfoPlistPath: AbsolutePath
-            let resourceBundlePath: AbsolutePath?
+            let frameworkBundlePath: URL
+            let frameworkInfoPlistPath: URL
+            let resourceBundlePath: URL?
         }
 
         private let fileSystem: any FileSystem
@@ -174,7 +174,7 @@ extension FrameworkBundleAssembler {
 
         func copyResources(
             sourceContext: SourceContext,
-            destinationFrameworkBundlePath: AbsolutePath
+            destinationFrameworkBundlePath: URL
         ) throws {
             if sourceContext.isFrameworkVersionedBundle {
                 // The framework is a versioned bundle, so copy entire Resources directory
@@ -182,15 +182,15 @@ extension FrameworkBundleAssembler {
                 let sourceResourcesPath = sourceContext.frameworkBundlePath.appending(component: "Resources")
                 let destinationResourcesPath = destinationFrameworkBundlePath.appending(component: "Resources")
                 try fileSystem.copy(
-                    from: sourceResourcesPath.asURL.resolvingSymlinksInPath(),
-                    to: destinationResourcesPath.asURL
+                    from: sourceResourcesPath.resolvingSymlinksInPath(),
+                    to: destinationResourcesPath
                 )
 
-                if let resourceBundleName = sourceContext.resourceBundlePath?.basename {
+                if let resourceBundleName = sourceContext.resourceBundlePath?.lastPathComponent {
                     let resourceBundlePath = destinationResourcesPath.appending(component: resourceBundleName)
                     // A resource bundle of versioned bundle framework has "Contents/Resources" directory.
                     try extractPrivacyInfoIfExists(
-                        from: RelativePath(validating: "Contents/Resources/PrivacyInfo.xcprivacy"),
+                        from: "Contents", "Resources", "PrivacyInfo.xcprivacy",
                         in: resourceBundlePath
                     )
                 }
@@ -206,7 +206,7 @@ extension FrameworkBundleAssembler {
 
                 if let copiedResourceBundlePath {
                     try extractPrivacyInfoIfExists(
-                        from: RelativePath(validating: "PrivacyInfo.xcprivacy"),
+                        from: "PrivacyInfo.xcprivacy",
                         in: copiedResourceBundlePath
                     )
                 }
@@ -215,21 +215,21 @@ extension FrameworkBundleAssembler {
 
         private func copyInfoPlist(
             sourceContext: SourceContext,
-            destinationFrameworkBundlePath: AbsolutePath
+            destinationFrameworkBundlePath: URL
         ) throws {
             let sourcePath = sourceContext.frameworkInfoPlistPath
             let destinationPath = destinationFrameworkBundlePath.appending(component: "Info.plist")
-            try fileSystem.copy(from: sourcePath.asURL, to: destinationPath.asURL)
+            try fileSystem.copy(from: sourcePath, to: destinationPath)
         }
 
         /// Returns the resulting, copied resource bundle path.
         private func copyResourceBundle(
             sourceContext: SourceContext,
-            destinationFrameworkBundlePath: AbsolutePath
-        ) throws -> AbsolutePath? {
+            destinationFrameworkBundlePath: URL
+        ) throws -> URL? {
             if let sourcePath = sourceContext.resourceBundlePath {
-                let destinationPath = destinationFrameworkBundlePath.appending(component: sourcePath.basename)
-                try fileSystem.copy(from: sourcePath.asURL, to: destinationPath.asURL)
+                let destinationPath = destinationFrameworkBundlePath.appending(component: sourcePath.lastPathComponent)
+                try fileSystem.copy(from: sourcePath, to: destinationPath)
                 return destinationPath
             } else {
                 return nil
@@ -240,16 +240,20 @@ extension FrameworkBundleAssembler {
         ///
         /// - seealso: https://developer.apple.com/documentation/bundleresources/adding-a-privacy-manifest-to-your-app-or-third-party-sdk#Add-a-privacy-manifest-to-your-framework
         private func extractPrivacyInfoIfExists(
-            from relativePrivacyInfoPath: RelativePath,
-            in resourceBundlePath: AbsolutePath
+            from relativePrivacyInfoPathComponents: String...,
+            in resourceBundlePath: URL,
         ) throws {
-            let privacyInfoPath = resourceBundlePath.appending(relativePrivacyInfoPath)
-            if fileSystem.exists(privacyInfoPath.asURL) {
+            guard let privacyInfoLastPathComponent = relativePrivacyInfoPathComponents.last else {
+                preconditionFailure("relativePrivacyInfoPathComponents must not be empty")
+            }
+
+            let privacyInfoPath = resourceBundlePath.appending(components: relativePrivacyInfoPathComponents)
+            if fileSystem.exists(privacyInfoPath)
+            {
                 try fileSystem.move(
-                    from: privacyInfoPath.asURL,
+                    from: privacyInfoPath,
                     to: resourceBundlePath.parentDirectory
-                        .appending(component: relativePrivacyInfoPath.basename)
-                        .asURL
+                        .appending(component: privacyInfoLastPathComponent)
                 )
             }
         }

--- a/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 
 /// FileLists to assemble a framework bundle
 struct FrameworkComponents {

--- a/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
@@ -204,7 +204,6 @@ struct FrameworkComponentsCollector {
         }
 
         let notSymlinks = publicHeaders.filter { !fileSystem.isSymlink($0) }
-            .map { $0 }
         let symlinks = publicHeaders.filter { fileSystem.isSymlink($0) }
 
         // Sometimes, public headers include a file and its symlink both.

--- a/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkComponentsCollector.swift
@@ -10,26 +10,26 @@ struct FrameworkComponents {
     /// - seealso: https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html
     var isVersionedBundle: Bool
     var frameworkName: String
-    var frameworkPath: AbsolutePath
-    var binaryPath: AbsolutePath
-    var infoPlistPath: AbsolutePath
-    var swiftModulesPath: AbsolutePath?
-    var includeDir: AbsolutePath?
-    var publicHeaderPaths: Set<AbsolutePath>?
-    var bridgingHeaderPath: AbsolutePath?
-    var modulemapPath: AbsolutePath?
-    var resourceBundlePath: AbsolutePath?
+    var frameworkPath: URL
+    var binaryPath: URL
+    var infoPlistPath: URL
+    var swiftModulesPath: URL?
+    var includeDir: URL?
+    var publicHeaderPaths: Set<URL>?
+    var bridgingHeaderPath: URL?
+    var modulemapPath: URL?
+    var resourceBundlePath: URL?
 }
 
 /// A collector to collect framework components from a DerivedData dir
 struct FrameworkComponentsCollector {
     enum Error: LocalizedError {
-        case infoPlistNotFound(frameworkBundlePath: AbsolutePath)
+        case infoPlistNotFound(frameworkBundlePath: URL)
 
         var errorDescription: String? {
             switch self {
             case .infoPlistNotFound(let frameworkBundlePath):
-                return "Info.plist is not found in \(frameworkBundlePath.pathString)"
+                return "Info.plist is not found in \(frameworkBundlePath.path(percentEncoded: false))"
             }
         }
     }
@@ -40,7 +40,7 @@ struct FrameworkComponentsCollector {
     private let packageLocator: any PackageLocator
     private let fileSystem: any FileSystem
 
-    private let productsDirectory: AbsolutePath
+    private let productsDirectory: URL
 
     init(
         buildProduct: BuildProduct,
@@ -62,7 +62,7 @@ struct FrameworkComponentsCollector {
     }
 
     func collectComponents(sdk: SDK) throws -> FrameworkComponents {
-        let frameworkModuleMapPath: AbsolutePath?
+        let frameworkModuleMapPath: URL?
         if let customFrameworkModuleMapContents = buildOptions.customFrameworkModuleMapContents {
             logger.info("📝 Using custom modulemap for \(buildProduct.target.name)(\(sdk.displayName))")
             frameworkModuleMapPath = try copyModuleMapContentsToBuildArtifacts(customFrameworkModuleMapContents)
@@ -74,7 +74,7 @@ struct FrameworkComponentsCollector {
         let generatedFrameworkPath = generatedFrameworkPath()
 
         let isVersionedBundle = fileSystem.exists(
-            generatedFrameworkPath.appending(component: "Resources").asURL,
+            generatedFrameworkPath.appending(component: "Resources"),
             followSymlink: true
         )
 
@@ -106,7 +106,7 @@ struct FrameworkComponentsCollector {
             binaryPath: binaryPath,
             infoPlistPath: infoPlistPath,
             swiftModulesPath: swiftModulesPath,
-            includeDir: buildProduct.target.resolvedModuleType.includeDir?.absolutePath,
+            includeDir: buildProduct.target.resolvedModuleType.includeDir,
             publicHeaderPaths: publicHeaders,
             bridgingHeaderPath: bridgingHeaderPath,
             modulemapPath: frameworkModuleMapPath,
@@ -116,14 +116,14 @@ struct FrameworkComponentsCollector {
     }
 
     /// Copy content data to the build artifacts
-    private func copyModuleMapContentsToBuildArtifacts(_ data: Data) throws -> AbsolutePath {
+    private func copyModuleMapContentsToBuildArtifacts(_ data: Data) throws -> URL {
         let generatedModuleMapPath = try packageLocator.generatedModuleMapPath(of: buildProduct.target, sdk: sdk)
 
-        try fileSystem.writeFileContents(generatedModuleMapPath.asURL, data: data)
+        try fileSystem.writeFileContents(generatedModuleMapPath, data: data)
         return generatedModuleMapPath
     }
 
-    private func generateFrameworkModuleMap() throws -> AbsolutePath? {
+    private func generateFrameworkModuleMap() throws -> URL? {
         let modulemapGenerator = FrameworkModuleMapGenerator(
             packageLocator: packageLocator,
             fileSystem: fileSystem
@@ -140,23 +140,23 @@ struct FrameworkComponentsCollector {
         return frameworkModuleMapPath
     }
 
-    private func generatedFrameworkPath() -> AbsolutePath {
+    private func generatedFrameworkPath() -> URL {
         productsDirectory.appending(component: "\(buildProduct.target.c99name).framework")
     }
 
-    private func generatedResourceBundlePath() -> AbsolutePath? {
+    private func generatedResourceBundlePath() -> URL? {
         let bundleName: String? = buildProduct.target.underlying.bundleName(for: buildProduct.package.manifest)
 
         guard let bundleName else { return nil }
 
         let path = productsDirectory.appending(component: "\(bundleName).bundle")
-        return fileSystem.exists(path.asURL) ? path : nil
+        return fileSystem.exists(path) ? path : nil
     }
 
     private func collectInfoPlist(
-        in frameworkBundlePath: AbsolutePath,
+        in frameworkBundlePath: URL,
         isVersionedBundle: Bool
-    ) throws -> AbsolutePath {
+    ) throws -> URL {
         let infoPlistLocation = if isVersionedBundle {
             // In a versioned framework bundle (for macOS), Info.plist should be in Resources
             frameworkBundlePath.appending(components: "Resources", "Info.plist")
@@ -165,7 +165,7 @@ struct FrameworkComponentsCollector {
             frameworkBundlePath.appending(component: "Info.plist")
         }
 
-        if fileSystem.exists(infoPlistLocation.asURL) {
+        if fileSystem.exists(infoPlistLocation) {
             return infoPlistLocation
         } else {
             throw Error.infoPlistNotFound(frameworkBundlePath: frameworkBundlePath)
@@ -173,24 +173,24 @@ struct FrameworkComponentsCollector {
     }
 
     /// Collects *.swiftmodules* in a generated framework bundle
-    private func collectSwiftModules(of targetName: String, in frameworkPath: AbsolutePath) throws -> AbsolutePath? {
+    private func collectSwiftModules(of targetName: String, in frameworkPath: URL) throws -> URL? {
         let swiftModulesPath = frameworkPath.appending(
             components: "Modules", "\(targetName).swiftmodule"
         )
 
-        if fileSystem.exists(swiftModulesPath.asURL) {
+        if fileSystem.exists(swiftModulesPath) {
             return swiftModulesPath
         }
         return nil
     }
 
     /// Collects a bridging header in a generated framework bundle
-    private func collectBridgingHeader(of targetName: String, in frameworkPath: AbsolutePath) throws -> AbsolutePath? {
+    private func collectBridgingHeader(of targetName: String, in frameworkPath: URL) throws -> URL? {
         let generatedBridgingHeader = frameworkPath.appending(
             components: "Headers", "\(targetName)-Swift.h"
         )
 
-        if fileSystem.exists(generatedBridgingHeader.asURL) {
+        if fileSystem.exists(generatedBridgingHeader) {
             return generatedBridgingHeader
         }
 
@@ -198,13 +198,13 @@ struct FrameworkComponentsCollector {
     }
 
     /// Collects public headers of clangTarget
-    private func collectPublicHeaders() throws -> Set<AbsolutePath>? {
+    private func collectPublicHeaders() throws -> Set<URL>? {
         guard case let .clang(_, publicHeaders) = buildProduct.target.resolvedModuleType else {
             return nil
         }
 
         let notSymlinks = publicHeaders.filter { !fileSystem.isSymlink($0) }
-            .map { $0.absolutePath }
+            .map { $0 }
         let symlinks = publicHeaders.filter { fileSystem.isSymlink($0) }
 
         // Sometimes, public headers include a file and its symlink both.
@@ -214,9 +214,13 @@ struct FrameworkComponentsCollector {
             // `FileManager.contentsEqual` does not traverse symbolic links, but compares the links themselves.
             // So we need to resolve the links beforehand.
             .map { $0.resolvingSymlinksInPath() }
-            .map(\.absolutePath)
             .filter { path in
-                notSymlinks.allSatisfy { !FileManager.default.contentsEqual(atPath: path.pathString, andPath: $0.pathString) }
+                notSymlinks.allSatisfy {
+                    !FileManager.default.contentsEqual(
+                        atPath: path.path(percentEncoded: false),
+                        andPath: $0.path(percentEncoded: false)
+                    )
+                }
             }
 
         return Set(notSymlinks + notDuplicatedSymlinks)

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 
 // A generator to generate modulemaps which are distributed in the XCFramework
 struct FrameworkModuleMapGenerator {

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -13,12 +13,12 @@ struct FrameworkModuleMapGenerator {
     private var fileSystem: any FileSystem
 
     enum Error: LocalizedError {
-        case unableToLoadCustomModuleMap(AbsolutePath)
+        case unableToLoadCustomModuleMap(URL)
 
         var errorDescription: String? {
             switch self {
             case .unableToLoadCustomModuleMap(let customModuleMapPath):
-                return "Something went wrong to load \(customModuleMapPath.pathString)"
+                return "Something went wrong to load \(customModuleMapPath.path(percentEncoded: false))"
             }
         }
     }
@@ -32,7 +32,7 @@ struct FrameworkModuleMapGenerator {
         resolvedTarget: ResolvedModule,
         sdk: SDK,
         keepPublicHeadersStructure: Bool
-    ) throws -> AbsolutePath? {
+    ) throws -> URL? {
         let context = Context(
             resolvedTarget: resolvedTarget,
             sdk: sdk,
@@ -67,23 +67,23 @@ struct FrameworkModuleMapGenerator {
         if let moduleMapType {
             switch moduleMapType {
             case .custom(let customModuleMap):
-                return try convertCustomModuleMapForFramework(customModuleMap.absolutePath)
+                return try convertCustomModuleMapForFramework(customModuleMap)
                     .trimmingCharacters(in: .whitespacesAndNewlines)
             case .umbrellaHeader(let headerPath):
                 return ([
                     "framework module \(context.resolvedTarget.c99name) {",
-                    "    umbrella header \"\(headerPath.absolutePath.basename)\"",
+                    "    umbrella header \"\(headerPath.lastPathComponent)\"",
                     "    export *",
                 ]
                 + generateLinkSection(context: context)
                 + ["}"])
                 .joined()
             case .umbrellaDirectory(let directoryPath):
-                let headers = try walkDirectoryContents(of: directoryPath.absolutePath)
+                let headers = try walkDirectoryContents(of: directoryPath)
                 let declarations = headers.map { header in
                     generateHeaderEntry(
                         for: header,
-                        of: directoryPath.absolutePath,
+                        of: directoryPath,
                         keepPublicHeadersStructure: context.keepPublicHeadersStructure
                     )
                 }
@@ -112,10 +112,10 @@ struct FrameworkModuleMapGenerator {
         }
     }
 
-    private func walkDirectoryContents(of directoryPath: AbsolutePath) throws -> Set<AbsolutePath> {
-        try fileSystem.getDirectoryContents(directoryPath.asURL).reduce(into: Set()) { headers, file in
+    private func walkDirectoryContents(of directoryPath: URL) throws -> Set<URL> {
+        try fileSystem.getDirectoryContents(directoryPath).reduce(into: Set()) { headers, file in
             let path = directoryPath.appending(component: file)
-            if fileSystem.isDirectory(path.asURL) {
+            if fileSystem.isDirectory(path) {
                 headers.formUnion(try walkDirectoryContents(of: path))
             } else if file.hasSuffix(".h") {
                 headers.insert(path)
@@ -124,23 +124,23 @@ struct FrameworkModuleMapGenerator {
     }
 
     private func generateHeaderEntry(
-        for header: AbsolutePath,
-        of directoryPath: AbsolutePath,
+        for header: URL,
+        of directoryPath: URL,
         keepPublicHeadersStructure: Bool
     ) -> String {
         if keepPublicHeadersStructure {
-            let subdirectoryComponents: [String] = if header.dirname.hasPrefix(directoryPath.pathString) {
-                header.dirname.dropFirst(directoryPath.pathString.count)
+            let subdirectoryComponents: [String] = if header.dirname.hasPrefix(directoryPath.path(percentEncoded: false)) {
+                header.dirname.dropFirst(directoryPath.path(percentEncoded: false).count)
                     .split(separator: "/")
                     .map(String.init)
             } else {
                 []
             }
 
-            let path = (subdirectoryComponents + [header.basename]).joined(separator: "/")
+            let path = (subdirectoryComponents + [header.lastPathComponent]).joined(separator: "/")
             return "    header \"\(path)\""
         } else {
-            return "    header \"\(header.basename)\""
+            return "    header \"\(header.lastPathComponent)\""
         }
     }
 
@@ -153,26 +153,26 @@ struct FrameworkModuleMapGenerator {
     private func generateModuleMapFile(
         context: Context,
         moduleMapType: ModuleMapType?,
-        outputPath: AbsolutePath
+        outputPath: URL
     ) throws {
         let dirPath = outputPath.parentDirectory
-        try fileSystem.createDirectory(dirPath.asURL, recursive: true)
+        try fileSystem.createDirectory(dirPath, recursive: true)
 
         let contents = try generateModuleMapContents(context: context, moduleMapType: moduleMapType)
-        try fileSystem.writeFileContents(outputPath.asURL, string: contents)
+        try fileSystem.writeFileContents(outputPath, string: contents)
     }
 
-    private func constructGeneratedModuleMapPath(context: Context) throws -> AbsolutePath {
+    private func constructGeneratedModuleMapPath(context: Context) throws -> URL {
         let generatedModuleMapPath = try packageLocator.generatedModuleMapPath(of: context.resolvedTarget, sdk: context.sdk)
         return generatedModuleMapPath
     }
 
-    private func convertCustomModuleMapForFramework(_ customModuleMap: AbsolutePath) throws -> String {
+    private func convertCustomModuleMapForFramework(_ customModuleMap: URL) throws -> String {
         // Sometimes, targets have their custom modulemaps.
         // However, these are not for frameworks
         // This process converts them to modulemaps for frameworks
         // like `module MyModule` to `framework module MyModule`
-        let rawData = try fileSystem.readFileContents(customModuleMap.asURL)
+        let rawData = try fileSystem.readFileContents(customModuleMap)
         guard let contents = String(bytes: rawData, encoding: .utf8) else {
             throw Error.unableToLoadCustomModuleMap(customModuleMap)
         }

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 
 struct PIFCompiler: Compiler {
     let descriptionPackage: DescriptionPackage

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 import PIFKit
 import TSCUtility
 

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -37,7 +37,7 @@ struct PIFGenerator {
             "package",
             "dump-pif",
             "--package-path",
-            packageLocator.packageDirectory.pathString,
+            packageLocator.packageDirectory.path(percentEncoded: false),
             "--build-system",
             "xcode",
         ]
@@ -46,7 +46,7 @@ struct PIFGenerator {
         return try PIFManipulator(jsonData: data)
     }
 
-    func generateJSON(for sdk: SDK) async throws -> AbsolutePath {
+    func generateJSON(for sdk: SDK) async throws -> Foundation.URL {
         let manipulator = try await buildPIFManipulator()
 
         manipulator.updateTargets { target in
@@ -57,7 +57,7 @@ struct PIFGenerator {
 
         let path = packageLocator.workspaceDirectory
             .appending(component: "manifest-\(packageName)-\(sdk.settingValue).pif")
-        try fileSystem.writeFileContents(path.asURL, data: newJSONData)
+        try fileSystem.writeFileContents(path, data: newJSONData)
         return path
     }
 
@@ -169,12 +169,12 @@ struct PIFGenerator {
             sdk: sdk
         )
         let bridgingHeaderFullPath = productsDirectory.appending(
-            components: ["\(target.c99Name).framework", "Headers", "\(target.name)-Swift.h"]
+            components: "\(target.c99Name).framework", "Headers", "\(target.name)-Swift.h"
         )
 
         configuration.buildSettings["MODULEMAP_FILE_CONTENTS"] = .string("""
         module \(target.c99Name) {
-            header "\(bridgingHeaderFullPath.pathString)"
+            header "\(bridgingHeaderFullPath.path(percentEncoded: false))"
             export *
         }
         """)
@@ -198,7 +198,7 @@ struct PIFGenerator {
             // `CFBundleExecutable` is not allowed for Info.plist contains in resource bundles.
             // So generating a Info.plist and set this
             mutableConfiguration.buildSettings["GENERATE_INFOPLIST_FILE"] = false
-            mutableConfiguration.buildSettings["INFOPLIST_FILE"] = .string(infoPlistPath.pathString)
+            mutableConfiguration.buildSettings["INFOPLIST_FILE"] = .string(infoPlistPath.path(percentEncoded: false))
             return mutableConfiguration
         }
     }

--- a/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/ToolchainGenerator.swift
@@ -2,12 +2,12 @@ import Foundation
 import TSCBasic
 
 struct ToolchainGenerator {
-    private let toolchainDirPath: AbsolutePath
+    private let toolchainDirPath: URL
     private let environment: [String: String]?
     private let executor: any Executor
 
     init(
-        toolchainDirPath: AbsolutePath,
+        toolchainDirPath: URL,
         environment: [String: String]? = nil,
         executor: any Executor = ProcessExecutor()
     ) {
@@ -25,16 +25,16 @@ struct ToolchainGenerator {
         )
             .unwrapOutput()
             .spm_chomp()
-        let sdkPath = try AbsolutePath(validating: sdkPathString)
+        let sdkPath = URL(filePath: sdkPathString)
 
         // Compute common arguments for clang and swift.
         var extraCCFlags: [String] = []
         var extraSwiftCFlags: [String] = []
         let macosSDKPlatformPaths = try await resolveSDKPlatformFrameworkPaths()
-        extraCCFlags += ["-F", macosSDKPlatformPaths.frameworkPath.pathString]
-        extraSwiftCFlags += ["-F", macosSDKPlatformPaths.frameworkPath.pathString]
-        extraSwiftCFlags += ["-I", macosSDKPlatformPaths.libPath.pathString]
-        extraSwiftCFlags += ["-L", macosSDKPlatformPaths.libPath.pathString]
+        extraCCFlags += ["-F", macosSDKPlatformPaths.frameworkPath.path(percentEncoded: false)]
+        extraSwiftCFlags += ["-F", macosSDKPlatformPaths.frameworkPath.path(percentEncoded: false)]
+        extraSwiftCFlags += ["-I", macosSDKPlatformPaths.libPath.path(percentEncoded: false)]
+        extraSwiftCFlags += ["-L", macosSDKPlatformPaths.libPath.path(percentEncoded: false)]
 
         let clangCompilerPath = try await resolveClangCompilerPath()
         let swiftCompilerPath = try await resolveSwiftCompilerPath()
@@ -46,7 +46,7 @@ struct ToolchainGenerator {
             clangCompilerPath: clangCompilerPath,
             swiftCompilerPath: swiftCompilerPath,
             toolchainLibDir: toolchainLibDir,
-            sdkPath: sdkPath.asURL,
+            sdkPath: sdkPath,
             extraFlags: UserToolchain.ExtraFlags(
                 cCompilerFlags: extraCCFlags,
                 cxxCompilerFlags: [],
@@ -86,7 +86,7 @@ extension ToolchainGenerator {
     /// This implementation is based on the original SwiftPM
     /// https://github.com/swiftlang/swift-package-manager/blob/release/6.0/Sources/PackageModel/SwiftSDKs/SwiftSDK.swift#L592-L595
     /// Returns `macosx` sdk platform framework path.
-    fileprivate func resolveSDKPlatformFrameworkPaths() async throws -> (frameworkPath: AbsolutePath, libPath: AbsolutePath) {
+    fileprivate func resolveSDKPlatformFrameworkPaths() async throws -> (frameworkPath: URL, libPath: URL) {
         let platformPath = try await executor.execute(
             "/usr/bin/xcrun",
             "--sdk",
@@ -101,12 +101,12 @@ extension ToolchainGenerator {
         }
 
         // For XCTest framework.
-        let frameworkPath = try AbsolutePath(validating: platformPath).appending(
+        let frameworkPath = URL(filePath: platformPath).appending(
             components: "Developer", "Library", "Frameworks"
         )
 
         // For XCTest Swift library.
-        let libPath = try AbsolutePath(validating: platformPath).appending(
+        let libPath = URL(filePath: platformPath).appending(
             components: "Developer", "usr", "lib"
         )
 

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -1,5 +1,4 @@
 import Foundation
-import TSCBasic
 
 struct XCBuildClient {
     enum Error: LocalizedError {

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -74,8 +74,8 @@ struct XCBuildClient {
 
     func buildFramework(
         sdk: SDK,
-        pifPath: AbsolutePath,
-        buildParametersPath: AbsolutePath
+        pifPath: URL,
+        buildParametersPath: URL
     ) async throws -> URL {
         let xcbuildPath = try await fetchXCBuildPath()
 
@@ -121,7 +121,7 @@ struct XCBuildClient {
         return try assembler.assemble()
     }
 
-    private func assembledFrameworkPath(target: ResolvedModule, of sdk: SDK) throws -> AbsolutePath {
+    private func assembledFrameworkPath(target: ResolvedModule, of sdk: SDK) throws -> URL {
         let assembledFrameworkDir = packageLocator.assembledFrameworksDirectory(
             buildConfiguration: buildOptions.buildConfiguration,
             sdk: sdk
@@ -132,8 +132,8 @@ struct XCBuildClient {
 
     func createXCFramework(
         sdks: Set<SDK>,
-        debugSymbols: [SDK: [AbsolutePath]]?,
-        outputPath: AbsolutePath
+        debugSymbols: [SDK: [URL]]?,
+        outputPath: URL
     ) async throws {
         let xcbuildPath = try await fetchXCBuildPath()
 
@@ -153,21 +153,21 @@ struct XCBuildClient {
 
     private func buildCreateXCFrameworkArguments(
         sdks: Set<SDK>,
-        debugSymbols: [SDK: [AbsolutePath]]?,
-        outputPath: AbsolutePath
+        debugSymbols: [SDK: [URL]]?,
+        outputPath: URL
     ) throws -> [String] {
         let frameworksWithDebugSymbolArguments: [String] = try sdks.reduce([]) { arguments, sdk in
             let path = try assembledFrameworkPath(target: buildProduct.target, of: sdk)
-            var result = arguments + ["-framework", path.pathString]
+            var result = arguments + ["-framework", path.path(percentEncoded: false)]
             if let debugSymbols, let paths = debugSymbols[sdk] {
                 paths.forEach { path in
-                    result += ["-debug-symbols", path.pathString]
+                    result += ["-debug-symbols", path.path(percentEncoded: false)]
                 }
             }
             return result
         }
 
-        let outputPathArguments: [String] = ["-output", outputPath.pathString]
+        let outputPathArguments: [String] = ["-output", outputPath.path(percentEncoded: false)]
 
         // Default behavior, this command requires swiftinterface. If they don't exist, `-allow-internal-distribution` must be required.
         let additionalFlags = buildOptions.enableLibraryEvolution ? [] : ["-allow-internal-distribution"]

--- a/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Logging
-import TSCBasic
 import Algorithms
 
 struct XCBuildExecutor {

--- a/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
@@ -8,22 +8,22 @@ struct XCBuildExecutor {
     var xcbuildPath: URL
 
     func build(
-        pifPath: AbsolutePath,
+        pifPath: URL,
         configuration: BuildConfiguration,
-        derivedDataPath: AbsolutePath,
-        buildParametersPath: AbsolutePath,
+        derivedDataPath: URL,
+        buildParametersPath: URL,
         target: ResolvedModule
     ) async throws {
         let executor = _Executor(args: [
             xcbuildPath.path(percentEncoded: false),
             "build",
-            pifPath.pathString,
+            pifPath.path(percentEncoded: false),
             "--configuration",
             configuration.settingsValue,
             "--derivedDataPath",
-            derivedDataPath.pathString,
+            derivedDataPath.path(percentEncoded: false),
             "--buildParametersFile",
-            buildParametersPath.pathString,
+            buildParametersPath.path(percentEncoded: false),
             "--target",
             target.name,
         ])

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ScipioStorage
-import TSCBasic
 
 public typealias PlatformMatrix = [String: Set<SDK>]
 

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -53,9 +53,9 @@ public struct Runner {
         fileprivate func resolve(packageDirectory: URL) -> URL {
             switch self {
             case .default:
-                return packageDirectory.appendingPathComponent("XCFrameworks")
+                packageDirectory.appendingPathComponent("XCFrameworks")
             case .custom(let url):
-                return url
+                url
             }
         }
     }

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -38,14 +38,11 @@ public struct Runner {
         self.fileSystem = fileSystem
     }
 
-    private func resolveURL(_ fileURL: URL) throws -> AbsolutePath {
-        if fileURL.path.hasPrefix("/") {
-            return try AbsolutePath(validating: fileURL.path)
-        } else if let currentDirectory = fileSystem.currentWorkingDirectory {
-            let scipioCurrentDirectory = currentDirectory.absolutePath
-            return try AbsolutePath(scipioCurrentDirectory, validating: fileURL.path)
+    private func resolveURL(_ fileURL: URL) -> URL {
+        if let currentDirectory = fileSystem.currentWorkingDirectory {
+            URL(filePath: fileURL.path, relativeTo: currentDirectory)
         } else {
-            return try! AbsolutePath(validating: fileURL.path)
+            URL(filePath: fileURL.path)
         }
     }
 
@@ -64,7 +61,7 @@ public struct Runner {
     }
 
     public func run(packageDirectory: URL, frameworkOutputDir: OutputDirectory) async throws {
-        let packagePath = try resolveURL(packageDirectory)
+        let packagePath = resolveURL(packageDirectory)
         let descriptionPackage: DescriptionPackage
 
         logger.info("🔁 Resolving Dependencies...")
@@ -83,7 +80,7 @@ public struct Runner {
             throw Error.platformNotSpecified
         }
 
-        try fileSystem.createDirectory(descriptionPackage.workspaceDirectory.asURL, recursive: true)
+        try fileSystem.createDirectory(descriptionPackage.workspaceDirectory, recursive: true)
 
         let outputDir = frameworkOutputDir.resolve(packageDirectory: packageDirectory)
 

--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -37,14 +37,6 @@ public struct Runner {
         self.fileSystem = fileSystem
     }
 
-    private func resolveURL(_ fileURL: URL) -> URL {
-        if let currentDirectory = fileSystem.currentWorkingDirectory {
-            URL(filePath: fileURL.path, relativeTo: currentDirectory)
-        } else {
-            URL(filePath: fileURL.path)
-        }
-    }
-
     public enum OutputDirectory {
         case `default`
         case custom(URL)
@@ -60,13 +52,12 @@ public struct Runner {
     }
 
     public func run(packageDirectory: URL, frameworkOutputDir: OutputDirectory) async throws {
-        let packagePath = resolveURL(packageDirectory)
         let descriptionPackage: DescriptionPackage
 
         logger.info("🔁 Resolving Dependencies...")
         do {
             descriptionPackage = try await DescriptionPackage(
-                packageDirectory: packagePath,
+                packageDirectory: packageDirectory,
                 mode: mode,
                 onlyUseVersionsFromResolvedFile: options.shouldOnlyUseVersionsFromResolvedFile
             )

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -4,7 +4,11 @@ import Foundation
 extension URL {
     // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L598-L614
     var dirname: String {
-        let path = self.standardizedFileURL.path(percentEncoded: false)
+        var path = self.standardizedFileURL.path(percentEncoded: false)
+        // Normalize path by removing trailing '/' to treat '/path/to/' and '/path/to' equivalently
+        if path.hasSuffix("/") && path != "/" {
+            path.removeLast()
+        }
         guard let idx = path.lastIndex(of: "/") else {
             // No path separators, so directory is current directory
             return "."
@@ -19,7 +23,7 @@ extension URL {
 
     // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L661-L663
     var parentDirectory: URL {
-        standardizedFileURL.path(percentEncoded: false) == "/" ? self : URL(filePath: dirname)
+        path(percentEncoded: false) == "/" ? self : URL(filePath: dirname, directoryHint: .isDirectory)
     }
 
     func appending(components: [String]) -> URL {

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -19,7 +19,7 @@ extension URL {
 
     // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L661-L663
     var parentDirectory: URL {
-        pathComponents.isEmpty ? self : deletingLastPathComponent()
+        standardizedFileURL.path(percentEncoded: false) == "/" ? self : standardizedFileURL.deletingLastPathComponent()
     }
 
     func appending(components: [String]) -> URL {

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -18,7 +18,7 @@ extension URL {
 
     // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L661-L663
     var parentDirectory: URL {
-        dirname.isEmpty ? self : deletingLastPathComponent()
+        pathComponents.isEmpty ? self : deletingLastPathComponent()
     }
 
     func appending(components: [String]) -> URL {

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Extensions for compatibility with TSC's Path implementation.
 extension URL {
     // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L598-L614
     var dirname: String {

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -19,7 +19,7 @@ extension URL {
 
     // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L661-L663
     var parentDirectory: URL {
-        standardizedFileURL.path(percentEncoded: false) == "/" ? self : standardizedFileURL.deletingLastPathComponent()
+        standardizedFileURL.path(percentEncoded: false) == "/" ? self : URL(filePath: dirname)
     }
 
     func appending(components: [String]) -> URL {

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -3,7 +3,7 @@ import Foundation
 extension URL {
     // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L598-L614
     var dirname: String {
-        let path = self.standardizedFileURL.path
+        let path = self.standardizedFileURL.path(percentEncoded: false)
         guard let idx = path.lastIndex(of: "/") else {
             // No path separators, so directory is current directory
             return "."

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -1,8 +1,25 @@
 import Foundation
-import TSCBasic
 
 extension URL {
-    var absolutePath: AbsolutePath {
-        return try! AbsolutePath(validating: path)
+    var dirname: String {
+        let path = self.standardizedFileURL.path
+        guard let idx = path.lastIndex(of: "/") else {
+            // No path separators, so directory is current directory
+            return "."
+        }
+        // If the only separator is the first character, it's the root directory
+        if idx == path.startIndex {
+            return "/"
+        }
+        // Otherwise, return everything up to (but not including) the last separator
+        return String(path.prefix(upTo: idx))
+    }
+
+    var parentDirectory: URL {
+        dirname.isEmpty ? self : deletingLastPathComponent()
+    }
+
+    func appending(components: [String]) -> URL {
+        components.reduce(self) { $0.appending(component: $1) }
     }
 }

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 extension URL {
+    // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L598-L614
     var dirname: String {
         let path = self.standardizedFileURL.path
         guard let idx = path.lastIndex(of: "/") else {
@@ -15,6 +16,7 @@ extension URL {
         return String(path.prefix(upTo: idx))
     }
 
+    // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L661-L663
     var parentDirectory: URL {
         dirname.isEmpty ? self : deletingLastPathComponent()
     }

--- a/Sources/ScipioKit/URL+Extensions.swift
+++ b/Sources/ScipioKit/URL+Extensions.swift
@@ -23,7 +23,7 @@ extension URL {
 
     // ref: https://github.com/swiftlang/swift-tools-support-core/blob/f9b401016b70c6b8409e5c97e74d97513d1a8d02/Sources/TSCBasic/Path.swift#L661-L663
     var parentDirectory: URL {
-        path(percentEncoded: false) == "/" ? self : URL(filePath: dirname, directoryHint: .isDirectory)
+        path(percentEncoded: false) == "/" ? self : URL(filePath: dirname)
     }
 
     func appending(components: [String]) -> URL {

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import ScipioKit
 import XCTest
-import TSCBasic
 
 private let fixturePath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -112,7 +112,7 @@ final class CacheSystemTests: XCTestCase {
 
         func scipioTestingCacheKey(fixture: String) async throws -> SwiftPMCacheKey {
             let descriptionPackage = try await DescriptionPackage(
-                packageDirectory: tempCacheKeyTestsDir.appending(component: fixture).absolutePath,
+                packageDirectory: tempCacheKeyTestsDir.appending(component: fixture),
                 mode: .createPackage,
                 onlyUseVersionsFromResolvedFile: false
             )
@@ -175,7 +175,7 @@ final class CacheSystemTests: XCTestCase {
         defer { try? fileSystem.removeFileTree(tempTestingPackagePath) }
 
         let descriptionPackage = try await DescriptionPackage(
-            packageDirectory: tempTestingPackagePath.absolutePath,
+            packageDirectory: tempTestingPackagePath,
             mode: .createPackage,
             onlyUseVersionsFromResolvedFile: false
         )

--- a/Tests/ScipioKitTests/DebugSymbolTests.swift
+++ b/Tests/ScipioKitTests/DebugSymbolTests.swift
@@ -28,7 +28,7 @@ struct DwarfExtractorTests {
         }
         let extractor = DwarfExtractor(executor: executor)
         let dwarfPath = URL(fileURLWithPath: "/dev/null")
-        let uuids = try await extractor.dump(dwarfPath: dwarfPath.absolutePath)
+        let uuids = try await extractor.dump(dwarfPath: dwarfPath)
 
         let firstArguments = try #require(executor.calledArguments.first)
         #expect(firstArguments == ["/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.path])

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -11,7 +11,7 @@ final class DescriptionPackageTests: XCTestCase {
     func testDescriptionPackage() async throws {
         let rootPath = fixturePath.appendingPathComponent("TestingPackage")
         let package = try await DescriptionPackage(
-            packageDirectory: rootPath.absolutePath,
+            packageDirectory: rootPath,
             mode: .prepareDependencies,
             onlyUseVersionsFromResolvedFile: false
         )
@@ -21,12 +21,12 @@ final class DescriptionPackageTests: XCTestCase {
         XCTAssertEqual(packageNames.sorted(), ["TestingPackage", "swift-log"].sorted())
 
         XCTAssertEqual(
-            package.workspaceDirectory.pathString,
+            package.workspaceDirectory.path(percentEncoded: false),
             rootPath.appendingPathComponent(".build/scipio").path
         )
 
         XCTAssertEqual(
-            package.derivedDataPath.pathString,
+            package.derivedDataPath.path(percentEncoded: false),
             rootPath.appendingPathComponent(".build/scipio/DerivedData").path
         )
     }
@@ -34,7 +34,7 @@ final class DescriptionPackageTests: XCTestCase {
     func testBuildProductsInPrepareMode() async throws {
         let rootPath = fixturePath.appendingPathComponent("IntegrationTestPackage")
         let package = try await DescriptionPackage(
-            packageDirectory: rootPath.absolutePath,
+            packageDirectory: rootPath,
             mode: .prepareDependencies,
             onlyUseVersionsFromResolvedFile: false
         )
@@ -70,7 +70,7 @@ final class DescriptionPackageTests: XCTestCase {
     func testBuildProductsInCreateMode() async throws {
         let rootPath = fixturePath.appendingPathComponent("TestingPackage")
         let package = try await DescriptionPackage(
-            packageDirectory: rootPath.absolutePath,
+            packageDirectory: rootPath,
             mode: .createPackage,
             onlyUseVersionsFromResolvedFile: false
         )
@@ -91,7 +91,7 @@ final class DescriptionPackageTests: XCTestCase {
     func testBinaryBuildProductsInCreateMode() async throws {
         let rootPath = fixturePath.appendingPathComponent("BinaryPackage")
         let package = try await DescriptionPackage(
-            packageDirectory: rootPath.absolutePath,
+            packageDirectory: rootPath,
             mode: .createPackage,
             onlyUseVersionsFromResolvedFile: false
         )

--- a/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
@@ -17,7 +17,6 @@ struct FrameworkBundleAssemblerTests {
         self.temporaryDirectory = fileSystem
             .tempDirectory
             .appending(components: "FrameworkBundleAssemblerTests")
-            
     }
 
     @Test

--- a/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import ScipioKit
 import Testing
-import TSCBasic
 
 private let fixturesPath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()

--- a/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
@@ -11,41 +11,41 @@ private let fixturesPath = URL(fileURLWithPath: #filePath)
 @Suite(.serialized)
 struct FrameworkBundleAssemblerTests {
     let fileSystem: LocalFileSystem = .default
-    let temporaryDirectory: AbsolutePath
+    let temporaryDirectory: URL
 
     init() {
         self.temporaryDirectory = fileSystem
             .tempDirectory
             .appending(components: "FrameworkBundleAssemblerTests")
-            .absolutePath
+            
     }
 
     @Test
     func copyHeaders_keepPublicHeadersStructure_is_false() throws {
         let outputDirectory = temporaryDirectory.appending(component: #function)
-        defer { try? fileSystem.removeFileTree(outputDirectory.asURL) }
+        defer { try? fileSystem.removeFileTree(outputDirectory) }
 
         try assembleFramework(keepPublicHeadersStructure: false, outputDirectory: outputDirectory)
 
         let frameworkHeadersPath = outputDirectory.appending(components: "Foo.framework", "Headers")
-        #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath.asURL)) == ["foo.h", "bar.h"])
+        #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath)) == ["foo.h", "bar.h"])
     }
 
     @Test
     func copyHeaders_keepPublicHeadersStructure_is_true() throws {
         let outputDirectory = temporaryDirectory.appending(component: #function)
-        defer { try? fileSystem.removeFileTree(outputDirectory.asURL) }
+        defer { try? fileSystem.removeFileTree(outputDirectory) }
 
         try assembleFramework(keepPublicHeadersStructure: true, outputDirectory: outputDirectory)
 
         let frameworkHeadersPath = outputDirectory.appending(components: "Foo.framework", "Headers")
-        #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath.asURL)) == ["foo", "bar"])
-        #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath.appending(component: "foo").asURL)) == ["foo.h"])
-        #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath.appending(component: "bar").asURL)) == ["bar.h"])
+        #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath)) == ["foo", "bar"])
+        #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath.appending(component: "foo"))) == ["foo.h"])
+        #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath.appending(component: "bar"))) == ["bar.h"])
     }
 
-    private func assembleFramework(keepPublicHeadersStructure: Bool, outputDirectory: AbsolutePath) throws {
-        let fixture = fixturesPath.appendingPathComponent("FrameworkBundleAssemblerTests").absolutePath
+    private func assembleFramework(keepPublicHeadersStructure: Bool, outputDirectory: URL) throws {
+        let fixture = fixturesPath.appendingPathComponent("FrameworkBundleAssemblerTests")
         let frameworkComponents = FrameworkComponents(
             isVersionedBundle: false,
             frameworkName: "Foo",

--- a/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
+++ b/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import ScipioKit
 import Testing
-import TSCBasic
 
 private let fixturesPath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()

--- a/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
+++ b/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
@@ -10,7 +10,7 @@ private let fixturesPath = URL(fileURLWithPath: #filePath)
 private let clangPackageWithUmbrellaDirectoryPath = fixturesPath.appendingPathComponent("ClangPackageWithUmbrellaDirectory")
 
 private struct PackageLocatorMock: PackageLocator {
-    let packageDirectory: AbsolutePath
+    let packageDirectory: URL
 }
 
 @Suite(.serialized)
@@ -31,7 +31,7 @@ struct FrameworkModuleMapGeneratorTests {
 
         let generatedModuleMapContents = try await generateModuleMap(
             keepPublicHeadersStructure: false,
-            outputDirectory: outputDirectory.absolutePath
+            outputDirectory: outputDirectory
         )
         let expectedModuleMapContents = """
 framework module MyTarget {
@@ -53,7 +53,7 @@ framework module MyTarget {
 
         let generatedModuleMapContents = try await generateModuleMap(
             keepPublicHeadersStructure: true,
-            outputDirectory: outputDirectory.absolutePath
+            outputDirectory: outputDirectory
         )
         let expectedModuleMapContents = """
 framework module MyTarget {
@@ -70,7 +70,7 @@ framework module MyTarget {
 
     private func generateModuleMap(
         keepPublicHeadersStructure: Bool,
-        outputDirectory: AbsolutePath
+        outputDirectory: URL
     ) async throws -> String {
         let packageLocator = PackageLocatorMock(packageDirectory: outputDirectory)
         let generator = FrameworkModuleMapGenerator(
@@ -79,7 +79,7 @@ framework module MyTarget {
         )
 
         let descriptionPackage = try await DescriptionPackage(
-            packageDirectory: clangPackageWithUmbrellaDirectoryPath.absolutePath,
+            packageDirectory: clangPackageWithUmbrellaDirectoryPath,
             mode: .createPackage,
             onlyUseVersionsFromResolvedFile: false
         )
@@ -89,7 +89,7 @@ framework module MyTarget {
             keepPublicHeadersStructure: keepPublicHeadersStructure
         )
 
-        let generatedModuleMapData = try Data(contentsOf: #require(generatedModuleMapPath).asURL)
+        let generatedModuleMapData = try Data(contentsOf: #require(generatedModuleMapPath))
         let generatedModuleMapContents = String(decoding: generatedModuleMapData, as: UTF8.self)
         return generatedModuleMapContents
     }

--- a/Tests/ScipioKitTests/InfoPlistGeneratorTests.swift
+++ b/Tests/ScipioKitTests/InfoPlistGeneratorTests.swift
@@ -17,7 +17,7 @@ final class InfoPlistGeneratorTests: XCTestCase {
     }
 
     func testGenerateForBundle() throws {
-        try generator.generateForResourceBundle(at: temporaryPath.absolutePath)
+        try generator.generateForResourceBundle(at: temporaryPath)
 
         let infoPlistBodyData = try fileSystem.readFileContents(temporaryPath)
         let infoPlistBody = try XCTUnwrap(String(data: infoPlistBodyData, encoding: .utf8))

--- a/Tests/ScipioKitTests/InfoPlistGeneratorTests.swift
+++ b/Tests/ScipioKitTests/InfoPlistGeneratorTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import XCTest
 @testable import ScipioKit
-import TSCBasic
 
 final class InfoPlistGeneratorTests: XCTestCase {
     let fileSystem: LocalFileSystem = .default

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -270,7 +270,7 @@ final class RunnerTests: XCTestCase {
 
     func testCacheIsValid() async throws {
         let descriptionPackage = try await DescriptionPackage(
-            packageDirectory: testPackagePath.absolutePath,
+            packageDirectory: testPackagePath,
             mode: .prepareDependencies,
             onlyUseVersionsFromResolvedFile: false
         )
@@ -496,7 +496,7 @@ final class RunnerTests: XCTestCase {
     func testBinaryHasValidCache() async throws {
         // Generate VersionFile
         let descriptionPackage = try await DescriptionPackage(
-            packageDirectory: usingBinaryPackagePath.absolutePath,
+            packageDirectory: usingBinaryPackagePath,
             mode: .prepareDependencies,
             onlyUseVersionsFromResolvedFile: false
         )

--- a/Tests/ScipioKitTests/URLExtensionsTests.swift
+++ b/Tests/ScipioKitTests/URLExtensionsTests.swift
@@ -1,0 +1,31 @@
+import Testing
+import Foundation
+@testable import ScipioKit
+
+struct URLExtensionsTests {
+    @Test("dirname returns the parent path component for given file paths", arguments: [
+        ("/path/to/test.txt", "/path/to"),
+        ("/test.txt", "/"),
+        ("/", "/"),
+        ("/path//to///test.txt", "/path/to"),
+        ("/path/to/", "/path/to"),
+        ("///multiple///slashes///test.txt", "/multiple/slashes"),
+        ("/path/to/../..", "/"),
+        ("/path/to/../test.txt", "/path"),
+    ])
+    func dirname(input: String, expected: String) {
+        let url = URL(filePath: input)
+        #expect(url.dirname == expected)
+    }
+
+    @Test("parentDirectory returns the parent directory URL for given file paths", arguments: [
+        ("/path/to/documents/projects", "/path/to/documents/"),
+        ("/path/to/../test.txt", "/path/"),
+        ("/", "/"),
+    ])
+    func parentDirectory(input: String, expectedPath: String) {
+        let url = URL(filePath: input)
+        let expected = URL(filePath: expectedPath)
+        #expect(url.parentDirectory == expected)
+    }
+}

--- a/Tests/ScipioKitTests/URLExtensionsTests.swift
+++ b/Tests/ScipioKitTests/URLExtensionsTests.swift
@@ -1,7 +1,6 @@
 import Testing
 import Foundation
 @testable import ScipioKit
-import TSCBasic
 
 struct URLExtensionsTests {
     @Test("dirname returns the parent path component for given file paths", arguments: [

--- a/Tests/ScipioKitTests/URLExtensionsTests.swift
+++ b/Tests/ScipioKitTests/URLExtensionsTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 @testable import ScipioKit
+import TSCBasic
 
 struct URLExtensionsTests {
     @Test("dirname returns the parent path component for given file paths", arguments: [
@@ -20,15 +21,15 @@ struct URLExtensionsTests {
     }
 
     @Test("parentDirectory returns the parent directory URL for given file paths", arguments: [
-        ("/path/to/test.txt", "/path/to/"),
+        ("/path/to/test.txt", "/path/to"),
         ("/test.txt", "/"),
         ("/", "/"),
-        ("/path//to///test.txt", "/path/to/"),
-        ("/path/to/", "/path/"),
-        ("/path/to", "/path/"),
-        ("///multiple///slashes///test.txt", "/multiple/slashes/"),
+        ("/path//to///test.txt", "/path/to"),
+        ("/path/to/", "/path"),
+        ("/path/to", "/path"),
+        ("///multiple///slashes///test.txt", "/multiple/slashes"),
         ("/path/to/../..", "/"),
-        ("/path/to/../test.txt", "/path/"),
+        ("/path/to/../test.txt", "/path"),
     ])
     func parentDirectory(input: String, expectedPath: String) {
         let url = URL(filePath: input)

--- a/Tests/ScipioKitTests/URLExtensionsTests.swift
+++ b/Tests/ScipioKitTests/URLExtensionsTests.swift
@@ -8,7 +8,8 @@ struct URLExtensionsTests {
         ("/test.txt", "/"),
         ("/", "/"),
         ("/path//to///test.txt", "/path/to"),
-        ("/path/to/", "/path/to"),
+        ("/path/to/", "/path"),
+        ("/path/to", "/path"),
         ("///multiple///slashes///test.txt", "/multiple/slashes"),
         ("/path/to/../..", "/"),
         ("/path/to/../test.txt", "/path"),
@@ -19,18 +20,18 @@ struct URLExtensionsTests {
     }
 
     @Test("parentDirectory returns the parent directory URL for given file paths", arguments: [
-        ("/path/to/test.txt", "/path/to"),
+        ("/path/to/test.txt", "/path/to/"),
         ("/test.txt", "/"),
         ("/", "/"),
-        ("/path//to///test.txt", "/path/to"),
-        ("/path/to/", "/path/to"),
-        ("///multiple///slashes///test.txt", "/multiple/slashes"),
+        ("/path//to///test.txt", "/path/to/"),
+        ("/path/to/", "/path/"),
+        ("/path/to", "/path/"),
+        ("///multiple///slashes///test.txt", "/multiple/slashes/"),
         ("/path/to/../..", "/"),
-        ("/path/to/../test.txt", "/path"),
+        ("/path/to/../test.txt", "/path/"),
     ])
     func parentDirectory(input: String, expectedPath: String) {
         let url = URL(filePath: input)
-        let expected = URL(filePath: expectedPath)
-        #expect(url.parentDirectory == expected)
+        #expect(url.parentDirectory.path(percentEncoded: false) == expectedPath)
     }
 }

--- a/Tests/ScipioKitTests/URLExtensionsTests.swift
+++ b/Tests/ScipioKitTests/URLExtensionsTests.swift
@@ -19,9 +19,14 @@ struct URLExtensionsTests {
     }
 
     @Test("parentDirectory returns the parent directory URL for given file paths", arguments: [
-        ("/path/to/documents/projects", "/path/to/documents/"),
-        ("/path/to/../test.txt", "/path/"),
+        ("/path/to/test.txt", "/path/to"),
+        ("/test.txt", "/"),
         ("/", "/"),
+        ("/path//to///test.txt", "/path/to"),
+        ("/path/to/", "/path/to"),
+        ("///multiple///slashes///test.txt", "/multiple/slashes"),
+        ("/path/to/../..", "/"),
+        ("/path/to/../test.txt", "/path"),
     ])
     func parentDirectory(input: String, expectedPath: String) {
         let url = URL(filePath: input)


### PR DESCRIPTION
I migrated `AbsolutePath` and `RelativePath` to `Foundation.URL`.