### PR TITLE
Add a workaround for DerivedData and Swift Build

### DIFF
--- a/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildExecutor.swift
@@ -14,6 +14,10 @@ struct XCBuildExecutor {
         buildParametersPath: URL,
         target: ResolvedModule
     ) async throws {
+        // [workaround]
+        // Scipio on CLI passes a relative path,
+        // but Swift Build doesn't accept a relative path to DerivedData.
+        // FIXME: Remove `absoluteURL` after `swbuild build` supports a relative path.
         let executor = await BufferedXCBuildMessageExecutor([
             xcbuildPath.path(percentEncoded: false),
             "build",
@@ -21,7 +25,7 @@ struct XCBuildExecutor {
             "--configuration",
             configuration.settingsValue,
             "--derivedDataPath",
-            derivedDataPath.path(percentEncoded: false),
+            derivedDataPath.absoluteURL.path(percentEncoded: false),
             "--buildParametersFile",
             buildParametersPath.path(percentEncoded: false),
             "--target",


### PR DESCRIPTION
# Overview

This PR will add a workaround to fix this issue:

> unable to write module session file at './relative/path/to/DerivedData/ModuleCache.noindex/Session.modulevalidation': unknown error
> #241

This PR won't close #241 because Scipio needs additional fixes to handle firebase-ios-sdk correctly.

# Cause of the Error

https://github.com/swiftlang/swift-build/issues/944

As I explained on the issue page, `swbuild build` uses `createDirectory(_:recursive:)` and it declines a relative path.
However Scipio on CLI passes a relative path to `--derivedDataPath`.

# Changes

This PR will

- make Scipio pass an absolute path forcibly.
  - This is a workaround. I hope we can pass a relative path after the Swift Build issue is resolved.

This PR won't

- add any tests.
  - Because `IntegrationTests` seems to pass an absolute path, which is proper for Swift Build.