### PR TITLE
Make Executor conform to Sendable

### DIFF
--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -10,7 +10,7 @@ private actor ProcessOutputBuffer {
 }
 
 @_spi(Internals)
-public protocol Executor {
+public protocol Executor: Sendable {
     /// Executes the command with the given arguments and environment variables.
     ///
     /// - Parameters:

--- a/Tests/ScipioKitTests/ClangCheckerTests.swift
+++ b/Tests/ScipioKitTests/ClangCheckerTests.swift
@@ -10,9 +10,9 @@ final class ClangCheckerTests: XCTestCase {
     """
 
     func testParseClangVersion() async throws {
-        let hook = { arguments in
+        let hook = { @Sendable [clangVersion] arguments in
             XCTAssertEqual(arguments, ["/usr/bin/xcrun", "clang", "--version"])
-            return StubbableExecutorResult(arguments: arguments, success: self.clangVersion)
+            return StubbableExecutorResult(arguments: arguments, success: clangVersion)
         }
         let clangParser = ClangChecker(executor: StubbableExecutor(executeHook: hook))
         let version = try await clangParser.fetchClangVersion()

--- a/Tests/ScipioKitTests/DebugSymbolTests.swift
+++ b/Tests/ScipioKitTests/DebugSymbolTests.swift
@@ -30,7 +30,7 @@ struct DwarfExtractorTests {
         let dwarfPath = URL(fileURLWithPath: "/dev/null")
         let uuids = try await extractor.dump(dwarfPath: dwarfPath)
 
-        let firstArguments = try #require(executor.calledArguments.first)
+        let firstArguments = try await #require(executor.calledArguments.first)
         #expect(firstArguments == ["/usr/bin/xcrun", "dwarfdump", "--uuid", dwarfPath.path])
 
         let expectedUUIDs = try argument.expectedUUIDs.mapValues {

--- a/Tests/ScipioKitTests/TestingExecutor.swift
+++ b/Tests/ScipioKitTests/TestingExecutor.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable @_spi(Internals) import ScipioKit
 
-final class StubbableExecutor: Executor {
+actor StubbableExecutor: Executor {
     init(executeHook: @escaping (([String]) throws -> ExecutorResult)) {
         self.executeHook = executeHook
     }


### PR DESCRIPTION
This PR makes the `Executor` protocol conform to Sendable.