### PR TITLE
Close FileHandle explicitly to prevent `bad file descriptor` error

### DIFF
--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -127,6 +127,7 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
         let localDecoder = errorDecoder
 
         let outputTask = Task {
+            defer { try? outputHandle.close() }
             for try await data in outputHandle.byteStream() {
                 let bytes = [UInt8](data)
                 await localStreamOutput?(bytes)
@@ -136,6 +137,7 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
         }
 
         let errorOutputTask = Task {
+            defer { try? errorHandle.close() }
             for try await data in errorHandle.byteStream() {
                 let bytes = [UInt8](data)
                 await errorBuffer.append(bytes)

--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -129,6 +129,7 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
         let outputTask = Task {
             // Workaround to avoid "Bad file descriptor" error when executing processes at high concurrency.
             // Investigate this section if command output is missing
+            // ref: https://github.com/swiftlang/swift/issues/57827
             defer { try? outputHandle.close() }
             for try await data in outputHandle.byteStream() {
                 let bytes = [UInt8](data)
@@ -141,6 +142,7 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
         let errorOutputTask = Task {
             // Workaround to avoid "Bad file descriptor" error when executing processes at high concurrency.
             // Investigate this section if command output is missing
+            // ref: https://github.com/swiftlang/swift/issues/57827
             defer { try? errorHandle.close() }
             for try await data in errorHandle.byteStream() {
                 let bytes = [UInt8](data)

--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -127,6 +127,8 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
         let localDecoder = errorDecoder
 
         let outputTask = Task {
+            // Workaround to avoid "Bad file descriptor" error when executing processes at high concurrency.
+            // Investigate this section if command output is missing
             defer { try? outputHandle.close() }
             for try await data in outputHandle.byteStream() {
                 let bytes = [UInt8](data)
@@ -137,6 +139,8 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
         }
 
         let errorOutputTask = Task {
+            // Workaround to avoid "Bad file descriptor" error when executing processes at high concurrency.
+            // Investigate this section if command output is missing
             defer { try? errorHandle.close() }
             for try await data in errorHandle.byteStream() {
                 let bytes = [UInt8](data)


### PR DESCRIPTION
## Abstract
Fix a rare “bad file descriptor” error by explicitly closing FileHandle.

## Motivation
In rare cases, ClangChecker fails with a “bad file descriptor” error when executing commands via ProcessExecutor:
https://github.com/giginet/Scipio/blob/28383cec93e01815c7666997c957b6b8efa989cc/Sources/ScipioKit/Producer/Cache/CacheSystem.swift#L25

According to Apple’s documentation, FileHandle usually doesn’t need to be closed manually:
> You don’t need to send closeFile() to this object or explicitly release the object after you have finished using it.

https://developer.apple.com/documentation/foundation/pipe/filehandleforreading

However, this behavior has been reported in the following Swift issue, where a "bad file descriptor" error can occur under specific conditions such as high concurrency or quick process termination:
https://github.com/swiftlang/swift/issues/57827

To prevent this, the FileHandle is now explicitly closed after reading process output.