### PR TITLE
Remove unnecessary resource copy of test fixtures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,8 +90,7 @@ let package = Package(
             dependencies: [
                 .target(name: "ScipioKit"),
             ],
-            exclude: ["Resources/Fixtures/"],
-            resources: [.copy("Resources/Fixtures")]
+            exclude: ["Resources/Fixtures/"]
         ),
         .testTarget(
             name: "PIFKitTests",


### PR DESCRIPTION
I removed an unnecessary resource copy configuration for the test target from Package.swift.

Copying the large set of test fixtures was causing significant delays before the start of test execution.
Since the tests do not fetch fixtures via the Bundle, but instead access them directly through the file system using explicit paths, the resource copy was redundant.