### PR TITLE
Add Xcode 26.4 to tests matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,16 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        xcode_version:
-          - "16.4" # 6.1.2
-          - "26.0.1" # 6.2
+        include:
+          - xcode_version: "16.4" # Swift 6.1.2
+            macos_version: macos-15
+          - xcode_version: "26.0.1" # Swift 6.2
+            macos_version: macos-15
+          - xcode_version: "26.4" # Swift 6.3
+            macos_version: macos-26
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer"
-    runs-on: macos-15
+    runs-on: ${{ matrix.macos_version }}
     steps:
     - name: Get swift version
       run: swift --version


### PR DESCRIPTION
## Summary

- Add Xcode 26.4 to the Tests workflow matrix.
- Use macos-26 for the Xcode 26.4 job while keeping existing Xcode jobs on macos-15.
- Normalize Swift version comments in the matrix entries.

## Validation

- Not run locally; this change only updates the GitHub Actions workflow definition.

Created with Codex.