### PR TITLE
Resolve some unhandled files warnings in SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,10 @@ let package = Package(
                 .product(name: "PackageManifestKit", package: "PackageManifestKit"),
                 .product(name: "AsyncOperations", package: "swift-async-operations"),
             ],
+            exclude: [
+                "SwiftPM/NOTICE.txt",
+                "SwiftPM/LICENSE",
+            ],
             plugins: [
                 .plugin(name: "GenerateScipioVersion")
             ]
@@ -86,7 +90,8 @@ let package = Package(
             name: "PIFKitTests",
             dependencies: [
                 .target(name: "PIFKit"),
-            ]
+            ],
+            exclude: ["Fixtures/"]
         ),
     ],
     swiftLanguageModes: [.v6]


### PR DESCRIPTION
```
warning: 'scipio': found 3 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/runner/work/Scipio/Scipio/Tests/PIFKitTests/Fixtures/BuildConfiguration.json
    /Users/runner/work/Scipio/Scipio/Tests/PIFKitTests/Fixtures/SimplePackage.pif
    /Users/runner/work/Scipio/Scipio/Tests/PIFKitTests/Fixtures/Target.json
warning: 'scipio': found 2 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/runner/work/Scipio/Scipio/Sources/ScipioKit/SwiftPM/NOTICE.txt
    /Users/runner/work/Scipio/Scipio/Sources/ScipioKit/SwiftPM/LICENSE
```