### PR TITLE
Add automatic cache sharing for restored frameworks

### DIFF
--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -48,7 +48,7 @@ public struct SwiftPMCacheKey: CacheKey {
 }
 
 struct CacheSystem: Sendable {
-    static let defaultParalellNumber = 8
+    static let defaultParallelNumber = 8
     private let outputDirectory: URL
     private let fileSystem: any FileSystem
 
@@ -92,7 +92,7 @@ struct CacheSystem: Sendable {
     }
 
     private func cacheFrameworks(_ targets: Set<CacheTarget>, to storage: some CacheStorage) async {
-        let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParalellNumber)
+        let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParallelNumber)
 
         let storageName = storage.displayName
         for chunk in chunked {

--- a/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
+++ b/Sources/ScipioKit/Producer/Cache/LocalDiskCacheStorage.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ScipioStorage
 
-struct LocalDiskCacheStorage: CacheStorage {
+struct LocalDiskCacheStorage: CacheStorage, Equatable {
     private let fileSystem: any FileSystem
 
     var parallelNumber: Int? { nil }
@@ -17,6 +17,11 @@ struct LocalDiskCacheStorage: CacheStorage {
     init(baseURL: URL?, fileSystem: FileSystem = LocalFileSystem.default) {
         self.baseURL = baseURL
         self.fileSystem = fileSystem
+    }
+
+    // MARK: - Equatable
+    static func == (lhs: LocalDiskCacheStorage, rhs: LocalDiskCacheStorage) -> Bool {
+        lhs.baseURL == rhs.baseURL
     }
 
     private func buildBaseDirectoryPath() throws -> URL {

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -390,6 +390,8 @@ struct FrameworkProducer {
         for storage in storagesWithProducer {
             await shareCachesToStorage(restoredTargets, to: storage, cacheSystem: cacheSystem)
         }
+
+        logger.info("⏹️ Sharing to other cache storages finished", metadata: .color(.green))
     }
 
     private func shareCachesToStorage(

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -160,7 +160,7 @@ struct FrameworkProducer {
                         do {
                             let product = target.buildProduct
                             let frameworkName = product.frameworkName
-                            let outputPath = outputDir.appendingPathComponent(frameworkName)
+                            let outputPath = outputDir.appending(component: frameworkName)
                             let exists = fileSystem.exists(outputPath)
                             guard exists else { return nil }
 
@@ -450,7 +450,7 @@ struct FrameworkProducer {
                             guard !hasCache else { return }
 
                             let frameworkName = target.buildProduct.frameworkName
-                            let frameworkPath = outputDir.appendingPathComponent(frameworkName)
+                            let frameworkPath = outputDir.appending(component: frameworkName)
 
                             logger.info(
                                 "🔄 Share \(frameworkName) to cache storage: \(storage.displayName)",

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -142,7 +142,7 @@ struct FrameworkProducer {
         availableTargets: Set<CacheSystem.CacheTarget>,
         cacheSystem: CacheSystem
     ) async -> Set<CacheSystem.CacheTarget> {
-        let chunked = availableTargets.chunks(ofCount: CacheSystem.defaultParalellNumber)
+        let chunked = availableTargets.chunks(ofCount: CacheSystem.defaultParallelNumber)
 
         var validFrameworks: Set<CacheSystem.CacheTarget> = []
         for chunk in chunked {
@@ -237,7 +237,7 @@ struct FrameworkProducer {
         from cacheStorage: any CacheStorage,
         cacheSystem: CacheSystem
     ) async -> Set<CacheSystem.CacheTarget> {
-        let chunked = targets.chunks(ofCount: cacheStorage.parallelNumber ?? CacheSystem.defaultParalellNumber)
+        let chunked = targets.chunks(ofCount: cacheStorage.parallelNumber ?? CacheSystem.defaultParallelNumber)
 
         var restored: Set<CacheSystem.CacheTarget> = []
         for chunk in chunked {
@@ -397,7 +397,7 @@ struct FrameworkProducer {
         to storage: any CacheStorage,
         cacheSystem: CacheSystem
     ) async {
-        let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParalellNumber)
+        let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParallelNumber)
 
         for chunk in chunked {
             await withTaskGroup(of: Void.self) { group in

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -375,7 +375,7 @@ struct FrameworkProducer {
         }
     }
 
-    internal func shareRestoredCachesToProducers(
+    private func shareRestoredCachesToProducers(
         _ restoredTargets: Set<CacheSystem.CacheTarget>,
         cacheSystem: CacheSystem
     ) async {

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -105,11 +105,11 @@ struct FrameworkProducer {
                     to: storagesWithConsumer,
                     cacheSystem: cacheSystem
                 )
-                
+
                 if !restored.isEmpty {
                     await shareRestoredCachesToProducers(restored, cacheSystem: cacheSystem)
                 }
-                
+
                 let skipTargets = valid.union(restored)
                 targetGraph.remove(skipTargets)
             }
@@ -374,21 +374,31 @@ struct FrameworkProducer {
             logger.warning("⚠️ Could not create VersionFile. This framework will not be cached.", metadata: .color(.yellow))
         }
     }
-    
-    internal func shareRestoredCachesToProducers(_ restoredTargets: Set<CacheSystem.CacheTarget>, cacheSystem: CacheSystem) async {
+
+    internal func shareRestoredCachesToProducers(
+        _ restoredTargets: Set<CacheSystem.CacheTarget>,
+        cacheSystem: CacheSystem
+    ) async {
         let storagesWithProducer = cachePolicies.storages(for: .producer)
         guard !storagesWithProducer.isEmpty else { return }
-        
-        logger.info("🔄 Sharing \(restoredTargets.count) restored framework(s) to other cache storages", metadata: .color(.blue))
-        
+
+        logger.info(
+            "🔄 Sharing \(restoredTargets.count) restored framework(s) to other cache storages",
+            metadata: .color(.blue)
+        )
+
         for storage in storagesWithProducer {
             await shareCachesToStorage(restoredTargets, to: storage, cacheSystem: cacheSystem)
         }
     }
-    
-    private func shareCachesToStorage(_ targets: Set<CacheSystem.CacheTarget>, to storage: any CacheStorage, cacheSystem: CacheSystem) async {
+
+    private func shareCachesToStorage(
+        _ targets: Set<CacheSystem.CacheTarget>,
+        to storage: any CacheStorage,
+        cacheSystem: CacheSystem
+    ) async {
         let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParalellNumber)
-        
+
         for chunk in chunked {
             await withTaskGroup(of: Void.self) { group in
                 for target in chunk {
@@ -397,14 +407,20 @@ struct FrameworkProducer {
                             let cacheKey = try await cacheSystem.calculateCacheKey(of: target)
                             let hasCache = try await storage.existsValidCache(for: cacheKey)
                             guard !hasCache else { return }
-                            
+
                             let frameworkName = target.buildProduct.frameworkName
                             let frameworkPath = outputDir.appendingPathComponent(frameworkName)
-                            
-                            logger.info("🔄 Share \(frameworkName) to cache storage: \(storage.displayName)", metadata: .color(.blue))
+
+                            logger.info(
+                                "🔄 Share \(frameworkName) to cache storage: \(storage.displayName)",
+                                metadata: .color(.blue)
+                            )
                             try await storage.cacheFramework(frameworkPath, for: cacheKey)
                         } catch {
-                            logger.warning("⚠️ Failed to share cache to \(storage.displayName): \(error.localizedDescription)", metadata: .color(.yellow))
+                            logger.warning(
+                                "⚠️ Failed to share cache to \(storage.displayName): \(error.localizedDescription)",
+                                metadata: .color(.yellow)
+                            )
                         }
                     }
                 }

--- a/Tests/ScipioKitTests/FrameworkProducerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkProducerTests.swift
@@ -5,26 +5,26 @@ import ScipioStorage
 import Logging
 
 struct FrameworkProducerTests {
-    
+
     init() {
         LoggingSystem.bootstrap { _ in SwiftLogNoOpLogHandler() }
     }
-    
+
     @Test func cacheSharing() async throws {
         let tempDir = FileManager.default.temporaryDirectory
         let outputDir = tempDir.appendingPathComponent("test-output-\(UUID().uuidString)")
-        
+
         try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
-        
+
         defer {
             try? FileManager.default.removeItem(at: outputDir)
         }
-        
+
         // Create mock cache storages
         let consumerStorage = MockCacheStorage(name: "consumer")
         let producer1Storage = MockCacheStorage(name: "producer1")
         let producer2Storage = MockCacheStorage(name: "producer2")
-        
+
         // Create cache policies
         let consumerPolicy = Runner.Options.CachePolicy(
             storage: consumerStorage,
@@ -38,9 +38,9 @@ struct FrameworkProducerTests {
             storage: producer2Storage,
             actors: [.producer]
         )
-        
+
         let cachePolicies = [consumerPolicy, producerPolicy1, producerPolicy2]
-        
+
         // Use CacheKeyTests/AsRemotePackage fixture to avoid revision detection issues
         let testPackagePath = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -48,13 +48,13 @@ struct FrameworkProducerTests {
             .appendingPathComponent("Fixtures")
             .appendingPathComponent("CacheKeyTests")
             .appendingPathComponent("AsRemotePackage")
-        
+
         let descriptionPackage = try await DescriptionPackage(
             packageDirectory: testPackagePath,
             mode: .prepareDependencies,
             onlyUseVersionsFromResolvedFile: false
         )
-        
+
         let frameworkProducer = FrameworkProducer(
             descriptionPackage: descriptionPackage,
             buildOptions: BuildOptions(
@@ -74,9 +74,9 @@ struct FrameworkProducerTests {
             overwrite: false,
             outputDir: outputDir
         )
-        
+
         let cacheSystem = CacheSystem(outputDirectory: outputDir)
-        
+
         // Create a mock cache target using the real package info
         let package = try #require(
             descriptionPackage
@@ -102,29 +102,29 @@ struct FrameworkProducerTests {
                 stripStaticDWARFSymbols: false
             )
         )
-        
+
         let restoredTargets: Set<CacheSystem.CacheTarget> = [mockTarget]
         let mockCacheKey = try await cacheSystem.calculateCacheKey(of: mockTarget)
-        
+
         // Setup initial state: producer1 has cache, producer2 doesn't
         try await producer1Storage.setHasCache(for: mockCacheKey, value: true)
         try await producer2Storage.setHasCache(for: mockCacheKey, value: false)
-        
+
         // Test FrameworkProducer's cache sharing functionality
         await frameworkProducer.shareRestoredCachesToProducers(restoredTargets, cacheSystem: cacheSystem)
-        
+
         let producer1CacheCalls = await producer1Storage.getCacheFrameworkCalls()
         let producer2CacheCalls = await producer2Storage.getCacheFrameworkCalls()
-        
+
         // Verify behavior: producer1 already has cache so no call, producer2 doesn't have cache so gets a call
         #expect(producer1CacheCalls.count == 0, "Producer1 already has cache, so cacheFramework should not be called")
         try #require(producer2CacheCalls.count == 1, "Producer2 doesn't have cache, so cacheFramework should be called once")
-        
+
         // Verify the cache call was made with correct parameters
         let actualFrameworkPath = producer2CacheCalls[0].frameworkPath
         let expectedFrameworkPath = outputDir.appendingPathComponent(buildProduct.frameworkName)
         #expect(actualFrameworkPath == expectedFrameworkPath, "Framework path should match")
-        
+
         // Verify the cache call was made with the correct cache key
         let expectedCacheKey = try mockCacheKey.calculateChecksum()
         #expect(producer2CacheCalls[0].cacheKey == expectedCacheKey, "Cache key should match the actual cache key used")
@@ -135,7 +135,7 @@ struct FrameworkProducerTests {
 
 private struct MockCacheKey: CacheKey {
     let targetName: String
-    
+
     func calculateChecksum() throws -> String {
         return "mock-checksum-\(targetName)"
     }
@@ -146,35 +146,35 @@ private struct MockCacheKey: CacheKey {
 private actor MockCacheStorage: CacheStorage {
     let displayName: String
     let parallelNumber: Int? = 1
-    
+
     private var hasCacheMap: [String: Bool] = [:]
     private var cacheFrameworkCalls: [(frameworkPath: URL, cacheKey: String)] = []
-    
+
     init(name: String) {
         self.displayName = name
     }
-    
+
     func existsValidCache(for cacheKey: some CacheKey) async throws -> Bool {
         let keyString = try cacheKey.calculateChecksum()
         return hasCacheMap[keyString] ?? false
     }
-    
+
     func fetchArtifacts(for cacheKey: some CacheKey, to destinationDir: URL) async throws {
         // Mock implementation - no-op
     }
-    
+
     func cacheFramework(_ frameworkPath: URL, for cacheKey: some CacheKey) async throws {
         let keyString = try cacheKey.calculateChecksum()
         let call = (frameworkPath: frameworkPath, cacheKey: keyString)
         cacheFrameworkCalls.append(call)
     }
-    
+
     // Test helper methods
     func setHasCache(for cacheKey: some CacheKey, value: Bool) async throws {
         let keyString = try cacheKey.calculateChecksum()
         hasCacheMap[keyString] = value
     }
-    
+
     func getCacheFrameworkCalls() -> [(frameworkPath: URL, cacheKey: String)] {
         return cacheFrameworkCalls
     }

--- a/Tests/ScipioKitTests/FrameworkProducerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkProducerTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import Testing
+@testable @_spi(Internals) import ScipioKit
+import ScipioStorage
+import Logging
+
+struct FrameworkProducerTests {
+    
+    init() {
+        LoggingSystem.bootstrap { _ in SwiftLogNoOpLogHandler() }
+    }
+    
+    @Test func cacheSharing() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+        let outputDir = tempDir.appendingPathComponent("test-output-\(UUID().uuidString)")
+        
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        
+        defer {
+            try? FileManager.default.removeItem(at: outputDir)
+        }
+        
+        // Create mock cache storages
+        let consumerStorage = MockCacheStorage(name: "consumer")
+        let producer1Storage = MockCacheStorage(name: "producer1")
+        let producer2Storage = MockCacheStorage(name: "producer2")
+        
+        // Create cache policies
+        let consumerPolicy = Runner.Options.CachePolicy(
+            storage: consumerStorage,
+            actors: [.consumer]
+        )
+        let producerPolicy1 = Runner.Options.CachePolicy(
+            storage: producer1Storage,
+            actors: [.producer]
+        )
+        let producerPolicy2 = Runner.Options.CachePolicy(
+            storage: producer2Storage,
+            actors: [.producer]
+        )
+        
+        let cachePolicies = [consumerPolicy, producerPolicy1, producerPolicy2]
+        
+        // Use CacheKeyTests/AsRemotePackage fixture to avoid revision detection issues
+        let testPackagePath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources")
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("CacheKeyTests")
+            .appendingPathComponent("AsRemotePackage")
+        
+        let descriptionPackage = try await DescriptionPackage(
+            packageDirectory: testPackagePath,
+            mode: .prepareDependencies,
+            onlyUseVersionsFromResolvedFile: false
+        )
+        
+        let frameworkProducer = FrameworkProducer(
+            descriptionPackage: descriptionPackage,
+            buildOptions: BuildOptions(
+                buildConfiguration: .debug,
+                isDebugSymbolsEmbedded: false,
+                frameworkType: .dynamic,
+                sdks: [.iOS],
+                extraFlags: nil,
+                extraBuildParameters: nil,
+                enableLibraryEvolution: false,
+                keepPublicHeadersStructure: false,
+                customFrameworkModuleMapContents: nil,
+                stripStaticDWARFSymbols: false
+            ),
+            buildOptionsMatrix: [:],
+            cachePolicies: cachePolicies,
+            overwrite: false,
+            outputDir: outputDir
+        )
+        
+        let cacheSystem = CacheSystem(outputDirectory: outputDir)
+        
+        // Create a mock cache target using the real package info
+        let package = try #require(
+            descriptionPackage
+                .graph
+                .allPackages
+                .values
+                .first { $0.name == "scipio-testing" }
+        )
+        let target = try #require(package.targets.first { $0.name == "ScipioTesting" })
+        let buildProduct = BuildProduct(package: package, target: target)
+        let mockTarget = CacheSystem.CacheTarget(
+            buildProduct: buildProduct,
+            buildOptions: BuildOptions(
+                buildConfiguration: .debug,
+                isDebugSymbolsEmbedded: false,
+                frameworkType: .dynamic,
+                sdks: [.iOS],
+                extraFlags: nil,
+                extraBuildParameters: nil,
+                enableLibraryEvolution: false,
+                keepPublicHeadersStructure: false,
+                customFrameworkModuleMapContents: nil,
+                stripStaticDWARFSymbols: false
+            )
+        )
+        
+        let restoredTargets: Set<CacheSystem.CacheTarget> = [mockTarget]
+        let mockCacheKey = try await cacheSystem.calculateCacheKey(of: mockTarget)
+        
+        // Setup initial state: producer1 has cache, producer2 doesn't
+        try await producer1Storage.setHasCache(for: mockCacheKey, value: true)
+        try await producer2Storage.setHasCache(for: mockCacheKey, value: false)
+        
+        // Test FrameworkProducer's cache sharing functionality
+        await frameworkProducer.shareRestoredCachesToProducers(restoredTargets, cacheSystem: cacheSystem)
+        
+        let producer1CacheCalls = await producer1Storage.getCacheFrameworkCalls()
+        let producer2CacheCalls = await producer2Storage.getCacheFrameworkCalls()
+        
+        // Verify behavior: producer1 already has cache so no call, producer2 doesn't have cache so gets a call
+        #expect(producer1CacheCalls.count == 0, "Producer1 already has cache, so cacheFramework should not be called")
+        try #require(producer2CacheCalls.count == 1, "Producer2 doesn't have cache, so cacheFramework should be called once")
+        
+        // Verify the cache call was made with correct parameters
+        let actualFrameworkPath = producer2CacheCalls[0].frameworkPath
+        let expectedFrameworkPath = outputDir.appendingPathComponent(buildProduct.frameworkName)
+        #expect(actualFrameworkPath == expectedFrameworkPath, "Framework path should match")
+        
+        // Verify the cache call was made with the correct cache key
+        let expectedCacheKey = try mockCacheKey.calculateChecksum()
+        #expect(producer2CacheCalls[0].cacheKey == expectedCacheKey, "Cache key should match the actual cache key used")
+    }
+}
+
+// MARK: - Mock Classes
+
+private struct MockCacheKey: CacheKey {
+    let targetName: String
+    
+    func calculateChecksum() throws -> String {
+        return "mock-checksum-\(targetName)"
+    }
+}
+
+// MARK: - Mock Cache Storage
+
+private actor MockCacheStorage: CacheStorage {
+    let displayName: String
+    let parallelNumber: Int? = 1
+    
+    private var hasCacheMap: [String: Bool] = [:]
+    private var cacheFrameworkCalls: [(frameworkPath: URL, cacheKey: String)] = []
+    
+    init(name: String) {
+        self.displayName = name
+    }
+    
+    func existsValidCache(for cacheKey: some CacheKey) async throws -> Bool {
+        let keyString = try cacheKey.calculateChecksum()
+        return hasCacheMap[keyString] ?? false
+    }
+    
+    func fetchArtifacts(for cacheKey: some CacheKey, to destinationDir: URL) async throws {
+        // Mock implementation - no-op
+    }
+    
+    func cacheFramework(_ frameworkPath: URL, for cacheKey: some CacheKey) async throws {
+        let keyString = try cacheKey.calculateChecksum()
+        let call = (frameworkPath: frameworkPath, cacheKey: keyString)
+        cacheFrameworkCalls.append(call)
+    }
+    
+    // Test helper methods
+    func setHasCache(for cacheKey: some CacheKey, value: Bool) async throws {
+        let keyString = try cacheKey.calculateChecksum()
+        hasCacheMap[keyString] = value
+    }
+    
+    func getCacheFrameworkCalls() -> [(frameworkPath: URL, cacheKey: String)] {
+        return cacheFrameworkCalls
+    }
+}

--- a/Tests/ScipioKitTests/FrameworkProducerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkProducerTests.swift
@@ -41,7 +41,7 @@ struct FrameworkProducerTests {
 
         let cachePolicies = [restoreSourcePolicy, alreadyHasCachePolicy, needsSharedCachePolicy]
 
-        // Use CacheKeyTests/AsRemotePackage fixture to avoid revision detection issues
+        // Use the CacheKeyTests/AsRemotePackage fixture here because it simulates a remote package with a fixed revision.
         let testPackagePath = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .appendingPathComponent("Resources")

--- a/Tests/ScipioKitTests/FrameworkProducerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkProducerTests.swift
@@ -12,7 +12,7 @@ struct FrameworkProducerTests {
 
     @Test func cacheSharing() async throws {
         let tempDir = FileManager.default.temporaryDirectory
-        let outputDir = tempDir.appendingPathComponent("test-output-\(UUID().uuidString)")
+        let outputDir = tempDir.appending(component: "test-output-\(UUID().uuidString)")
 
         try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
 
@@ -42,12 +42,9 @@ struct FrameworkProducerTests {
         let cachePolicies = [restoreSourcePolicy, alreadyHasCachePolicy, needsSharedCachePolicy]
 
         // Use the CacheKeyTests/AsRemotePackage fixture here because it simulates a remote package with a fixed revision.
-        let testPackagePath = URL(fileURLWithPath: #filePath)
+        let testPackagePath = URL(filePath: #filePath)
             .deletingLastPathComponent()
-            .appendingPathComponent("Resources")
-            .appendingPathComponent("Fixtures")
-            .appendingPathComponent("CacheKeyTests")
-            .appendingPathComponent("AsRemotePackage")
+            .appending(components: "Resources", "Fixtures", "CacheKeyTests", "AsRemotePackage")
 
         let descriptionPackage = try await DescriptionPackage(
             packageDirectory: testPackagePath,
@@ -142,7 +139,7 @@ struct FrameworkProducerTests {
 
         // Verify the cache call was made with correct parameters
         let actualFrameworkPath = needsSharedCacheCalls[0].frameworkPath
-        let expectedFrameworkPath = outputDir.appendingPathComponent(buildProduct.frameworkName)
+        let expectedFrameworkPath = outputDir.appending(component: buildProduct.frameworkName)
         #expect(actualFrameworkPath == expectedFrameworkPath, "Framework path should match")
 
         // Verify the cache call was made with the correct cache key


### PR DESCRIPTION
## Summary
- Enhance FrameworkProducer to automatically share restored frameworks to other producer cache storages
- Add existsValidCache check to prevent duplicate caching and improve cache efficiency
- Add comprehensive Swift Testing test suite for cache sharing functionality

## Changes
- **FrameworkProducer**: Add `shareRestoredCachesToProducers` method to distribute restored caches across multiple storage backends
- **Cache Logic**: Implement `existsValidCache` check before caching to avoid duplicates
- **Logging**: Add informative log messages for cache sharing operations
- **Tests**: Add new `FrameworkProducerTests` with Swift Testing framework to verify cache sharing behavior

## Test Plan
- [x] Verify cache sharing only occurs when producer storages are configured
- [x] Verify duplicate caching is prevented when cache already exists
- [x] Verify cache sharing happens only for storages that don't have the cache
- [x] Verify correct framework paths and cache keys are used
- [x] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)

---

refs:
- #148
- #156