### PR TITLE
Make `ExecutorResult` used in `Executor` protocol use opaque result type instead of existential type

### DIFF
--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -219,7 +219,7 @@ final class CacheSystemTests: XCTestCase {
         }
 
         // Ensure that the cache key is properly calculated when the package is in a repository with the correct tag."
-        let processExecutor: Executor = ProcessExecutor()
+        let processExecutor = ProcessExecutor()
         let tempTestingPackagePathString = tempTestingPackagePath.path(percentEncoded: false)
         try await processExecutor.execute(["/usr/bin/xcrun", "git", "init", tempTestingPackagePathString])
         try await processExecutor.execute([

--- a/Tests/ScipioKitTests/TestingExecutor.swift
+++ b/Tests/ScipioKitTests/TestingExecutor.swift
@@ -1,19 +1,19 @@
 import Foundation
 @testable @_spi(Internals) import ScipioKit
 
-actor StubbableExecutor: Executor {
-    init(executeHook: @escaping (([String]) throws -> ExecutorResult)) {
+actor StubbableExecutor<R: ExecutorResult>: Executor {
+    init(executeHook: @escaping (([String]) throws -> R)) {
         self.executeHook = executeHook
     }
 
-    let executeHook: (([String]) throws -> any ExecutorResult)
+    let executeHook: (([String]) throws -> R)
     private(set) var calledArguments: [[String]] = []
 
     var calledCount: Int {
         calledArguments.count
     }
 
-    func execute(_ arguments: [String], environment: [String: String]?) async throws -> ExecutorResult {
+    func execute(_ arguments: [String], environment: [String: String]?) async throws -> R {
         calledArguments.append(arguments)
         return try executeHook(arguments)
     }


### PR DESCRIPTION
I changed `ExecutorResult` used in the `Executor` protocol from an existential type to an opaque result type (`some`).