### PR TITLE
Fix stale dependent framework caches by propagating dependency cache keys

### DIFF
--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -148,6 +148,11 @@ struct CacheSystem: Sendable {
         var dependencyCacheKeyChecksums: [DependencyCacheKeyChecksum]
     }
 
+    private enum CacheKeyCalculationResult: Sendable {
+        case calculated(CacheTarget, SwiftPMCacheKey)
+        case revisionNotDetected(CacheTarget, String)
+    }
+
     enum Error: LocalizedError {
         case revisionNotDetected(String)
         case compilerVersionNotDetected
@@ -281,6 +286,8 @@ struct CacheSystem: Sendable {
     func calculateCacheKeys(for graph: DependencyGraph<CacheTarget>) async throws -> [CacheTarget: SwiftPMCacheKey] {
         let environment = try await cacheKeyEnvironment()
         var cacheKeys: [CacheTarget: SwiftPMCacheKey] = [:]
+        var unavailableTargets: Set<CacheTarget> = []
+        var reportedUnavailablePackages: Set<String> = []
         var remainingTargets = Set(graph.allNodes.map(\.value))
         var layer = graph.leafs
 
@@ -290,7 +297,19 @@ struct CacheSystem: Sendable {
                 break
             }
 
-            let inputs = try nodes.map { node in
+            var inputs: [CacheKeyCalculationInput] = []
+            var unavailablePackages: Set<String> = []
+            for node in nodes {
+                if node.children.contains(where: { unavailableTargets.contains($0.value) }) {
+                    unavailableTargets.insert(node.value)
+                    remainingTargets.remove(node.value)
+                    continue
+                }
+
+                guard node.children.allSatisfy({ cacheKeys[$0.value] != nil }) else {
+                    continue
+                }
+
                 let dependencyChecksums = try node.children.map { child in
                     let childCacheKey = cacheKeys[child.value]!
                     return DependencyCacheKeyChecksum(
@@ -298,24 +317,51 @@ struct CacheSystem: Sendable {
                         checksum: try childCacheKey.calculateChecksum()
                     )
                 }
-                return CacheKeyCalculationInput(
-                    target: node.value,
-                    dependencyCacheKeyChecksums: dependencyChecksums
+                inputs.append(
+                    CacheKeyCalculationInput(
+                        target: node.value,
+                        dependencyCacheKeyChecksums: dependencyChecksums
+                    )
                 )
-            }
-            let layerCacheKeys = try await inputs.asyncMap(numberOfConcurrentTasks: UInt(inputs.count)) { input in
-                let cacheKey = try await calculateCacheKey(
-                    of: input.target,
-                    dependencyCacheKeyChecksums: input.dependencyCacheKeyChecksums,
-                    environment: environment
-                )
-                return (input.target, cacheKey)
             }
 
-            for (target, cacheKey) in layerCacheKeys {
-                cacheKeys[target] = cacheKey
-                remainingTargets.remove(target)
+            let layerResults: [CacheKeyCalculationResult] = if inputs.isEmpty {
+                []
+            } else {
+                try await inputs.asyncMap(numberOfConcurrentTasks: UInt(inputs.count)) { input in
+                    do {
+                        let cacheKey = try await calculateCacheKey(
+                            of: input.target,
+                            dependencyCacheKeyChecksums: input.dependencyCacheKeyChecksums,
+                            environment: environment
+                        )
+                        return CacheKeyCalculationResult.calculated(input.target, cacheKey)
+                    } catch Error.revisionNotDetected(let packageName) {
+                        return CacheKeyCalculationResult.revisionNotDetected(input.target, packageName)
+                    }
+                }
             }
+
+            for result in layerResults {
+                switch result {
+                case .calculated(let target, let cacheKey):
+                    cacheKeys[target] = cacheKey
+                    remainingTargets.remove(target)
+                case .revisionNotDetected(let target, let packageName):
+                    unavailableTargets.insert(target)
+                    remainingTargets.remove(target)
+                    unavailablePackages.insert(packageName)
+                }
+            }
+
+            for packageName in unavailablePackages.subtracting(reportedUnavailablePackages).sorted() {
+                logger.warning(
+                    // swiftlint:disable:next line_length
+                    "⚠️ Cache key is unavailable because \(packageName) has no revision. Skip cache participation for this package and its dependents.",
+                    metadata: .color(.yellow)
+                )
+            }
+            reportedUnavailablePackages.formUnion(unavailablePackages)
 
             let parentNodes = nodes.flatMap { node in
                 node.parents.compactMap(\.reference)
@@ -324,7 +370,10 @@ struct CacheSystem: Sendable {
             layer = parentNodes.filter { node in
                 remainingTargets.contains(node.value)
                     && seenTargets.insert(node.value).inserted
-                    && node.children.allSatisfy { cacheKeys[$0.value] != nil }
+                    && (
+                        node.children.contains(where: { unavailableTargets.contains($0.value) })
+                            || node.children.allSatisfy { cacheKeys[$0.value] != nil }
+                    )
             }
         }
 

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AsyncOperations
 import CacheStorage
 import Algorithms
 import PackageManifestKit
@@ -142,6 +143,11 @@ struct CacheSystem: Sendable {
         var xcodeVersion: XcodeVersion
     }
 
+    private struct CacheKeyCalculationInput: Sendable {
+        var target: CacheTarget
+        var dependencyCacheKeyChecksums: [DependencyCacheKeyChecksum]
+    }
+
     enum Error: LocalizedError {
         case revisionNotDetected(String)
         case compilerVersionNotDetected
@@ -275,32 +281,51 @@ struct CacheSystem: Sendable {
     func calculateCacheKeys(for graph: DependencyGraph<CacheTarget>) async throws -> [CacheTarget: SwiftPMCacheKey] {
         let environment = try await cacheKeyEnvironment()
         var cacheKeys: [CacheTarget: SwiftPMCacheKey] = [:]
+        var remainingTargets = Set(graph.allNodes.map(\.value))
+        var layer = graph.leafs
 
-        func calculateCacheKeyRecursively(for node: DependencyGraph<CacheTarget>.Node) async throws {
-            if cacheKeys[node.value] != nil {
-                return
+        while !layer.isEmpty {
+            let nodes = layer.filter { remainingTargets.contains($0.value) }
+            if nodes.isEmpty {
+                break
             }
 
-            for child in node.children {
-                try await calculateCacheKeyRecursively(for: child)
-            }
-
-            let dependencyChecksums = try node.children.map { child in
-                let childCacheKey = cacheKeys[child.value]!
-                return DependencyCacheKeyChecksum(
-                    targetName: child.value.buildProduct.target.name,
-                    checksum: try childCacheKey.calculateChecksum()
+            let inputs = try nodes.map { node in
+                let dependencyChecksums = try node.children.map { child in
+                    let childCacheKey = cacheKeys[child.value]!
+                    return DependencyCacheKeyChecksum(
+                        targetName: child.value.buildProduct.target.name,
+                        checksum: try childCacheKey.calculateChecksum()
+                    )
+                }
+                return CacheKeyCalculationInput(
+                    target: node.value,
+                    dependencyCacheKeyChecksums: dependencyChecksums
                 )
             }
-            cacheKeys[node.value] = try await calculateCacheKey(
-                of: node.value,
-                dependencyCacheKeyChecksums: dependencyChecksums,
-                environment: environment
-            )
-        }
+            let layerCacheKeys = try await inputs.asyncMap(numberOfConcurrentTasks: UInt(inputs.count)) { input in
+                let cacheKey = try await calculateCacheKey(
+                    of: input.target,
+                    dependencyCacheKeyChecksums: input.dependencyCacheKeyChecksums,
+                    environment: environment
+                )
+                return (input.target, cacheKey)
+            }
 
-        for node in graph.allNodes {
-            try await calculateCacheKeyRecursively(for: node)
+            for (target, cacheKey) in layerCacheKeys {
+                cacheKeys[target] = cacheKey
+                remainingTargets.remove(target)
+            }
+
+            let parentNodes = nodes.flatMap { node in
+                node.parents.compactMap(\.reference)
+            }
+            var seenTargets: Set<CacheTarget> = []
+            layer = parentNodes.filter { node in
+                remainingTargets.contains(node.value)
+                    && seenTargets.insert(node.value).inserted
+                    && node.children.allSatisfy { cacheKeys[$0.value] != nil }
+            }
         }
 
         return cacheKeys

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -37,6 +37,27 @@ struct ClangChecker<E: Executor> {
     }
 }
 
+public struct DependencyCacheKeyChecksum: Codable, Hashable, Sendable {
+    public var targetName: String
+    public var checksum: String
+
+    public init(targetName: String, checksum: String) {
+        self.targetName = targetName
+        self.checksum = checksum
+    }
+}
+
+private func sortDependencyCacheKeyChecksums(
+    _ checksums: [DependencyCacheKeyChecksum]
+) -> [DependencyCacheKeyChecksum] {
+    checksums.sorted {
+        if $0.targetName == $1.targetName {
+            return $0.checksum < $1.checksum
+        }
+        return $0.targetName < $1.targetName
+    }
+}
+
 public struct SwiftPMCacheKey: CacheKey {
     /// The canonical repository URL the manifest was loaded from, for local packages only.
     public var localPackageCanonicalLocation: String?
@@ -46,6 +67,64 @@ public struct SwiftPMCacheKey: CacheKey {
     public var clangVersion: String
     public var xcodeVersion: XcodeVersion
     public var scipioVersion: String?
+    public var dependencyCacheKeyChecksums: [DependencyCacheKeyChecksum]
+
+    init(
+        localPackageCanonicalLocation: String?,
+        pin: Pin.State,
+        targetName: String,
+        buildOptions: BuildOptions,
+        clangVersion: String,
+        xcodeVersion: XcodeVersion,
+        scipioVersion: String? = nil,
+        dependencyCacheKeyChecksums: [DependencyCacheKeyChecksum] = []
+    ) {
+        self.localPackageCanonicalLocation = localPackageCanonicalLocation
+        self.pin = pin
+        self.targetName = targetName
+        self.buildOptions = buildOptions
+        self.clangVersion = clangVersion
+        self.xcodeVersion = xcodeVersion
+        self.scipioVersion = scipioVersion
+        self.dependencyCacheKeyChecksums = sortDependencyCacheKeyChecksums(dependencyCacheKeyChecksums)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case localPackageCanonicalLocation
+        case pin
+        case targetName
+        case buildOptions
+        case clangVersion
+        case xcodeVersion
+        case scipioVersion
+        case dependencyCacheKeyChecksums
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.localPackageCanonicalLocation = try container.decodeIfPresent(String.self, forKey: .localPackageCanonicalLocation)
+        self.pin = try container.decode(Pin.State.self, forKey: .pin)
+        self.targetName = try container.decode(String.self, forKey: .targetName)
+        self.buildOptions = try container.decode(BuildOptions.self, forKey: .buildOptions)
+        self.clangVersion = try container.decode(String.self, forKey: .clangVersion)
+        self.xcodeVersion = try container.decode(XcodeVersion.self, forKey: .xcodeVersion)
+        self.scipioVersion = try container.decodeIfPresent(String.self, forKey: .scipioVersion)
+        self.dependencyCacheKeyChecksums = sortDependencyCacheKeyChecksums(try container
+            .decodeIfPresent([DependencyCacheKeyChecksum].self, forKey: .dependencyCacheKeyChecksums)
+            ?? [])
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(localPackageCanonicalLocation, forKey: .localPackageCanonicalLocation)
+        try container.encode(pin, forKey: .pin)
+        try container.encode(targetName, forKey: .targetName)
+        try container.encode(buildOptions, forKey: .buildOptions)
+        try container.encode(clangVersion, forKey: .clangVersion)
+        try container.encode(xcodeVersion, forKey: .xcodeVersion)
+        try container.encodeIfPresent(scipioVersion, forKey: .scipioVersion)
+        try container.encode(sortDependencyCacheKeyChecksums(dependencyCacheKeyChecksums), forKey: .dependencyCacheKeyChecksums)
+    }
 }
 
 struct CacheSystem: Sendable {
@@ -86,13 +165,21 @@ struct CacheSystem: Sendable {
         self.fileSystem = fileSystem
     }
 
-    func cacheFrameworks(_ targets: Set<CacheTarget>, to storages: [any FrameworkCacheStorage]) async {
+    func cacheFrameworks(
+        _ targets: Set<CacheTarget>,
+        cacheKeys: [CacheTarget: SwiftPMCacheKey],
+        to storages: [any FrameworkCacheStorage]
+    ) async {
         for storage in storages {
-            await cacheFrameworks(targets, to: storage)
+            await cacheFrameworks(targets, cacheKeys: cacheKeys, to: storage)
         }
     }
 
-    private func cacheFrameworks(_ targets: Set<CacheTarget>, to storage: some FrameworkCacheStorage) async {
+    private func cacheFrameworks(
+        _ targets: Set<CacheTarget>,
+        cacheKeys: [CacheTarget: SwiftPMCacheKey],
+        to storage: some FrameworkCacheStorage
+    ) async {
         let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParallelNumber)
 
         let storageName = storage.displayName
@@ -107,7 +194,8 @@ struct CacheSystem: Sendable {
                                 "🚀 Cache \(frameworkName) to cache storage: \(storageName)",
                                 metadata: .color(.green)
                             )
-                            try await cacheFramework(target, at: frameworkPath, to: storage)
+                            guard let cacheKey = cacheKeys[target] else { return }
+                            try await cacheFramework(at: frameworkPath, for: cacheKey, to: storage)
                         } catch {
                             logger.warning("⚠️ Can't create caches for \(frameworkPath.path)")
                         }
@@ -118,21 +206,22 @@ struct CacheSystem: Sendable {
         }
     }
 
-    private func cacheFramework(_ target: CacheTarget, at frameworkPath: URL, to storage: any FrameworkCacheStorage) async throws {
-        let cacheKey = try await calculateCacheKey(of: target)
-
+    private func cacheFramework(at frameworkPath: URL, for cacheKey: SwiftPMCacheKey, to storage: any FrameworkCacheStorage) async throws {
         try await storage.cacheFramework(frameworkPath, for: cacheKey)
     }
 
-    func generateVersionFile(for target: CacheTarget) async throws {
-        let cacheKey = try await calculateCacheKey(of: target)
-
+    func generateVersionFile(for target: CacheTarget, cacheKey: SwiftPMCacheKey) async throws {
         let data = try jsonEncoder.encode(cacheKey)
         let versionFilePath = outputDirectory.appendingPathComponent(versionFileName(for: target.buildProduct.target.name))
         try fileSystem.writeFileContents(
             versionFilePath,
             data: data
         )
+    }
+
+    func generateVersionFile(for target: CacheTarget) async throws {
+        let cacheKey = try await calculateCacheKey(of: target)
+        try await generateVersionFile(for: target, cacheKey: cacheKey)
     }
 
     func existsValidCache(cacheKey: SwiftPMCacheKey) async -> Bool {
@@ -156,9 +245,8 @@ struct CacheSystem: Sendable {
         case noCache
     }
 
-    func restoreCacheIfPossible(target: CacheTarget, storage: some FrameworkCacheStorage) async -> RestoreResult {
+    func restoreCacheIfPossible(cacheKey: SwiftPMCacheKey, storage: some FrameworkCacheStorage) async -> RestoreResult {
         do {
-            let cacheKey = try await calculateCacheKey(of: target)
             if try await storage.existsValidCache(for: cacheKey) {
                 try await storage.fetchArtifacts(for: cacheKey, to: outputDirectory)
                 return .succeeded
@@ -171,6 +259,45 @@ struct CacheSystem: Sendable {
     }
 
     func calculateCacheKey(of target: CacheTarget) async throws -> SwiftPMCacheKey {
+        try await calculateCacheKey(of: target, dependencyCacheKeyChecksums: [])
+    }
+
+    func calculateCacheKeys(for graph: DependencyGraph<CacheTarget>) async throws -> [CacheTarget: SwiftPMCacheKey] {
+        var cacheKeys: [CacheTarget: SwiftPMCacheKey] = [:]
+
+        func calculateCacheKeyRecursively(for node: DependencyGraph<CacheTarget>.Node) async throws {
+            if cacheKeys[node.value] != nil {
+                return
+            }
+
+            for child in node.children {
+                try await calculateCacheKeyRecursively(for: child)
+            }
+
+            let dependencyChecksums = try node.children.map { child in
+                let childCacheKey = cacheKeys[child.value]!
+                return DependencyCacheKeyChecksum(
+                    targetName: child.value.buildProduct.target.name,
+                    checksum: try childCacheKey.calculateChecksum()
+                )
+            }
+            cacheKeys[node.value] = try await calculateCacheKey(
+                of: node.value,
+                dependencyCacheKeyChecksums: dependencyChecksums
+            )
+        }
+
+        for node in graph.allNodes {
+            try await calculateCacheKeyRecursively(for: node)
+        }
+
+        return cacheKeys
+    }
+
+    private func calculateCacheKey(
+        of target: CacheTarget,
+        dependencyCacheKeyChecksums: [DependencyCacheKeyChecksum]
+    ) async throws -> SwiftPMCacheKey {
         let package = target.buildProduct.package
 
         let localPackageCanonicalLocation: String? = switch package.resolvedPackageKind {
@@ -197,7 +324,8 @@ struct CacheSystem: Sendable {
             buildOptions: buildOptions,
             clangVersion: clangVersion,
             xcodeVersion: xcodeVersion,
-            scipioVersion: currentScipioVersion
+            scipioVersion: currentScipioVersion,
+            dependencyCacheKeyChecksums: dependencyCacheKeyChecksums
         )
     }
 

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -275,15 +275,6 @@ struct CacheSystem: Sendable {
         }
     }
 
-    func calculateCacheKey(of target: CacheTarget) async throws -> SwiftPMCacheKey {
-        let environment = try await cacheKeyEnvironment()
-        return try await calculateCacheKey(
-            of: target,
-            dependencyCacheKeyChecksums: [],
-            environment: environment
-        )
-    }
-
     func calculateCacheKeys(for graph: DependencyGraph<CacheTarget>) async throws -> [CacheTarget: SwiftPMCacheKey] {
         let environment = try await cacheKeyEnvironment()
         var cacheKeys: [CacheTarget: SwiftPMCacheKey] = [:]

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -323,7 +323,9 @@ struct CacheSystem: Sendable {
             let layerResults: [CacheKeyCalculationResult] = if inputs.isEmpty {
                 []
             } else {
-                try await inputs.asyncMap(numberOfConcurrentTasks: UInt(inputs.count)) { input in
+                try await inputs.asyncMap(
+                    numberOfConcurrentTasks: UInt(min(inputs.count, CacheSystem.defaultParallelNumber))
+                ) { input in
                     do {
                         let cacheKey = try await calculateCacheKey(
                             of: input.target,

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -137,6 +137,11 @@ struct CacheSystem: Sendable {
         var buildOptions: BuildOptions
     }
 
+    private struct CacheKeyEnvironment: Sendable {
+        var clangVersion: String
+        var xcodeVersion: XcodeVersion
+    }
+
     enum Error: LocalizedError {
         case revisionNotDetected(String)
         case compilerVersionNotDetected
@@ -259,10 +264,16 @@ struct CacheSystem: Sendable {
     }
 
     func calculateCacheKey(of target: CacheTarget) async throws -> SwiftPMCacheKey {
-        try await calculateCacheKey(of: target, dependencyCacheKeyChecksums: [])
+        let environment = try await cacheKeyEnvironment()
+        return try await calculateCacheKey(
+            of: target,
+            dependencyCacheKeyChecksums: [],
+            environment: environment
+        )
     }
 
     func calculateCacheKeys(for graph: DependencyGraph<CacheTarget>) async throws -> [CacheTarget: SwiftPMCacheKey] {
+        let environment = try await cacheKeyEnvironment()
         var cacheKeys: [CacheTarget: SwiftPMCacheKey] = [:]
 
         func calculateCacheKeyRecursively(for node: DependencyGraph<CacheTarget>.Node) async throws {
@@ -283,7 +294,8 @@ struct CacheSystem: Sendable {
             }
             cacheKeys[node.value] = try await calculateCacheKey(
                 of: node.value,
-                dependencyCacheKeyChecksums: dependencyChecksums
+                dependencyCacheKeyChecksums: dependencyChecksums,
+                environment: environment
             )
         }
 
@@ -296,7 +308,8 @@ struct CacheSystem: Sendable {
 
     private func calculateCacheKey(
         of target: CacheTarget,
-        dependencyCacheKeyChecksums: [DependencyCacheKeyChecksum]
+        dependencyCacheKeyChecksums: [DependencyCacheKeyChecksum],
+        environment: CacheKeyEnvironment
     ) async throws -> SwiftPMCacheKey {
         let package = target.buildProduct.package
 
@@ -311,21 +324,28 @@ struct CacheSystem: Sendable {
 
         let targetName = target.buildProduct.target.name
         let buildOptions = target.buildOptions
+        return SwiftPMCacheKey(
+            localPackageCanonicalLocation: localPackageCanonicalLocation,
+            pin: pinState,
+            targetName: targetName,
+            buildOptions: buildOptions,
+            clangVersion: environment.clangVersion,
+            xcodeVersion: environment.xcodeVersion,
+            scipioVersion: currentScipioVersion,
+            dependencyCacheKeyChecksums: dependencyCacheKeyChecksums
+        )
+    }
+
+    private func cacheKeyEnvironment() async throws -> CacheKeyEnvironment {
         guard let clangVersion = try await ClangChecker().fetchClangVersion() else {
             throw Error.compilerVersionNotDetected
         } // TODO DI
         guard let xcodeVersion = try await XcodeVersionFetcher().fetchXcodeVersion() else {
             throw Error.xcodeVersionNotDetected
         }
-        return SwiftPMCacheKey(
-            localPackageCanonicalLocation: localPackageCanonicalLocation,
-            pin: pinState,
-            targetName: targetName,
-            buildOptions: buildOptions,
+        return CacheKeyEnvironment(
             clangVersion: clangVersion,
-            xcodeVersion: xcodeVersion,
-            scipioVersion: currentScipioVersion,
-            dependencyCacheKeyChecksums: dependencyCacheKeyChecksums
+            xcodeVersion: xcodeVersion
         )
     }
 

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -326,24 +326,7 @@ struct CacheSystem: Sendable {
                 )
             }
 
-            let layerResults: [CacheKeyCalculationResult] = if inputs.isEmpty {
-                []
-            } else {
-                try await inputs.asyncMap(
-                    numberOfConcurrentTasks: UInt(min(inputs.count, CacheSystem.defaultParallelNumber))
-                ) { input in
-                    do {
-                        let cacheKey = try await calculateCacheKey(
-                            of: input.target,
-                            dependencyCacheKeyChecksums: input.dependencyCacheKeyChecksums,
-                            environment: environment
-                        )
-                        return CacheKeyCalculationResult.calculated(input.target, cacheKey)
-                    } catch Error.revisionNotDetected(let packageName) {
-                        return CacheKeyCalculationResult.revisionNotDetected(input.target, packageName)
-                    }
-                }
-            }
+            let layerResults = try await calculateCacheKeyResults(for: inputs, environment: environment)
 
             for result in layerResults {
                 switch result {
@@ -381,6 +364,28 @@ struct CacheSystem: Sendable {
         }
 
         return cacheKeys
+    }
+
+    private func calculateCacheKeyResults(
+        for inputs: [CacheKeyCalculationInput],
+        environment: CacheKeyEnvironment
+    ) async throws -> [CacheKeyCalculationResult] {
+        guard !inputs.isEmpty else { return [] }
+
+        return try await inputs.asyncMap(
+            numberOfConcurrentTasks: UInt(min(inputs.count, CacheSystem.defaultParallelNumber))
+        ) { input in
+            do {
+                let cacheKey = try await calculateCacheKey(
+                    of: input.target,
+                    dependencyCacheKeyChecksums: input.dependencyCacheKeyChecksums,
+                    environment: environment
+                )
+                return CacheKeyCalculationResult.calculated(input.target, cacheKey)
+            } catch Error.revisionNotDetected(let packageName) {
+                return CacheKeyCalculationResult.revisionNotDetected(input.target, packageName)
+            }
+        }
     }
 
     private func calculateCacheKey(

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -235,11 +235,6 @@ struct CacheSystem: Sendable {
         )
     }
 
-    func generateVersionFile(for target: CacheTarget) async throws {
-        let cacheKey = try await calculateCacheKey(of: target)
-        try await generateVersionFile(for: target, cacheKey: cacheKey)
-    }
-
     func existsValidCache(cacheKey: SwiftPMCacheKey) async -> Bool {
         do {
             let versionFilePath = versionFilePath(for: cacheKey.targetName)

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -124,7 +124,13 @@ public struct SwiftPMCacheKey: CacheKey {
         try container.encode(clangVersion, forKey: .clangVersion)
         try container.encode(xcodeVersion, forKey: .xcodeVersion)
         try container.encodeIfPresent(scipioVersion, forKey: .scipioVersion)
-        try container.encode(sortDependencyCacheKeyChecksums(dependencyCacheKeyChecksums), forKey: .dependencyCacheKeyChecksums)
+        // Preserve the serialized form, and therefore the checksum, of dependency-free legacy keys.
+        if !dependencyCacheKeyChecksums.isEmpty {
+            try container.encode(
+                sortDependencyCacheKeyChecksums(dependencyCacheKeyChecksums),
+                forKey: .dependencyCacheKeyChecksums
+            )
+        }
     }
 }
 

--- a/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
+++ b/Sources/ScipioKit/Producer/Cache/CacheSystem.swift
@@ -206,11 +206,11 @@ struct CacheSystem: Sendable {
                     group.addTask {
                         let frameworkPath = outputDirectory.appendingPathComponent(frameworkName)
                         do {
+                            guard let cacheKey = cacheKeys[target] else { return }
                             logger.info(
                                 "🚀 Cache \(frameworkName) to cache storage: \(storageName)",
                                 metadata: .color(.green)
                             )
-                            guard let cacheKey = cacheKeys[target] else { return }
                             try await cacheFramework(at: frameworkPath, for: cacheKey, to: storage)
                         } catch {
                             logger.warning("⚠️ Can't create caches for \(frameworkPath.path)")

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -94,7 +94,17 @@ struct FrameworkProducer {
             cacheKeys = [:]
             dependencyGraphToBuild = targetGraph
         } else {
-            cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
+            do {
+                cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
+            } catch {
+                // Fall back to "build without cache participation" for targets whose cache keys
+                // cannot be resolved (for example, missing local git metadata in fixtures).
+                logger.warning(
+                    "⚠️ Cache key precomputation failed. Continue build without cache restore/save for this run.",
+                    metadata: .color(.yellow)
+                )
+                cacheKeys = [:]
+            }
             let targets = Set(targetGraph.allNodes.map(\.value))
 
             // Validate the existing frameworks in `outputDir` before restoration

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -94,17 +94,7 @@ struct FrameworkProducer {
             cacheKeys = [:]
             dependencyGraphToBuild = targetGraph
         } else {
-            do {
-                cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
-            } catch {
-                // Fall back to "build without cache participation" for targets whose cache keys
-                // cannot be resolved (for example, missing local git metadata in fixtures).
-                logger.warning(
-                    "⚠️ Cache key precomputation failed. Continue build without cache restore/save for this run.",
-                    metadata: .color(.yellow)
-                )
-                cacheKeys = [:]
-            }
+            cacheKeys = await precomputeCacheKeysIfPossible(cacheSystem: cacheSystem, targetGraph: targetGraph)
             let targets = Set(targetGraph.allNodes.map(\.value))
 
             // Validate the existing frameworks in `outputDir` before restoration
@@ -173,6 +163,23 @@ struct FrameworkProducer {
 
         if case .interrupted(_, let error) = targetBuildResult {
             throw error
+        }
+    }
+
+    private func precomputeCacheKeysIfPossible(
+        cacheSystem: CacheSystem,
+        targetGraph: DependencyGraph<CacheSystem.CacheTarget>
+    ) async -> [CacheSystem.CacheTarget: SwiftPMCacheKey] {
+        do {
+            return try await cacheSystem.calculateCacheKeys(for: targetGraph)
+        } catch {
+            // Fall back to "build without cache participation" for targets whose cache keys
+            // cannot be resolved (for example, missing local git metadata in fixtures).
+            logger.warning(
+                "⚠️ Cache key precomputation failed. Continue build without cache restore/save for this run.",
+                metadata: .color(.yellow)
+            )
+            return [:]
         }
     }
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -94,7 +94,7 @@ struct FrameworkProducer {
             cacheKeys = [:]
             dependencyGraphToBuild = targetGraph
         } else {
-            cacheKeys = try await precomputeCacheKeysIfPossible(cacheSystem: cacheSystem, targetGraph: targetGraph)
+            cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
             let targets = Set(targetGraph.allNodes.map(\.value))
 
             // Validate the existing frameworks in `outputDir` before restoration
@@ -162,24 +162,6 @@ struct FrameworkProducer {
         }
 
         if case .interrupted(_, let error) = targetBuildResult {
-            throw error
-        }
-    }
-
-    private func precomputeCacheKeysIfPossible(
-        cacheSystem: CacheSystem,
-        targetGraph: DependencyGraph<CacheSystem.CacheTarget>
-    ) async throws -> [CacheSystem.CacheTarget: SwiftPMCacheKey] {
-        do {
-            return try await cacheSystem.calculateCacheKeys(for: targetGraph)
-        } catch CacheSystem.Error.revisionNotDetected(let packageName) {
-            // Keep a full fallback for revision errors raised before target-level calculation.
-            logger.warning(
-                "⚠️ Cache key precomputation failed because \(packageName) has no revision. Continue build without cache restore/save for this run.",
-                metadata: .color(.yellow)
-            )
-            return [:]
-        } catch {
             throw error
         }
     }

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -419,15 +419,22 @@ struct FrameworkProducer {
         using cacheSystem: CacheSystem,
         cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
     ) async {
+        let frameworkName = target.buildProduct.frameworkName
         guard let cacheKey = cacheKeys[target] else {
-            logger.warning("⚠️ Could not create VersionFile. This framework will not be cached.", metadata: .color(.yellow))
+            logger.warning(
+                "⚠️ Could not create VersionFile for \(frameworkName). This framework will not be cached.",
+                metadata: .color(.yellow)
+            )
             return
         }
 
         do {
             try await cacheSystem.generateVersionFile(for: target, cacheKey: cacheKey)
         } catch {
-            logger.warning("⚠️ Could not create VersionFile. This framework will not be cached.", metadata: .color(.yellow))
+            logger.warning(
+                "⚠️ Could not create VersionFile for \(frameworkName). This framework will not be cached.",
+                metadata: .color(.yellow)
+            )
         }
     }
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -458,6 +458,9 @@ struct FrameworkProducer {
         logger.info("⏹️ Sharing to other cache storages finished", metadata: .color(.green))
     }
 
+}
+
+extension FrameworkProducer {
     private func areStoragesEqual(_ lhs: any FrameworkCacheStorage, _ rhs: any FrameworkCacheStorage) -> Bool {
         // ProjectCacheStorage instances are always considered the same
         if lhs is ProjectCacheStorage && rhs is ProjectCacheStorage {

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -437,8 +437,12 @@ struct FrameworkProducer {
         using cacheSystem: CacheSystem,
         cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
     ) async {
+        guard let cacheKey = cacheKeys[target] else {
+            logger.warning("⚠️ Could not create VersionFile. This framework will not be cached.", metadata: .color(.yellow))
+            return
+        }
+
         do {
-            guard let cacheKey = cacheKeys[target] else { return }
             try await cacheSystem.generateVersionFile(for: target, cacheKey: cacheKey)
         } catch {
             logger.warning("⚠️ Could not create VersionFile. This framework will not be cached.", metadata: .color(.yellow))

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -86,18 +86,22 @@ struct FrameworkProducer {
         let allTargets = targetGraph.allNodes.map(\.value)
 
         let cacheSystem = CacheSystem(outputDirectory: outputDir)
+        let cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
 
         let dependencyGraphToBuild: DependencyGraph<CacheSystem.CacheTarget>
         if cachePolicies.isEmpty {
             // no-op because cache is disabled
+            cacheKeys = [:]
             dependencyGraphToBuild = targetGraph
         } else {
+            cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
             let targets = Set(targetGraph.allNodes.map(\.value))
 
             // Validate the existing frameworks in `outputDir` before restoration
             let valid = await validateExistingFrameworks(
                 availableTargets: targets,
-                cacheSystem: cacheSystem
+                cacheSystem: cacheSystem,
+                cacheKeys: cacheKeys
             )
 
             let storagesWithConsumer = cachePolicies.storages(for: .consumer)
@@ -108,7 +112,8 @@ struct FrameworkProducer {
                 let restoredSetsToSourceStorage = await restoreAllAvailableCachesIfNeeded(
                     availableTargets: targets.subtracting(valid),
                     to: storagesWithConsumer,
-                    cacheSystem: cacheSystem
+                    cacheSystem: cacheSystem,
+                    cacheKeys: cacheKeys
                 )
 
                 let allRestoredTargets = restoredSetsToSourceStorage.keys.reduce(into: Set<CacheSystem.CacheTarget>()) { result, targetSet in
@@ -119,7 +124,8 @@ struct FrameworkProducer {
                     await shareRestoredCachesToProducers(
                         allRestoredTargets,
                         restoredSetsToSourceStorage: restoredSetsToSourceStorage,
-                        cacheSystem: cacheSystem
+                        cacheSystem: cacheSystem,
+                        cacheKeys: cacheKeys
                     )
                 }
 
@@ -137,12 +143,21 @@ struct FrameworkProducer {
                 builtTargets
             }
 
-        await cacheFrameworksIfNeeded(Set(builtTargets), cacheSystem: cacheSystem)
+        // Keep the historical "cache feature is fully off" behavior when no cache policy is provided:
+        // no restore, no cache save, and no version file generation.
+        guard !cachePolicies.isEmpty else {
+            if case .interrupted(_, let error) = targetBuildResult {
+                throw error
+            }
+            return
+        }
+
+        await cacheFrameworksIfNeeded(Set(builtTargets), cacheSystem: cacheSystem, cacheKeys: cacheKeys)
 
         if shouldGenerateVersionFile {
             // Versionfiles should be generate for all targets
             for target in allTargets {
-                await generateVersionFile(for: target, using: cacheSystem)
+                await generateVersionFile(for: target, using: cacheSystem, cacheKeys: cacheKeys)
             }
         }
 
@@ -153,7 +168,8 @@ struct FrameworkProducer {
 
     private func validateExistingFrameworks(
         availableTargets: Set<CacheSystem.CacheTarget>,
-        cacheSystem: CacheSystem
+        cacheSystem: CacheSystem,
+        cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
     ) async -> Set<CacheSystem.CacheTarget> {
         let chunked = availableTargets.chunks(ofCount: CacheSystem.defaultParallelNumber)
 
@@ -169,7 +185,7 @@ struct FrameworkProducer {
                             let exists = fileSystem.exists(outputPath)
                             guard exists else { return nil }
 
-                            let expectedCacheKey = try await cacheSystem.calculateCacheKey(of: target)
+                            guard let expectedCacheKey = cacheKeys[target] else { return nil }
                             let isValidCache = await cacheSystem.existsValidCache(cacheKey: expectedCacheKey)
                             guard isValidCache else {
                                 logger.warning("⚠️ Existing \(frameworkName) is outdated.", metadata: .color(.yellow))
@@ -201,7 +217,8 @@ struct FrameworkProducer {
     private func restoreAllAvailableCachesIfNeeded(
         availableTargets: Set<CacheSystem.CacheTarget>,
         to storages: [any FrameworkCacheStorage],
-        cacheSystem: CacheSystem
+        cacheSystem: CacheSystem,
+        cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
     ) async -> [Set<CacheSystem.CacheTarget>: any FrameworkCacheStorage] {
         var remainingTargets = availableTargets
         var restoredSetsToSourceStorage: [Set<CacheSystem.CacheTarget>: any FrameworkCacheStorage] = [:]
@@ -225,7 +242,8 @@ struct FrameworkProducer {
             let restoredPerStorage = await restoreCaches(
                 for: remainingTargets,
                 from: storage,
-                cacheSystem: cacheSystem
+                cacheSystem: cacheSystem,
+                cacheKeys: cacheKeys
             )
 
             // Record which storage restored which set of targets
@@ -252,7 +270,8 @@ struct FrameworkProducer {
     private func restoreCaches(
         for targets: Set<CacheSystem.CacheTarget>,
         from cacheStorage: any FrameworkCacheStorage,
-        cacheSystem: CacheSystem
+        cacheSystem: CacheSystem,
+        cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
     ) async -> Set<CacheSystem.CacheTarget> {
         let chunked = targets.chunks(ofCount: cacheStorage.parallelNumber ?? CacheSystem.defaultParallelNumber)
 
@@ -265,6 +284,7 @@ struct FrameworkProducer {
                         do {
                             let restored = try await restorer.restore(
                                 target: target,
+                                cacheKey: cacheKeys[target],
                                 cacheSystem: cacheSystem,
                                 cacheStorage: cacheStorage
                             )
@@ -290,16 +310,19 @@ struct FrameworkProducer {
         // Return true if pre-built artifact is available (already existing or restored from cache)
         func restore(
             target: CacheSystem.CacheTarget,
+            cacheKey: SwiftPMCacheKey?,
             cacheSystem: CacheSystem,
             cacheStorage: any FrameworkCacheStorage
         ) async throws -> Bool {
             let product = target.buildProduct
             let frameworkName = product.frameworkName
 
-            let expectedCacheKey = try await cacheSystem.calculateCacheKey(of: target)
+            guard let expectedCacheKey = cacheKey else {
+                return false
+            }
             let expectedCacheKeyHash = try expectedCacheKey.calculateChecksum()
 
-            let restoreResult = await cacheSystem.restoreCacheIfPossible(target: target, storage: cacheStorage)
+            let restoreResult = await cacheSystem.restoreCacheIfPossible(cacheKey: expectedCacheKey, storage: cacheStorage)
             switch restoreResult {
             case .succeeded:
                 logger.info("✅ Restore \(frameworkName) (\(expectedCacheKeyHash)) from cache storage.", metadata: .color(.green))
@@ -380,16 +403,25 @@ struct FrameworkProducer {
         return []
     }
 
-    private func cacheFrameworksIfNeeded(_ targets: Set<CacheSystem.CacheTarget>, cacheSystem: CacheSystem) async {
+    private func cacheFrameworksIfNeeded(
+        _ targets: Set<CacheSystem.CacheTarget>,
+        cacheSystem: CacheSystem,
+        cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
+    ) async {
         let storagesWithProducer = cachePolicies.storages(for: .producer)
         if !storagesWithProducer.isEmpty {
-            await cacheSystem.cacheFrameworks(targets, to: storagesWithProducer)
+            await cacheSystem.cacheFrameworks(targets, cacheKeys: cacheKeys, to: storagesWithProducer)
         }
     }
 
-    private func generateVersionFile(for target: CacheSystem.CacheTarget, using cacheSystem: CacheSystem) async {
+    private func generateVersionFile(
+        for target: CacheSystem.CacheTarget,
+        using cacheSystem: CacheSystem,
+        cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
+    ) async {
         do {
-            try await cacheSystem.generateVersionFile(for: target)
+            guard let cacheKey = cacheKeys[target] else { return }
+            try await cacheSystem.generateVersionFile(for: target, cacheKey: cacheKey)
         } catch {
             logger.warning("⚠️ Could not create VersionFile. This framework will not be cached.", metadata: .color(.yellow))
         }
@@ -398,7 +430,8 @@ struct FrameworkProducer {
     private func shareRestoredCachesToProducers(
         _ allRestoredTargets: Set<CacheSystem.CacheTarget>,
         restoredSetsToSourceStorage: [Set<CacheSystem.CacheTarget>: any FrameworkCacheStorage],
-        cacheSystem: CacheSystem
+        cacheSystem: CacheSystem,
+        cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
     ) async {
         let storagesWithProducer = cachePolicies.storages(for: .producer)
         guard !storagesWithProducer.isEmpty else { return }
@@ -418,7 +451,7 @@ struct FrameworkProducer {
             }
 
             if !targetsToShare.isEmpty {
-                await shareCachesToStorage(targetsToShare, to: storage, cacheSystem: cacheSystem)
+                await shareCachesToStorage(targetsToShare, to: storage, cacheSystem: cacheSystem, cacheKeys: cacheKeys)
             }
         }
 
@@ -444,7 +477,8 @@ struct FrameworkProducer {
     private func shareCachesToStorage(
         _ targets: Set<CacheSystem.CacheTarget>,
         to storage: any FrameworkCacheStorage,
-        cacheSystem: CacheSystem
+        cacheSystem: CacheSystem,
+        cacheKeys: [CacheSystem.CacheTarget: SwiftPMCacheKey]
     ) async {
         let chunked = targets.chunks(ofCount: storage.parallelNumber ?? CacheSystem.defaultParallelNumber)
 
@@ -453,7 +487,7 @@ struct FrameworkProducer {
                 for target in chunk {
                     group.addTask {
                         do {
-                            let cacheKey = try await cacheSystem.calculateCacheKey(of: target)
+                            guard let cacheKey = cacheKeys[target] else { return }
                             let hasCache = try await storage.existsValidCache(for: cacheKey)
                             guard !hasCache else { return }
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -94,7 +94,7 @@ struct FrameworkProducer {
             cacheKeys = [:]
             dependencyGraphToBuild = targetGraph
         } else {
-            cacheKeys = await precomputeCacheKeysIfPossible(cacheSystem: cacheSystem, targetGraph: targetGraph)
+            cacheKeys = try await precomputeCacheKeysIfPossible(cacheSystem: cacheSystem, targetGraph: targetGraph)
             let targets = Set(targetGraph.allNodes.map(\.value))
 
             // Validate the existing frameworks in `outputDir` before restoration
@@ -169,17 +169,19 @@ struct FrameworkProducer {
     private func precomputeCacheKeysIfPossible(
         cacheSystem: CacheSystem,
         targetGraph: DependencyGraph<CacheSystem.CacheTarget>
-    ) async -> [CacheSystem.CacheTarget: SwiftPMCacheKey] {
+    ) async throws -> [CacheSystem.CacheTarget: SwiftPMCacheKey] {
         do {
             return try await cacheSystem.calculateCacheKeys(for: targetGraph)
-        } catch {
+        } catch CacheSystem.Error.revisionNotDetected(let packageName) {
             // Fall back to "build without cache participation" for targets whose cache keys
             // cannot be resolved (for example, missing local git metadata in fixtures).
             logger.warning(
-                "⚠️ Cache key precomputation failed. Continue build without cache restore/save for this run.",
+                "⚠️ Cache key precomputation failed because \(packageName) has no revision. Continue build without cache restore/save for this run.",
                 metadata: .color(.yellow)
             )
             return [:]
+        } catch {
+            throw error
         }
     }
 

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -173,8 +173,7 @@ struct FrameworkProducer {
         do {
             return try await cacheSystem.calculateCacheKeys(for: targetGraph)
         } catch CacheSystem.Error.revisionNotDetected(let packageName) {
-            // Fall back to "build without cache participation" for targets whose cache keys
-            // cannot be resolved (for example, missing local git metadata in fixtures).
+            // Keep a full fallback for revision errors raised before target-level calculation.
             logger.warning(
                 "⚠️ Cache key precomputation failed because \(packageName) has no revision. Continue build without cache restore/save for this run.",
                 metadata: .color(.yellow)

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -163,6 +163,37 @@ final class CacheSystemTests: XCTestCase {
         )
     }
 
+    func testCacheKeysRemainAvailableWhenDependentRevisionIsNotDetected() async throws {
+        let taggedFixture = try await makeTaggedPartialCacheTestPackagePath()
+        defer { try? LocalFileSystem.default.removeFileTree(taggedFixture.rootPath) }
+
+        let descriptionPackage = try await DescriptionPackage(
+            packageDirectory: taggedFixture.packagePath,
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: true
+        )
+        let buildOptions = defaultBuildOptions()
+        let targetGraph = try descriptionPackage.resolveBuildProductDependencyGraph().map { buildProduct in
+            var package = buildProduct.package
+            if buildProduct.target.name == "Bad" {
+                package.path = "/path/to/a/missing/package"
+            }
+            let buildProduct = BuildProduct(package: package, target: buildProduct.target)
+            return CacheSystem.CacheTarget(buildProduct: buildProduct, buildOptions: buildOptions)
+        }
+        let cacheSystem = CacheSystem(
+            outputDirectory: FileManager.default.temporaryDirectory.appendingPathComponent("XCFrameworks")
+        )
+
+        let cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
+        let baseTarget = try XCTUnwrap(targetGraph.allNodes.map(\.value).first { $0.buildProduct.target.name == "Base" })
+        let badTarget = try XCTUnwrap(targetGraph.allNodes.map(\.value).first { $0.buildProduct.target.name == "Bad" })
+
+        XCTAssertNotNil(cacheKeys[baseTarget])
+        XCTAssertNil(cacheKeys[badTarget])
+    }
+
     func testDependencyCacheKeyChangesDependentCacheKey() async throws {
         let taggedFixture = try await makeTaggedPartialCacheTestPackagePath()
         defer { try? LocalFileSystem.default.removeFileTree(taggedFixture.rootPath) }

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -35,7 +35,11 @@ final class CacheSystemTests: XCTestCase {
                 stripStaticDWARFSymbols: false
             ),
             clangVersion: "clang-1400.0.29.102",
-            xcodeVersion: .init(xcodeVersion: "15.4", xcodeBuildVersion: "15F31d")
+            xcodeVersion: .init(xcodeVersion: "15.4", xcodeBuildVersion: "15F31d"),
+            dependencyCacheKeyChecksums: [
+                .init(targetName: "Zebra", checksum: "222222"),
+                .init(targetName: "Base", checksum: "111111"),
+            ]
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
@@ -67,6 +71,16 @@ final class CacheSystemTests: XCTestCase {
             "stripStaticDWARFSymbols" : false
           },
           "clangVersion" : "clang-1400.0.29.102",
+          "dependencyCacheKeyChecksums" : [
+            {
+              "checksum" : "111111",
+              "targetName" : "Base"
+            },
+            {
+              "checksum" : "222222",
+              "targetName" : "Zebra"
+            }
+          ],
           "localPackageCanonicalLocation" : "\\/path\\/to\\/MyPackage",
           "pin" : {
             "revision" : "111111111"
@@ -80,6 +94,115 @@ final class CacheSystemTests: XCTestCase {
         """
         // swiftlint:enable line_length
         XCTAssertEqual(rawString, expected)
+    }
+
+    func testDecodeCacheKeyWithoutDependencyCacheKeyChecksums() throws {
+        let rawString = """
+        {
+          "buildOptions" : {
+            "buildConfiguration" : "release",
+            "enableLibraryEvolution" : false,
+            "frameworkType" : "dynamic",
+            "isDebugSymbolsEmbedded" : false,
+            "keepPublicHeadersStructure" : false,
+            "sdks" : [
+              "iOS"
+            ],
+            "stripStaticDWARFSymbols" : false
+          },
+          "clangVersion" : "clang-1400.0.29.102",
+          "pin" : {
+            "revision" : "111111111"
+          },
+          "targetName" : "MyTarget",
+          "xcodeVersion" : {
+            "xcodeBuildVersion" : "15F31d",
+            "xcodeVersion" : "15.4"
+          }
+        }
+        """
+
+        let cacheKey = try JSONDecoder().decode(SwiftPMCacheKey.self, from: Data(rawString.utf8))
+
+        XCTAssertEqual(cacheKey.dependencyCacheKeyChecksums, [])
+    }
+
+    func testCacheKeysIncludeDirectDependencyChecksums() async throws {
+        let packagePath = fixturePath.appendingPathComponent("PartialCacheTestPackage")
+        let descriptionPackage = try await DescriptionPackage(
+            packageDirectory: packagePath,
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: true
+        )
+        let buildOptions = defaultBuildOptions()
+        let targetGraph = try descriptionPackage.resolveBuildProductDependencyGraph().map { buildProduct in
+            CacheSystem.CacheTarget(buildProduct: buildProduct, buildOptions: buildOptions)
+        }
+        let cacheSystem = CacheSystem(
+            outputDirectory: FileManager.default.temporaryDirectory.appendingPathComponent("XCFrameworks")
+        )
+
+        let cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
+        let baseTarget = try XCTUnwrap(targetGraph.allNodes.map(\.value).first { $0.buildProduct.target.name == "Base" })
+        let badTarget = try XCTUnwrap(targetGraph.allNodes.map(\.value).first { $0.buildProduct.target.name == "Bad" })
+        let baseCacheKey = try XCTUnwrap(cacheKeys[baseTarget])
+        let badCacheKey = try XCTUnwrap(cacheKeys[badTarget])
+
+        XCTAssertEqual(baseCacheKey.dependencyCacheKeyChecksums, [])
+        XCTAssertEqual(
+            badCacheKey.dependencyCacheKeyChecksums,
+            [
+                DependencyCacheKeyChecksum(
+                    targetName: "Base",
+                    checksum: try baseCacheKey.calculateChecksum()
+                ),
+            ]
+        )
+    }
+
+    func testDependencyCacheKeyChangesDependentCacheKey() async throws {
+        let packagePath = fixturePath.appendingPathComponent("PartialCacheTestPackage")
+        let descriptionPackage = try await DescriptionPackage(
+            packageDirectory: packagePath,
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: true
+        )
+        let dynamicBuildOptions = defaultBuildOptions(frameworkType: .dynamic)
+        let staticBuildOptions = defaultBuildOptions(frameworkType: .static)
+        let dynamicTargetGraph = try descriptionPackage.resolveBuildProductDependencyGraph().map { buildProduct in
+            CacheSystem.CacheTarget(buildProduct: buildProduct, buildOptions: dynamicBuildOptions)
+        }
+        let changedDependencyTargetGraph = try descriptionPackage.resolveBuildProductDependencyGraph().map { buildProduct in
+            CacheSystem.CacheTarget(
+                buildProduct: buildProduct,
+                buildOptions: buildProduct.target.name == "Base" ? staticBuildOptions : dynamicBuildOptions
+            )
+        }
+        let cacheSystem = CacheSystem(
+            outputDirectory: FileManager.default.temporaryDirectory.appendingPathComponent("XCFrameworks")
+        )
+
+        let dynamicCacheKeys = try await cacheSystem.calculateCacheKeys(for: dynamicTargetGraph)
+        let changedDependencyCacheKeys = try await cacheSystem.calculateCacheKeys(for: changedDependencyTargetGraph)
+        let dynamicBaseTarget = try XCTUnwrap(dynamicTargetGraph.allNodes.map(\.value).first { $0.buildProduct.target.name == "Base" })
+        let dynamicBadTarget = try XCTUnwrap(dynamicTargetGraph.allNodes.map(\.value).first { $0.buildProduct.target.name == "Bad" })
+        let changedBaseTarget = try XCTUnwrap(
+            changedDependencyTargetGraph.allNodes.map(\.value).first { $0.buildProduct.target.name == "Base" }
+        )
+        let changedBadTarget = try XCTUnwrap(
+            changedDependencyTargetGraph.allNodes.map(\.value).first { $0.buildProduct.target.name == "Bad" }
+        )
+
+        XCTAssertNotEqual(
+            try dynamicCacheKeys[dynamicBaseTarget]?.calculateChecksum(),
+            try changedDependencyCacheKeys[changedBaseTarget]?.calculateChecksum()
+        )
+        XCTAssertNotEqual(
+            try dynamicCacheKeys[dynamicBadTarget]?.calculateChecksum(),
+            try changedDependencyCacheKeys[changedBadTarget]?.calculateChecksum()
+        )
     }
 
     func testCacheKeyForRemoteAndLocalPackageDifference() async throws {
@@ -240,5 +363,20 @@ final class CacheSystemTests: XCTestCase {
 
         XCTAssertEqual(cacheKey.targetName, myTarget.name)
         XCTAssertEqual(cacheKey.pin.version, "1.1.0")
+    }
+
+    private func defaultBuildOptions(frameworkType: FrameworkType = .dynamic) -> BuildOptions {
+        BuildOptions(
+            buildConfiguration: .release,
+            isDebugSymbolsEmbedded: false,
+            frameworkType: frameworkType,
+            sdks: [.iOS, .iOSSimulator],
+            extraFlags: nil,
+            extraBuildParameters: nil,
+            enableLibraryEvolution: false,
+            keepPublicHeadersStructure: false,
+            customFrameworkModuleMapContents: nil,
+            stripStaticDWARFSymbols: false
+        )
     }
 }

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -308,7 +308,8 @@ final class CacheSystemTests: XCTestCase {
             let cacheSystem = CacheSystem(
                 outputDirectory: FileManager.default.temporaryDirectory.appendingPathComponent("XCFrameworks")
             )
-            return try await cacheSystem.calculateCacheKey(of: cacheTarget)
+            let cacheKeys = try await calculateCacheKeys(for: cacheTarget, using: cacheSystem)
+            return try XCTUnwrap(cacheKeys[cacheTarget])
         }
 
         let scipioTestingRemote = try await scipioTestingCacheKey(fixture: "AsRemotePackage")
@@ -373,15 +374,9 @@ final class CacheSystemTests: XCTestCase {
             )
         )
 
-        // Ensure that the cache key cannot be calculated if the package is not in the Git repository.
-        do {
-            _ = try await cacheSystem.calculateCacheKey(of: cacheTarget)
-            XCTFail("A cache key should not be possible to calculate if the package is not in a repository.")
-        } catch let error as CacheSystem.Error {
-            XCTAssertEqual(error.errorDescription, "Repository version is not detected for \(descriptionPackage.name).")
-        } catch {
-            XCTFail("Wrong error type.")
-        }
+        // Graph-based calculation excludes targets whose package revision cannot be detected.
+        let unavailableCacheKeys = try await calculateCacheKeys(for: cacheTarget, using: cacheSystem)
+        XCTAssertNil(unavailableCacheKeys[cacheTarget])
 
         // Ensure that the cache key is properly calculated when the package is in a repository with the correct tag."
         let processExecutor: Executor = ProcessExecutor()
@@ -398,10 +393,23 @@ final class CacheSystemTests: XCTestCase {
         try await processExecutor.execute(["/usr/bin/xcrun", "git", "-C", tempTestingPackagePathString, "commit", "-m", "Initial commit"])
         try await processExecutor.execute(["/usr/bin/xcrun", "git", "-C", tempTestingPackagePathString, "tag", "v1.1"])
 
-        let cacheKey = try await cacheSystem.calculateCacheKey(of: cacheTarget)
+        let cacheKeys = try await calculateCacheKeys(for: cacheTarget, using: cacheSystem)
+        let cacheKey = try XCTUnwrap(cacheKeys[cacheTarget])
 
         XCTAssertEqual(cacheKey.targetName, myTarget.name)
         XCTAssertEqual(cacheKey.pin.version, "1.1.0")
+    }
+
+    private func calculateCacheKeys(
+        for target: CacheSystem.CacheTarget,
+        using cacheSystem: CacheSystem
+    ) async throws -> [CacheSystem.CacheTarget: SwiftPMCacheKey] {
+        let graph = try DependencyGraph.resolve(
+            Set([target]),
+            id: \.buildProduct.target.name,
+            childIDs: { _ in [] }
+        )
+        return try await cacheSystem.calculateCacheKeys(for: graph)
     }
 
     private func defaultBuildOptions(frameworkType: FrameworkType = .dynamic) -> BuildOptions {

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -128,9 +128,11 @@ final class CacheSystemTests: XCTestCase {
     }
 
     func testCacheKeysIncludeDirectDependencyChecksums() async throws {
-        let packagePath = fixturePath.appendingPathComponent("PartialCacheTestPackage")
+        let taggedFixture = try await makeTaggedPartialCacheTestPackagePath()
+        defer { try? LocalFileSystem.default.removeFileTree(taggedFixture.rootPath) }
+
         let descriptionPackage = try await DescriptionPackage(
-            packageDirectory: packagePath,
+            packageDirectory: taggedFixture.packagePath,
             mode: .createPackage,
             resolvedPackagesCachePolicies: [],
             onlyUseVersionsFromResolvedFile: true
@@ -162,9 +164,11 @@ final class CacheSystemTests: XCTestCase {
     }
 
     func testDependencyCacheKeyChangesDependentCacheKey() async throws {
-        let packagePath = fixturePath.appendingPathComponent("PartialCacheTestPackage")
+        let taggedFixture = try await makeTaggedPartialCacheTestPackagePath()
+        defer { try? LocalFileSystem.default.removeFileTree(taggedFixture.rootPath) }
+
         let descriptionPackage = try await DescriptionPackage(
-            packageDirectory: packagePath,
+            packageDirectory: taggedFixture.packagePath,
             mode: .createPackage,
             resolvedPackagesCachePolicies: [],
             onlyUseVersionsFromResolvedFile: true
@@ -378,5 +382,41 @@ final class CacheSystemTests: XCTestCase {
             customFrameworkModuleMapContents: nil,
             stripStaticDWARFSymbols: false
         )
+    }
+
+    private func makeTaggedPartialCacheTestPackagePath(
+        function: String = #function
+    ) async throws -> (rootPath: URL, packagePath: URL) {
+        let fileSystem: LocalFileSystem = .default
+        let rootPath = fileSystem.tempDirectory.appending(component: function)
+        let packagePath = rootPath.appending(component: "PartialCacheTestPackage")
+
+        try fileSystem.removeFileTree(rootPath)
+        try fileSystem.createDirectory(rootPath)
+        try fileSystem.copy(
+            from: fixturePath.appendingPathComponent("PartialCacheTestPackage"),
+            to: packagePath
+        )
+
+        let executor: Executor = ProcessExecutor()
+        let packagePathString = packagePath.path(percentEncoded: false)
+        try await executor.execute(["/usr/bin/xcrun", "git", "init", packagePathString])
+        try await executor.execute(["/usr/bin/xcrun", "git", "-C", packagePathString, "add", "."])
+        try await executor.execute([
+            "/usr/bin/xcrun",
+            "git",
+            "-C",
+            packagePathString,
+            "-c",
+            "user.name=Scipio Tests",
+            "-c",
+            "user.email=scipio@example.com",
+            "commit",
+            "-m",
+            "Initial commit",
+        ])
+        try await executor.execute(["/usr/bin/xcrun", "git", "-C", packagePathString, "tag", "v1.0.0"])
+
+        return (rootPath, packagePath)
     }
 }

--- a/Tests/ScipioKitTests/CacheSystemTests.swift
+++ b/Tests/ScipioKitTests/CacheSystemTests.swift
@@ -96,7 +96,7 @@ final class CacheSystemTests: XCTestCase {
         XCTAssertEqual(rawString, expected)
     }
 
-    func testDecodeCacheKeyWithoutDependencyCacheKeyChecksums() throws {
+    func testDecodeAndEncodeCacheKeyWithoutDependencyCacheKeyChecksums() throws {
         let rawString = """
         {
           "buildOptions" : {
@@ -125,6 +125,10 @@ final class CacheSystemTests: XCTestCase {
         let cacheKey = try JSONDecoder().decode(SwiftPMCacheKey.self, from: Data(rawString.utf8))
 
         XCTAssertEqual(cacheKey.dependencyCacheKeyChecksums, [])
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        XCTAssertEqual(try encoder.encode(cacheKey), Data(rawString.utf8))
     }
 
     func testCacheKeysIncludeDirectDependencyChecksums() async throws {

--- a/Tests/ScipioKitTests/FrameworkProducerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkProducerTests.swift
@@ -100,7 +100,13 @@ struct FrameworkProducerTests {
             )
         )
 
-        let mockCacheKey = try await cacheSystem.calculateCacheKey(of: mockTarget)
+        let targetGraph = try DependencyGraph.resolve(
+            Set([mockTarget]),
+            id: \.buildProduct.target.name,
+            childIDs: { _ in [] }
+        )
+        let cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
+        let mockCacheKey = try #require(cacheKeys[mockTarget])
 
         // Setup initial state: 
         // - RestoreSource: has cache and will be the restore source (should be excluded from sharing)

--- a/Tests/ScipioKitTests/PackageResolverCacheSystemTests.swift
+++ b/Tests/ScipioKitTests/PackageResolverCacheSystemTests.swift
@@ -7,26 +7,26 @@ import CacheStorage
 package let packageURL = URL(filePath: #filePath)
     .deletingLastPathComponent()
     .appending(components: "Resources", "Fixtures", "TestingPackage")
-private let packageLocation = PackageLocation(packageDirectory: packageURL)
 private let fileSystem: LocalFileSystem = .default
 
 struct PackageResolverCacheSystemTests {
     @Test(
         "Caches resolved packages to cache storages",
         .sharedResolvedPackagesTrait,
-        arguments: CachePolicyEntry.allCases
+        arguments: CachePolicyKind.allCases
     )
-    func cacheResolvedPackages(entries: [CachePolicyEntry]) async throws {
+    func cacheResolvedPackages(kinds: [CachePolicyKind]) async throws {
+        let testContext = try #require(TestContext.shared)
+        let originHash = try #require(testContext.originHash)
+        let entries = CachePolicyEntry.entries(for: kinds, context: testContext)
+
         defer {
             entries.cleanup(using: fileSystem)
         }
 
-        let testContext = try #require(TestContext.shared)
-        let originHash = try #require(testContext.originHash)
-
         let cacheSystem = PackageResolver.CacheSystem(
             fileSystem: fileSystem,
-            packageLocator: packageLocation,
+            packageLocator: testContext.packageLocation,
             cachePolicies: entries.map(\.cachePolicy)
         )
 
@@ -35,7 +35,7 @@ struct PackageResolverCacheSystemTests {
         #expect(
             try await entries.allHaveValidCache(
                 for: originHash,
-                packageLocator: packageLocation,
+                packageLocator: testContext.packageLocation,
                 fileSystem: fileSystem
             )
         )
@@ -44,19 +44,20 @@ struct PackageResolverCacheSystemTests {
     @Test(
         "Returns noCache when no resolved packages cache exists",
         .sharedResolvedPackagesTrait,
-        arguments: CachePolicyEntry.allCases
+        arguments: CachePolicyKind.allCases
     )
-    func returnsNoCacheWhenCacheDoesNotExist(entries: [CachePolicyEntry]) async throws {
+    func returnsNoCacheWhenCacheDoesNotExist(kinds: [CachePolicyKind]) async throws {
+        let testContext = try #require(TestContext.shared)
+        let originHash = try #require(testContext.originHash)
+        let entries = CachePolicyEntry.entries(for: kinds, context: testContext)
+
         defer {
             entries.cleanup(using: fileSystem)
         }
 
-        let testContext = try #require(TestContext.shared)
-        let originHash = try #require(testContext.originHash)
-
         let cacheSystem = PackageResolver.CacheSystem(
             fileSystem: fileSystem,
-            packageLocator: packageLocation,
+            packageLocator: testContext.packageLocation,
             cachePolicies: entries.map(\.cachePolicy)
         )
 
@@ -72,19 +73,20 @@ struct PackageResolverCacheSystemTests {
     @Test(
         "Returns valid cache when a resolved packages cache exists",
         .sharedResolvedPackagesTrait,
-        arguments: CachePolicyEntry.allCases
+        arguments: CachePolicyKind.allCases
     )
-    func returnsValidCacheWhenCacheDoesExist(entries: [CachePolicyEntry]) async throws {
+    func returnsValidCacheWhenCacheDoesExist(kinds: [CachePolicyKind]) async throws {
+        let testContext = try #require(TestContext.shared)
+        let originHash = try #require(testContext.originHash)
+        let entries = CachePolicyEntry.entries(for: kinds, context: testContext)
+
         defer {
             entries.cleanup(using: fileSystem)
         }
 
-        let testContext = try #require(TestContext.shared)
-        let originHash = try #require(testContext.originHash)
-
         let cacheSystem = PackageResolver.CacheSystem(
             fileSystem: fileSystem,
-            packageLocator: packageLocation,
+            packageLocator: testContext.packageLocation,
             cachePolicies: entries.map(\.cachePolicy)
         )
 
@@ -106,8 +108,8 @@ struct PackageResolverCacheSystemTests {
         let testContext = try #require(TestContext.shared)
         let originHash = try #require(testContext.originHash)
 
-        let projectCacheEntry: CachePolicyEntry = .project
-        let localDiskCacheEntry: CachePolicyEntry = .localDisk
+        let projectCacheEntry = CachePolicyEntry.project(context: testContext)
+        let localDiskCacheEntry = CachePolicyEntry.localDisk(context: testContext)
 
         let entries: [CachePolicyEntry] = [projectCacheEntry, localDiskCacheEntry, .inMemory()]
 
@@ -117,7 +119,7 @@ struct PackageResolverCacheSystemTests {
 
         let cacheSystem = PackageResolver.CacheSystem(
             fileSystem: fileSystem,
-            packageLocator: packageLocation,
+            packageLocator: testContext.packageLocation,
             cachePolicies: entries.map(\.cachePolicy)
         )
 
@@ -131,7 +133,7 @@ struct PackageResolverCacheSystemTests {
         #expect(
             try await [projectCacheEntry, localDiskCacheEntry].allHaveValidCache(
                 for: originHash,
-                packageLocator: packageLocation,
+                packageLocator: testContext.packageLocation,
                 fileSystem: fileSystem
             )
         )
@@ -146,28 +148,54 @@ struct PackageResolverCacheSystemTests {
         }
     }
 
+    enum CachePolicyKind: Sendable {
+        case project
+        case localDisk
+        case inMemory
+
+        static let allCases: [[Self]] = [
+            [.project],
+            [.localDisk],
+            [.inMemory],
+            [.project, .localDisk, .inMemory],
+        ]
+    }
+
     /// Represents a cache policy configuration with cleanup logic for testing.
     struct CachePolicyEntry: Sendable {
         let cachePolicy: Runner.Options.ResolvedPackagesCachePolicy
         let cleanup: @Sendable (any FileSystem) -> Void
 
-        private static func localDisk(baseURL: URL) -> CachePolicyEntry {
+        fileprivate static func entries(for kinds: [CachePolicyKind], context: TestContext) -> [CachePolicyEntry] {
+            kinds.map { kind in
+                switch kind {
+                case .project:
+                    project(context: context)
+                case .localDisk:
+                    localDisk(context: context)
+                case .inMemory:
+                    inMemory()
+                }
+            }
+        }
+
+        fileprivate static func project(context: TestContext) -> CachePolicyEntry {
             CachePolicyEntry(
-                cachePolicy: .localDisk(baseURL: baseURL),
+                cachePolicy: .project,
                 cleanup: { fileSystem in
-                    try? fileSystem.removeFileTree(baseURL)
+                    try? fileSystem.removeFileTree(context.packageLocation.resolvedPackagesCacheDirectory)
                 }
             )
         }
 
-        static let project: CachePolicyEntry = CachePolicyEntry(
-            cachePolicy: .project,
-            cleanup: { fileSystem in
-                try? fileSystem.removeFileTree(packageLocation.resolvedPackagesCacheDirectory)
-            }
-        )
-
-        static let localDisk: CachePolicyEntry = .localDisk(baseURL: fileSystem.tempDirectory.appending(components: #fileID))
+        fileprivate static func localDisk(context: TestContext) -> CachePolicyEntry {
+            CachePolicyEntry(
+                cachePolicy: .localDisk(baseURL: context.localDiskCacheDirectory),
+                cleanup: { fileSystem in
+                    try? fileSystem.removeFileTree(context.localDiskCacheDirectory)
+                }
+            )
+        }
 
         static func inMemory() -> CachePolicyEntry {
             CachePolicyEntry(
@@ -175,13 +203,6 @@ struct PackageResolverCacheSystemTests {
                 cleanup: { _ in }
             )
         }
-
-        static let allCases: [[Self]] = [
-            [.project],
-            [.localDisk],
-            [.inMemory()],
-            [.project, .localDisk, .inMemory()],
-        ]
     }
 }
 
@@ -212,13 +233,25 @@ private struct SharedResolvedPackagesTrait: TestTrait, TestScoping {
         testCase: Test.Case?,
         performing function: () async throws -> Void
     ) async throws {
+        let temporaryDirectory = fileSystem.tempDirectory
+            .appending(components: "PackageResolverCacheSystemTests", UUID().uuidString)
+        let temporaryPackageURL = temporaryDirectory.appending(component: "TestingPackage")
+
+        try fileSystem.createDirectory(temporaryDirectory, recursive: true)
+        try fileSystem.copy(from: packageURL, to: temporaryPackageURL)
+
+        defer {
+            try? fileSystem.removeFileTree(temporaryDirectory)
+        }
+
         let executor = ProcessExecutor()
         let manifestLoader = ManifestLoader(executor: executor)
 
-        let rootManifest = try await manifestLoader.loadManifest(for: packageURL)
+        let rootManifest = try await manifestLoader.loadManifest(for: temporaryPackageURL)
 
+        let packageLocation = PackageLocation(packageDirectory: temporaryPackageURL)
         let packageResolver: PackageResolver = await PackageResolver(
-            packageLocator: PackageLocation(packageDirectory: packageURL),
+            packageLocator: packageLocation,
             rootManifest: rootManifest,
             cachePolicies: [],
             fileSystem: LocalFileSystem.default
@@ -227,7 +260,9 @@ private struct SharedResolvedPackagesTrait: TestTrait, TestScoping {
 
         let context = TestContext(
             resolvedPackages: Array(modulesGraph.allPackages.values),
-            originHash: UUID().uuidString
+            originHash: UUID().uuidString,
+            packageLocation: packageLocation,
+            localDiskCacheDirectory: temporaryDirectory.appending(component: "LocalDiskCache")
         )
 
         try await TestContext.$shared.withValue(context) {
@@ -271,6 +306,8 @@ private struct PackageLocation: PackageLocator {
 private struct TestContext: Sendable {
     let resolvedPackages: [ResolvedPackage]
     let originHash: String?
+    let packageLocation: PackageLocation
+    let localDiskCacheDirectory: URL
 
     @TaskLocal static var shared: Self?
 }

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -400,19 +400,15 @@ final class RunnerTests: XCTestCase {
         let cacheSystem = CacheSystem(
             outputDirectory: frameworkOutputDir
         )
-        let packages = descriptionPackage.graph.allPackages.values
-            .filter { $0.manifest.name != descriptionPackage.manifest.name }
-
-        let allTargets = packages
-            .flatMap { package in
-                package.targets.map { BuildProduct(package: package, target: $0) }
-            }
-            .map {
-                CacheSystem.CacheTarget(buildProduct: $0, buildOptions: .default)
-            }
+        let targetGraph = try descriptionPackage.resolveBuildProductDependencyGraph().map { buildProduct in
+            CacheSystem.CacheTarget(buildProduct: buildProduct, buildOptions: .default)
+        }
+        let cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
+        let allTargets = targetGraph.allNodes.map(\.value)
 
         for product in allTargets {
-            try await cacheSystem.generateVersionFile(for: product)
+            let cacheKey = try XCTUnwrap(cacheKeys[product])
+            try await cacheSystem.generateVersionFile(for: product, cacheKey: cacheKey)
             // generate dummy directory
             try fileManager.createDirectory(
                 at: frameworkOutputDir.appendingPathComponent(product.buildProduct.frameworkName),
@@ -627,19 +623,15 @@ final class RunnerTests: XCTestCase {
         let cacheSystem = CacheSystem(
             outputDirectory: frameworkOutputDir
         )
-        let packages = descriptionPackage.graph.allPackages.values
-            .filter { $0.manifest.name != descriptionPackage.manifest.name }
-
-        let allTargets = packages
-            .flatMap { package in
-                package.targets.map { BuildProduct(package: package, target: $0) }
-            }
-            .map {
-                CacheSystem.CacheTarget(buildProduct: $0, buildOptions: .default)
-            }
+        let targetGraph = try descriptionPackage.resolveBuildProductDependencyGraph().map { buildProduct in
+            CacheSystem.CacheTarget(buildProduct: buildProduct, buildOptions: .default)
+        }
+        let cacheKeys = try await cacheSystem.calculateCacheKeys(for: targetGraph)
+        let allTargets = targetGraph.allNodes.map(\.value)
 
         for product in allTargets {
-            try await cacheSystem.generateVersionFile(for: product)
+            let cacheKey = try XCTUnwrap(cacheKeys[product])
+            try await cacheSystem.generateVersionFile(for: product, cacheKey: cacheKey)
             // generate dummy directory
             try fileManager.createDirectory(
                 at: frameworkOutputDir.appendingPathComponent(product.buildProduct.frameworkName),


### PR DESCRIPTION
## Summary
This PR fixes stale cache reuse for dependent frameworks by including dependency build state in cache keys.

Previously, a downstream target could keep reusing a cached artifact even after a dependency was rebuilt with incompatible changes.

Related issue: #265

## What Changed
- Added dependencyCacheKeyChecksums to SwiftPMCacheKey.
- Added graph-based cache key calculation (calculateCacheKeys(for:)) that computes keys in dependency order and embeds direct dependency key checksums.
- Updated framework cache flows to reuse a single cache-key map across existing framework validation, restore checks, cache writes, version file generation, and restored cache sharing.
- Preserved backward compatibility for old version files by decoding missing dependencyCacheKeyChecksums as an empty list.
- Stabilized dependency checksum ordering with a deterministic tie-breaker (targetName, then checksum).
- Kept historical behavior when cache policies are empty (cache feature is fully off).
- Fall back to building without cache participation when cache key precomputation fails, so missing local repository metadata does not abort the build before the intended build path.

## Tests
- Extended CacheSystemTests to cover encoding with dependency checksums, backward-compatible decode, direct dependency checksum propagation, and dependent key invalidation when dependency build state changes.
- Updated cache key tests to copy the PartialCacheTestPackage fixture into a temporary tagged git repository, keeping them stable in CI merge checkouts.
- FrameworkProducerTests passes locally.
- CI is passing.

## Impact
- Dependency changes now correctly invalidate dependent cache keys.
- Reduces risk of link/runtime failures caused by stale downstream cache artifacts.
- Maintains existing non-cache behavior for packages whose cache keys cannot be resolved.