### PR TITLE
Update minimum dependency versions to latest releases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,21 +26,21 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git",
-                 from: "1.5.2"),
+                 from: "1.10.1"),
         .package(url: "https://github.com/apple/swift-collections",
-                 from: "1.0.4"),
+                 from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git",
-                 from: "1.1.0"),
+                 from: "1.7.0"),
         .package(url: "https://github.com/apple/swift-algorithms.git",
-                 from: "1.0.0"),
+                 from: "1.2.1"),
         .package(url: "https://github.com/onevcat/Rainbow",
-                 from: "4.0.1"),
+                 from: "4.2.1"),
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git",
-                 from: "5.0.0"),
+                 from: "5.0.2"),
         .package(url: "https://github.com/giginet/PackageManifestKit",
                  from: "0.2.0"),
         .package(url: "https://github.com/mtj0928/swift-async-operations.git",
-                 from: "0.4.0"),
+                 from: "0.5.0"),
     ],
     targets: [
         .executableTarget(
@@ -117,6 +117,6 @@ let isDevelopment = ProcessInfo.processInfo.environment["SCIPIO_DEVELOPMENT"] ==
 // swift-docs is not needed for package users
 if isDevelopment {
     package.dependencies += [
-        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.3.0"),
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.6"),
     ]
 }

--- a/Sources/ScipioKit/BuildOptions.swift
+++ b/Sources/ScipioKit/BuildOptions.swift
@@ -1,5 +1,5 @@
 import Foundation
-import OrderedCollections
+import Collections
 
 struct BuildOptions: Hashable, Codable, Sendable {
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -126,7 +126,7 @@ struct FrameworkProducer {
 
         let targetBuildResult = await buildTargets(dependencyGraphToBuild)
 
-        let builtTargets: OrderedCollections.OrderedSet<CacheSystem.CacheTarget> = switch targetBuildResult {
+        let builtTargets: OrderedSet<CacheSystem.CacheTarget> = switch targetBuildResult {
             case .completed(let builtTargets),
                  .interrupted(let builtTargets, _):
                 builtTargets
@@ -313,7 +313,7 @@ struct FrameworkProducer {
     }
 
     private func buildTargets(_ targets: DependencyGraph<CacheSystem.CacheTarget>) async -> TargetBuildResult {
-        var builtTargets = OrderedCollections.OrderedSet<CacheSystem.CacheTarget>()
+        var builtTargets = OrderedSet<CacheSystem.CacheTarget>()
 
         do {
             var targets = targets
@@ -334,8 +334,8 @@ struct FrameworkProducer {
     }
 
     private enum TargetBuildResult {
-        case interrupted(builtTargets: OrderedCollections.OrderedSet<CacheSystem.CacheTarget>, error: any Error)
-        case completed(builtTargets: OrderedCollections.OrderedSet<CacheSystem.CacheTarget>)
+        case interrupted(builtTargets: OrderedSet<CacheSystem.CacheTarget>, error: any Error)
+        case completed(builtTargets: OrderedSet<CacheSystem.CacheTarget>)
     }
 
     @discardableResult

--- a/Sources/ScipioKit/Resolver/PackageResolver.swift
+++ b/Sources/ScipioKit/Resolver/PackageResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
 import PackageManifestKit
-import OrderedCollections
+import Collections
 import AsyncOperations
 import ScipioKitCore
 

--- a/Sources/ScipioKit/SwiftPM/topologicalSort.swift
+++ b/Sources/ScipioKit/SwiftPM/topologicalSort.swift
@@ -11,7 +11,7 @@
 // ===----------------------------------------------------------------------===//
 
 import Foundation
-import OrderedCollections
+import Collections
 
 func topologicalSort<T: Identifiable>(
     _ nodes: [T], successors: (T) throws -> [T]


### PR DESCRIPTION
## Summary

Bump minimum version requirements for all dependencies to their latest releases: `swift-log` 1.10.1, `swift-collections` 1.4.0, `swift-argument-parser` 1.7.0, `swift-algorithms` 1.2.1, `Rainbow` 4.2.1, `SwiftyJSON` 5.0.2, `swift-async-operations` 0.5.0, and `swift-docc-plugin` 1.4.6. Adapt to `swift-collections` 1.4.0 by replacing `import OrderedCollections` with `import Collections` and removing `OrderedCollections.` type prefixes in `FrameworkProducer.swift`, `BuildOptions.swift`, `PackageResolver.swift`, and `topologicalSort.swift`.

## Added Tests

No new tests added. All existing 46 tests pass with the updated dependencies.