### PR TITLE
Expose ProcessExecutor via `@_spi(Internals)`

### DIFF
--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -96,7 +96,7 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
         self.fileSystem = fileSystem
     }
 
-    public  var streamOutput: (@Sendable ([UInt8]) async -> Void)?
+    public var streamOutput: (@Sendable ([UInt8]) async -> Void)?
 
     public func execute(_ arguments: [String]) async throws -> ExecutorResult {
         guard let executable = arguments.first, !executable.isEmpty else {

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import ScipioKit
+@testable @_spi(Internals) import ScipioKit
 import XCTest
 import TSCBasic
 

--- a/Tests/ScipioKitTests/DWARFSymbolStripperTests.swift
+++ b/Tests/ScipioKitTests/DWARFSymbolStripperTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-@testable import ScipioKit
+@testable @_spi(Internals) import ScipioKit
 
 @Suite(.serialized)
 struct DWARFSymbolStripperTests {

--- a/Tests/ScipioKitTests/PartialCacheTests.swift
+++ b/Tests/ScipioKitTests/PartialCacheTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-@testable import ScipioKit
+@testable @_spi(Internals) import ScipioKit
 
 private let fixturePath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()

--- a/Tests/ScipioKitTests/ProcessExecutorTests.swift
+++ b/Tests/ScipioKitTests/ProcessExecutorTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-@testable import ScipioKit
+@testable @_spi(Internals) import ScipioKit
 
 struct ProcessExecutorTests {
 

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import ScipioKit
+@testable @_spi(Internals) import ScipioKit
 import Logging
 
 private let fixturePath = URL(fileURLWithPath: #filePath)

--- a/Tests/ScipioKitTests/TestingExecutor.swift
+++ b/Tests/ScipioKitTests/TestingExecutor.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import ScipioKit
+@testable @_spi(Internals) import ScipioKit
 
 final class StubbableExecutor: Executor {
     init(executeHook: @escaping (([String]) throws -> ExecutorResult)) {

--- a/Tests/ScipioKitTests/VariousModulePathsTests.swift
+++ b/Tests/ScipioKitTests/VariousModulePathsTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Testing
 import PackageManifestKit
-@testable import ScipioKit
+@testable @_spi(Internals) import ScipioKit
 
 struct VariousModulePathsTests {
     private static let fixturePath = URL(filePath: #filePath)

--- a/Tests/ScipioKitTests/XCTestCase+Utils.swift
+++ b/Tests/ScipioKitTests/XCTestCase+Utils.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import ScipioKit
+@testable @_spi(Internals) import ScipioKit
 import XCTest
 
 extension XCTestCase {

--- a/Tests/ScipioKitTests/XcodeVersionFetcherTests.swift
+++ b/Tests/ScipioKitTests/XcodeVersionFetcherTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import ScipioKit
+@testable @_spi(Internals) import ScipioKit
 
 final class XcodeVersionFetcherTests: XCTestCase {
     func testFetchVersionForStableVersion() async throws {


### PR DESCRIPTION
This PR makes the existing `ProcessExecutor` in ScipioKit publicly accessible under `@_spi(Internals)`.

### Motivation

Custom build pipelines in ScipioKit sometimes require executing shell commands.  
However, `TSC.Process` is not `Sendable` and cannot be abstracted via protocols.

To address these limitations, `ProcessExecutor` was previously introduced as a `Sendable` and protocol-oriented alternative.

By exposing it through `@_spi(Internals)`, this PR enables executing arbitrary commands in a `Sendable` and testable way, simplifying the development of custom pipelines in ScipioKit.