### PR TITLE
Propagate underlying error in Runner.Error.invalidPackage

### DIFF
--- a/Sources/ScipioKit/Runner.swift
+++ b/Sources/ScipioKit/Runner.swift
@@ -13,7 +13,7 @@ public struct Runner {
     }
 
     public enum Error: Swift.Error, LocalizedError {
-        case invalidPackage(URL)
+        case invalidPackage(URL, Swift.Error)
         case platformNotSpecified
         case compilerError(Swift.Error)
 
@@ -21,8 +21,8 @@ public struct Runner {
             switch self {
             case .platformNotSpecified:
                 return "Any platforms are not spcified in Package.swift"
-            case .invalidPackage(let path):
-                return "Invalid package. \(path.path)"
+            case .invalidPackage(let path, let underlyingError):
+                return "Invalid package. \(path.path)\n\(underlyingError.localizedDescription)"
             case .compilerError(let error):
                 return "\(error.localizedDescription)"
             }
@@ -63,7 +63,7 @@ public struct Runner {
                 onlyUseVersionsFromResolvedFile: options.shouldOnlyUseVersionsFromResolvedFile
             )
         } catch {
-            throw Error.invalidPackage(packageDirectory)
+            throw Error.invalidPackage(packageDirectory, error)
         }
 
         let buildOptions = try options.buildOptionsContainer.makeBuildOptions(descriptionPackage: descriptionPackage)


### PR DESCRIPTION
## Summary

- `Runner.Error.invalidPackage` now carries the underlying `Swift.Error` that caused the failure
- When `DescriptionPackage` initialization fails, the original error (e.g. package resolution failure, manifest parsing error) is preserved and displayed to the user instead of being silently discarded
- This makes it much easier to diagnose CI failures like "Failed to parse package manifests"

## Test plan

- [x] `swift build` succeeds
- [ ] Verify that when `DescriptionPackage` initialization fails, the error message now includes the underlying cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)