### PR TITLE
Add Swift main snapshot CI

### DIFF
--- a/.github/workflows/swift-main-snapshot.yml
+++ b/.github/workflows/swift-main-snapshot.yml
@@ -1,0 +1,50 @@
+name: Swift Main Snapshot
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Tests:
+    timeout-minutes: 30
+    continue-on-error: true
+    runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.4.1.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Swift main snapshot
+        run: |
+          curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg
+          installer -pkg swiftly.pkg -target CurrentUserHomeDirectory
+          ~/.swiftly/bin/swiftly init --quiet-shell-followup
+          . "${SWIFTLY_HOME_DIR:-$HOME/.swiftly}/env.sh"
+          swiftly install main-snapshot
+          swiftly use main-snapshot
+          swift --version
+          echo "SWIFTLY_HOME_DIR=${SWIFTLY_HOME_DIR:-$HOME/.swiftly}" >> "$GITHUB_ENV"
+          echo "${SWIFTLY_HOME_DIR:-$HOME/.swiftly}/bin" >> "$GITHUB_PATH"
+      - name: Build
+        run: |
+          . "${SWIFTLY_HOME_DIR:-$HOME/.swiftly}/env.sh"
+          swiftly use main-snapshot
+          swift build
+      - name: Run Tests
+        run: |
+          . "${SWIFTLY_HOME_DIR:-$HOME/.swiftly}/env.sh"
+          swiftly use main-snapshot
+          swift test --no-parallel
+        env:
+          ENABLE_INTEGRATION_TESTS: 1
+          IS_CI: 1

--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
                 .target(name: "CacheStorage"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Collections", package: "swift-collections"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
                 .product(name: "Algorithms", package: "swift-algorithms"),
                 .product(name: "Rainbow", package: "Rainbow"),
                 .product(name: "PackageManifestKit", package: "PackageManifestKit"),

--- a/Sources/ScipioKit/BuildOptions.swift
+++ b/Sources/ScipioKit/BuildOptions.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Collections
+import OrderedCollections
 
 struct BuildOptions: Hashable, Codable, Sendable {
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CacheStorage
 import Collections
+import OrderedCollections
 import PackageManifestKit
 
 struct FrameworkProducer {

--- a/Sources/ScipioKit/SwiftPM/topologicalSort.swift
+++ b/Sources/ScipioKit/SwiftPM/topologicalSort.swift
@@ -11,7 +11,7 @@
 // ===----------------------------------------------------------------------===//
 
 import Foundation
-import Collections
+import OrderedCollections
 
 func topologicalSort<T: Identifiable>(
     _ nodes: [T], successors: (T) throws -> [T]


### PR DESCRIPTION
## Summary

- Add a Swift main snapshot CI workflow using Swiftly on `macos-26` with Xcode 26.4.1.
- Run `swift build` and `swift test --no-parallel` against `main-snapshot` on pushes, pull requests, daily schedule, and manual dispatch.
- Import `OrderedCollections` explicitly where `OrderedSet` appears in declarations to satisfy stricter snapshot diagnostics.

## Verification

- `swift build`

Created with Codex.