### PR TITLE
Fix process executor hang on inherited pipes

### DIFF
--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -1,11 +1,64 @@
 import Foundation
+import Darwin
+import os
 
-/// Buffer to collect process output bytes.
-private actor ProcessOutputBuffer {
-    private(set) var bytes: [UInt8] = []
+/// Buffer to collect process output bytes from Foundation callbacks.
+private final class ProcessOutputBuffer: Sendable {
+    private let storage = OSAllocatedUnfairLock(initialState: [UInt8]())
+    private let lastStreamOutputTask = OSAllocatedUnfairLock(initialState: Task<Void, Never> {})
+    private let streamOutput: (@Sendable ([UInt8]) async -> Void)?
 
-    func append(_ newBytes: [UInt8]) {
-        bytes += newBytes
+    init(streamOutput: (@Sendable ([UInt8]) async -> Void)? = nil) {
+        self.streamOutput = streamOutput
+    }
+
+    func drain(from fileDescriptor: Int32) {
+        for bytes in Self.drainAvailableBytes(from: fileDescriptor) {
+            storage.withLock {
+                $0.append(contentsOf: bytes)
+            }
+            if let streamOutput {
+                lastStreamOutputTask.withLock {
+                    let previousTask = $0
+                    $0 = Task {
+                        await previousTask.value
+                        await streamOutput(bytes)
+                    }
+                }
+            }
+        }
+    }
+
+    var snapshot: [UInt8] {
+        storage.withLock { $0 }
+    }
+
+    func finishStreaming() async {
+        let task = lastStreamOutputTask.withLock { $0 }
+        await task.value
+    }
+
+    private static func drainAvailableBytes(from fileDescriptor: Int32) -> [[UInt8]] {
+        var chunks: [[UInt8]] = []
+        var buffer = [UInt8](repeating: 0, count: 4096)
+
+        while true {
+            let byteCount = buffer.withUnsafeMutableBytes {
+                Darwin.read(fileDescriptor, $0.baseAddress, $0.count)
+            }
+
+            switch byteCount {
+            case let byteCount where byteCount > 0:
+                chunks.append(Array(buffer.prefix(byteCount)))
+            case 0:
+                return chunks
+            default:
+                if errno == EINTR {
+                    continue
+                }
+                return chunks
+            }
+        }
     }
 }
 
@@ -141,79 +194,72 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
 
         let outputHandle = stdoutPipe.fileHandleForReading
         let errorHandle = stderrPipe.fileHandleForReading
+        let outputFileDescriptor = outputHandle.fileDescriptor
+        let errorFileDescriptor = errorHandle.fileDescriptor
 
-        let outputBuffer = ProcessOutputBuffer()
+        let outputBuffer = ProcessOutputBuffer(streamOutput: streamOutput)
         let errorBuffer = ProcessOutputBuffer()
 
-        let localStreamOutput = streamOutput
         let localDecoder = errorDecoder
 
-        let outputTask = Task {
-            // Workaround to avoid "Bad file descriptor" error when executing processes at high concurrency.
-            // Investigate this section if command output is missing
-            // ref: https://github.com/swiftlang/swift/issues/57827
-            defer { try? outputHandle.close() }
-            for try await data in outputHandle.byteStream() {
-                let bytes = [UInt8](data)
-                await localStreamOutput?(bytes)
-                await outputBuffer.append(bytes)
-            }
-            return await outputBuffer.bytes
+        Self.setNonBlocking(outputFileDescriptor)
+        Self.setNonBlocking(errorFileDescriptor)
+
+        outputHandle.readabilityHandler = { _ in
+            outputBuffer.drain(from: outputFileDescriptor)
         }
 
-        let errorOutputTask = Task {
-            // Workaround to avoid "Bad file descriptor" error when executing processes at high concurrency.
-            // Investigate this section if command output is missing
-            // ref: https://github.com/swiftlang/swift/issues/57827
-            defer { try? errorHandle.close() }
-            for try await data in errorHandle.byteStream() {
-                let bytes = [UInt8](data)
-                await errorBuffer.append(bytes)
-            }
-            return await errorBuffer.bytes
+        errorHandle.readabilityHandler = { _ in
+            errorBuffer.drain(from: errorFileDescriptor)
         }
 
-        do {
-            try process.run()
-        } catch {
-            throw ProcessExecutorError.unknownError(error)
-        }
-
-        process.waitUntilExit()
-
-        let finalOutput = try await outputTask.value
-        let finalErrorOutput = try await errorOutputTask.value
-
-        // Wait for process to complete
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ExecutorResult, Error>) in
             process.terminationHandler = { process in
                 outputHandle.readabilityHandler = nil
                 errorHandle.readabilityHandler = nil
 
-                let exitStatus = exitStatus(of: process)
+                Task {
+                    outputBuffer.drain(from: outputFileDescriptor)
+                    errorBuffer.drain(from: errorFileDescriptor)
+                    try? outputHandle.close()
+                    try? errorHandle.close()
+                    await outputBuffer.finishStreaming()
 
-                let result = FoundationProcessResult(
-                    arguments: arguments,
-                    exitStatus: exitStatus,
-                    output: .success(finalOutput),
-                    stderrOutput: .success(finalErrorOutput)
-                )
+                    let result = FoundationProcessResult(
+                        arguments: arguments,
+                        exitStatus: exitStatus(of: process),
+                        output: .success(outputBuffer.snapshot),
+                        stderrOutput: .success(errorBuffer.snapshot)
+                    )
 
-                switch exitStatus {
-                case .terminated(let code) where code == 0:
-                    continuation.resume(returning: result)
-                case .terminated:
-                    do {
-                        let errorOutput = try localDecoder.decode(result)
+                    switch result.exitStatus {
+                    case .terminated(let code) where code == 0:
+                        continuation.resume(returning: result)
+                    case .terminated:
+                        let errorOutput = try? localDecoder.decode(result)
                         continuation.resume(throwing: ProcessExecutorError.terminated(errorOutput: errorOutput))
-                    } catch {
-                        continuation.resume(throwing: ProcessExecutorError.terminated(errorOutput: nil))
+                    case .signalled(let signal):
+                        continuation.resume(throwing: ProcessExecutorError.signalled(signal))
                     }
-                case .signalled(let signal):
-                    continuation.resume(throwing: ProcessExecutorError.signalled(signal))
                 }
             }
+
+            do {
+                try process.run()
+            } catch {
+                outputHandle.readabilityHandler = nil
+                errorHandle.readabilityHandler = nil
+                try? outputHandle.close()
+                try? errorHandle.close()
+                continuation.resume(throwing: ProcessExecutorError.unknownError(error))
+            }
         }
+    }
+
+    private static func setNonBlocking(_ fileDescriptor: Int32) {
+        let flags = fcntl(fileDescriptor, F_GETFL)
+        guard flags != -1 else { return }
+        _ = fcntl(fileDescriptor, F_SETFL, flags | O_NONBLOCK)
     }
 
     /// Determines the exit status of the process based on its termination reason.
@@ -261,25 +307,5 @@ public struct StandardOutputDecoder: ErrorDecoder, Sendable {
 
     public func decode(_ result: ExecutorResult) throws -> String? {
         try result.unwrapOutput()
-    }
-}
-
-extension FileHandle {
-    fileprivate func byteStream() -> AsyncThrowingStream<Data, Error> {
-        AsyncThrowingStream { continuation in
-            self.readabilityHandler = { handle in
-                let data = handle.availableData
-                if data.isEmpty {
-                    continuation.finish()
-                    handle.readabilityHandler = nil
-                } else {
-                    continuation.yield(data)
-                }
-            }
-
-            continuation.onTermination = { @Sendable _ in
-                self.readabilityHandler = nil
-            }
-        }
     }
 }

--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -2,9 +2,17 @@ import Foundation
 import Darwin
 import os
 
-/// Buffer to collect process output bytes from Foundation callbacks.
-private final class ProcessOutputBuffer: Sendable {
+/// Reads currently available process output without waiting for EOF.
+///
+/// The file descriptor is non-blocking. `readabilityHandler` drains while the
+/// process is running, and `terminationHandler` drains once more to capture
+/// trailing bytes that Foundation has not delivered yet. This intentionally
+/// does not wait for pipe EOF because long-lived descendants may inherit the
+/// write end and keep it open after the immediate child exits.
+private final class ProcessOutputReader: Sendable {
     private let storage = OSAllocatedUnfairLock(initialState: [UInt8]())
+
+    // Serializes async stream callbacks in the same order as bytes were read.
     private let lastStreamOutputTask = OSAllocatedUnfairLock(initialState: Task<Void, Never> {})
     private let streamOutput: (@Sendable ([UInt8]) async -> Void)?
 
@@ -38,6 +46,8 @@ private final class ProcessOutputBuffer: Sendable {
         await task.value
     }
 
+    /// Reads all bytes currently available on a non-blocking file descriptor.
+    /// EAGAIN/EWOULDBLOCK means there is no more data ready right now.
     private static func drainAvailableBytes(from fileDescriptor: Int32) -> [[UInt8]] {
         var chunks: [[UInt8]] = []
         var buffer = [UInt8](repeating: 0, count: 4096)
@@ -197,8 +207,8 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
         let outputFileDescriptor = outputHandle.fileDescriptor
         let errorFileDescriptor = errorHandle.fileDescriptor
 
-        let outputBuffer = ProcessOutputBuffer(streamOutput: streamOutput)
-        let errorBuffer = ProcessOutputBuffer()
+        let outputReader = ProcessOutputReader(streamOutput: streamOutput)
+        let errorReader = ProcessOutputReader()
 
         let localDecoder = errorDecoder
 
@@ -206,11 +216,11 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
         Self.setNonBlocking(errorFileDescriptor)
 
         outputHandle.readabilityHandler = { _ in
-            outputBuffer.drain(from: outputFileDescriptor)
+            outputReader.drain(from: outputFileDescriptor)
         }
 
         errorHandle.readabilityHandler = { _ in
-            errorBuffer.drain(from: errorFileDescriptor)
+            errorReader.drain(from: errorFileDescriptor)
         }
 
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ExecutorResult, Error>) in
@@ -219,17 +229,17 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
                 errorHandle.readabilityHandler = nil
 
                 Task {
-                    outputBuffer.drain(from: outputFileDescriptor)
-                    errorBuffer.drain(from: errorFileDescriptor)
+                    outputReader.drain(from: outputFileDescriptor)
+                    errorReader.drain(from: errorFileDescriptor)
                     try? outputHandle.close()
                     try? errorHandle.close()
-                    await outputBuffer.finishStreaming()
+                    await outputReader.finishStreaming()
 
                     let result = FoundationProcessResult(
                         arguments: arguments,
                         exitStatus: exitStatus(of: process),
-                        output: .success(outputBuffer.snapshot),
-                        stderrOutput: .success(errorBuffer.snapshot)
+                        output: .success(outputReader.snapshot),
+                        stderrOutput: .success(errorReader.snapshot)
                     )
 
                     switch result.exitStatus {

--- a/Sources/ScipioKit/Executor.swift
+++ b/Sources/ScipioKit/Executor.swift
@@ -2,53 +2,126 @@ import Foundation
 import Darwin
 import os
 
-/// Reads currently available process output without waiting for EOF.
+/// Collects process output from a single non-blocking file handle.
 ///
-/// The file descriptor is non-blocking. `readabilityHandler` drains while the
-/// process is running, and `terminationHandler` drains once more to capture
-/// trailing bytes that Foundation has not delivered yet. This intentionally
-/// does not wait for pipe EOF because long-lived descendants may inherit the
-/// write end and keep it open after the immediate child exits.
-private final class ProcessOutputReader: Sendable {
-    private let storage = OSAllocatedUnfairLock(initialState: [UInt8]())
+/// The reader owns the handle's readability notifications and closes the handle
+/// when collection finishes. `readabilityHandler` drains while the process is
+/// running, and `terminationHandler` drains once more to capture trailing bytes
+/// that Foundation has not delivered yet. The final drain reads only immediately
+/// available bytes instead of waiting for pipe EOF because long-lived descendants
+/// may inherit the write end and keep it open after the immediate child exits.
+final class ProcessOutputReader: Sendable {
+    enum DrainResult: Equatable {
+        /// The owned handle remains open and has not reached EOF.
+        case continueReading
 
-    // Serializes async stream callbacks in the same order as bytes were read.
-    private let lastStreamOutputTask = OSAllocatedUnfairLock(initialState: Task<Void, Never> {})
+        /// Observation can stop because the reader is closed or has reached EOF.
+        case finished
+    }
+
+    private struct State {
+        var closed = false
+        var reachedEndOfFile = false
+        var bytes: [UInt8] = []
+        var lastStreamOutputTask = Task<Void, Never> {}
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    private let fileHandle: FileHandle
     private let streamOutput: (@Sendable ([UInt8]) async -> Void)?
 
-    init(streamOutput: (@Sendable ([UInt8]) async -> Void)? = nil) {
+    /// Creates a reader that manages the supplied file handle until ``close()``.
+    ///
+    /// The handle must be configured for non-blocking reads before calling
+    /// ``startReading()`` or ``drain()``.
+    init(fileHandle: FileHandle, streamOutput: (@Sendable ([UInt8]) async -> Void)? = nil) {
+        self.fileHandle = fileHandle
         self.streamOutput = streamOutput
     }
 
-    func drain(from fileDescriptor: Int32) {
-        for bytes in Self.drainAvailableBytes(from: fileDescriptor) {
-            storage.withLock {
-                $0.append(contentsOf: bytes)
+    /// Starts draining whenever the file handle reports readable data.
+    func startReading() {
+        fileHandle.readabilityHandler = { [weak self] handle in
+            guard let self else {
+                handle.readabilityHandler = nil
+                return
             }
-            if let streamOutput {
-                lastStreamOutputTask.withLock {
-                    let previousTask = $0
-                    $0 = Task {
+
+            if case .finished = drain() {
+                handle.readabilityHandler = nil
+            }
+        }
+    }
+
+    /// Stops receiving readability notifications without closing the handle.
+    func stopReading() {
+        fileHandle.readabilityHandler = nil
+    }
+
+    /// Appends all bytes currently available from the owned file handle.
+    ///
+    /// Draining is serialized with ``close()`` so the handle cannot be
+    /// closed while a read is in progress.
+    ///
+    /// - Returns: ``DrainResult/finished`` after EOF or closure; otherwise,
+    ///   ``DrainResult/continueReading`` so observation can continue.
+    @discardableResult
+    func drain() -> DrainResult {
+        state.withLock { state in
+            guard !state.closed else { return .finished }
+            guard !state.reachedEndOfFile else { return .finished }
+
+            let result = Self.drainAvailableBytes(from: fileHandle.fileDescriptor)
+            for bytes in result.bytes {
+                state.bytes.append(contentsOf: bytes)
+                if let streamOutput {
+                    // Serialize callbacks in the same order as bytes were read.
+                    let previousTask = state.lastStreamOutputTask
+                    state.lastStreamOutputTask = Task {
                         await previousTask.value
                         await streamOutput(bytes)
                     }
                 }
             }
+
+            if result.reachedEndOfFile {
+                state.reachedEndOfFile = true
+                return .finished
+            }
+
+            return .continueReading
         }
     }
 
     var snapshot: [UInt8] {
-        storage.withLock { $0 }
+        state.withLock { $0.bytes }
     }
 
+    /// Waits for all stream output callbacks scheduled before this call.
     func finishStreaming() async {
-        let task = lastStreamOutputTask.withLock { $0 }
+        let task = state.withLock { $0.lastStreamOutputTask }
         await task.value
     }
 
+    /// Stops readability notifications and closes the owned handle once.
+    ///
+    /// Closing is serialized with any in-progress drain so no drain can access
+    /// the descriptor concurrently or after this method returns.
+    func close() {
+        stopReading()
+        state.withLock { state in
+            guard !state.closed else { return }
+            state.closed = true
+            try? fileHandle.close()
+        }
+    }
+
     /// Reads all bytes currently available on a non-blocking file descriptor.
-    /// EAGAIN/EWOULDBLOCK means there is no more data ready right now.
-    private static func drainAvailableBytes(from fileDescriptor: Int32) -> [[UInt8]] {
+    ///
+    /// `EINTR` retries the read. Any other read error ends the current drain
+    /// without treating it as EOF.
+    private static func drainAvailableBytes(from fileDescriptor: Int32) -> (bytes: [[UInt8]], reachedEndOfFile: Bool) {
         var chunks: [[UInt8]] = []
         var buffer = [UInt8](repeating: 0, count: 4096)
 
@@ -61,12 +134,12 @@ private final class ProcessOutputReader: Sendable {
             case let byteCount where byteCount > 0:
                 chunks.append(Array(buffer.prefix(byteCount)))
             case 0:
-                return chunks
+                return (chunks, true)
             default:
                 if errno == EINTR {
                     continue
                 }
-                return chunks
+                return (chunks, false)
             }
         }
     }
@@ -204,35 +277,33 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
 
         let outputHandle = stdoutPipe.fileHandleForReading
         let errorHandle = stderrPipe.fileHandleForReading
-        let outputFileDescriptor = outputHandle.fileDescriptor
-        let errorFileDescriptor = errorHandle.fileDescriptor
-
-        let outputReader = ProcessOutputReader(streamOutput: streamOutput)
-        let errorReader = ProcessOutputReader()
+        let outputReader = ProcessOutputReader(fileHandle: outputHandle, streamOutput: streamOutput)
+        let errorReader = ProcessOutputReader(fileHandle: errorHandle)
 
         let localDecoder = errorDecoder
 
-        Self.setNonBlocking(outputFileDescriptor)
-        Self.setNonBlocking(errorFileDescriptor)
-
-        outputHandle.readabilityHandler = { _ in
-            outputReader.drain(from: outputFileDescriptor)
+        do {
+            try Self.setNonBlocking(outputHandle.fileDescriptor)
+            try Self.setNonBlocking(errorHandle.fileDescriptor)
+        } catch {
+            outputReader.close()
+            errorReader.close()
+            throw ProcessExecutorError.unknownError(error)
         }
 
-        errorHandle.readabilityHandler = { _ in
-            errorReader.drain(from: errorFileDescriptor)
-        }
+        outputReader.startReading()
+        errorReader.startReading()
 
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ExecutorResult, Error>) in
             process.terminationHandler = { process in
-                outputHandle.readabilityHandler = nil
-                errorHandle.readabilityHandler = nil
+                outputReader.stopReading()
+                errorReader.stopReading()
 
                 Task {
-                    outputReader.drain(from: outputFileDescriptor)
-                    errorReader.drain(from: errorFileDescriptor)
-                    try? outputHandle.close()
-                    try? errorHandle.close()
+                    outputReader.drain()
+                    errorReader.drain()
+                    outputReader.close()
+                    errorReader.close()
                     await outputReader.finishStreaming()
 
                     let result = FoundationProcessResult(
@@ -257,19 +328,31 @@ public struct ProcessExecutor<Decoder: ErrorDecoder>: Executor, Sendable {
             do {
                 try process.run()
             } catch {
-                outputHandle.readabilityHandler = nil
-                errorHandle.readabilityHandler = nil
-                try? outputHandle.close()
-                try? errorHandle.close()
+                outputReader.close()
+                errorReader.close()
                 continuation.resume(throwing: ProcessExecutorError.unknownError(error))
             }
         }
     }
 
-    private static func setNonBlocking(_ fileDescriptor: Int32) {
-        let flags = fcntl(fileDescriptor, F_GETFL)
-        guard flags != -1 else { return }
-        _ = fcntl(fileDescriptor, F_SETFL, flags | O_NONBLOCK)
+    private static func setNonBlocking(_ fileDescriptor: Int32) throws {
+        let flags: Int32
+        while true {
+            let result = fcntl(fileDescriptor, F_GETFL)
+            if result != -1 {
+                flags = result
+                break
+            }
+            guard errno == EINTR else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
+
+        while fcntl(fileDescriptor, F_SETFL, flags | O_NONBLOCK) == -1 {
+            guard errno == EINTR else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
     }
 
     /// Determines the exit status of the process based on its termination reason.

--- a/Sources/ScipioKit/Logger.swift
+++ b/Sources/ScipioKit/Logger.swift
@@ -63,6 +63,7 @@ struct ScipioLogHandler: LogHandler {
         } else {
             print(message.description)
         }
+        fflush(stdout)
     }
 }
 

--- a/Tests/ScipioKitTests/ProcessExecutorTests.swift
+++ b/Tests/ScipioKitTests/ProcessExecutorTests.swift
@@ -101,26 +101,17 @@ struct ProcessExecutorTests {
     @Test("Executor completes when a descendant keeps stdout open")
     func completesWhenDescendantKeepsStdoutOpen() async throws {
         let executor = createExecutor()
-        let result = try await withThrowingTaskGroup(of: ExecutorResult.self) { group in
-            group.addTask {
-                try await executor.execute([
-                    "/bin/sh",
-                    "-c",
-                    "echo parent-output; (sleep 5) & exit 0",
-                ])
-            }
-            group.addTask {
-                try await Task.sleep(for: .seconds(1))
-                throw ProcessExecutorTestError.timedOut
-            }
-
-            let result = try #require(try await group.next())
-            group.cancelAll()
-            return result
-        }
+        let start = ContinuousClock.now
+        let result = try await executor.execute([
+            "/bin/sh",
+            "-c",
+            "echo parent-output; (sleep 5) & exit 0",
+        ])
+        let duration = start.duration(to: ContinuousClock.now)
 
         #expect(result.exitStatus == .terminated(code: 0))
         #expect(try result.unwrapOutput().contains("parent-output"))
+        #expect(duration < .seconds(1))
     }
 
     @Test("Executor waits for stream output delivery before returning")
@@ -334,10 +325,6 @@ private actor OutputDeliveryMarker {
     func collect(_ newBytes: [UInt8]) {
         bytes.append(contentsOf: newBytes)
     }
-}
-
-private enum ProcessExecutorTestError: Error {
-    case timedOut
 }
 
 private struct TestErrorDecoder: ErrorDecoder {

--- a/Tests/ScipioKitTests/ProcessExecutorTests.swift
+++ b/Tests/ScipioKitTests/ProcessExecutorTests.swift
@@ -111,7 +111,7 @@ struct ProcessExecutorTests {
 
         #expect(result.exitStatus == .terminated(code: 0))
         #expect(try result.unwrapOutput().contains("parent-output"))
-        #expect(duration < .seconds(1))
+        #expect(duration < .seconds(4))
     }
 
     @Test("Executor waits for stream output delivery before returning")

--- a/Tests/ScipioKitTests/ProcessExecutorTests.swift
+++ b/Tests/ScipioKitTests/ProcessExecutorTests.swift
@@ -98,6 +98,46 @@ struct ProcessExecutorTests {
         #expect(streamedString.contains(testCase.expectedOutputContains))
     }
 
+    @Test("Executor completes when a descendant keeps stdout open")
+    func completesWhenDescendantKeepsStdoutOpen() async throws {
+        let executor = createExecutor()
+        let result = try await withThrowingTaskGroup(of: ExecutorResult.self) { group in
+            group.addTask {
+                try await executor.execute([
+                    "/bin/sh",
+                    "-c",
+                    "echo parent-output; (sleep 5) & exit 0",
+                ])
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(1))
+                throw ProcessExecutorTestError.timedOut
+            }
+
+            let result = try #require(try await group.next())
+            group.cancelAll()
+            return result
+        }
+
+        #expect(result.exitStatus == .terminated(code: 0))
+        #expect(try result.unwrapOutput().contains("parent-output"))
+    }
+
+    @Test("Executor waits for stream output delivery before returning")
+    func waitsForStreamOutputDeliveryBeforeReturning() async throws {
+        let marker = OutputDeliveryMarker()
+        var executor = createExecutor()
+        executor.streamOutput = { bytes in
+            try? await Task.sleep(for: .milliseconds(100))
+            await marker.collect(bytes)
+        }
+
+        let result = try await executor.execute(["/bin/echo", "delivered-output"])
+
+        #expect(result.exitStatus == .terminated(code: 0))
+        #expect(await marker.outputString.contains("delivered-output"))
+    }
+
     // MARK: - Error Cases
 
     @Test("Executable not found error cases", arguments: [
@@ -282,6 +322,22 @@ private final class OutputCollector: @unchecked Sendable {
             _collectedOutput.append(bytes)
         }
     }
+}
+
+private actor OutputDeliveryMarker {
+    private var bytes: [UInt8] = []
+
+    var outputString: String {
+        String(decoding: bytes, as: UTF8.self)
+    }
+
+    func collect(_ newBytes: [UInt8]) {
+        bytes.append(contentsOf: newBytes)
+    }
+}
+
+private enum ProcessExecutorTestError: Error {
+    case timedOut
 }
 
 private struct TestErrorDecoder: ErrorDecoder {

--- a/Tests/ScipioKitTests/ProcessOutputReaderTests.swift
+++ b/Tests/ScipioKitTests/ProcessOutputReaderTests.swift
@@ -1,0 +1,68 @@
+import Darwin
+import Foundation
+import Testing
+@testable import ScipioKit
+
+struct ProcessOutputReaderTests {
+    @Test("Reader finishes when the pipe reaches EOF")
+    func finishesAtEOF() throws {
+        let pipe = Pipe()
+        let readHandle = pipe.fileHandleForReading
+        let writeHandle = pipe.fileHandleForWriting
+        let reader = ProcessOutputReader(fileHandle: readHandle)
+        defer {
+            reader.close()
+            try? writeHandle.close()
+        }
+
+        try writeHandle.close()
+
+        #expect(reader.drain() == .finished)
+        #expect(reader.drain() == .finished)
+    }
+
+    @Test("Reader ignores stale drains after closing")
+    func ignoresStaleDrainsAfterClosing() throws {
+        let sourcePipe = Pipe()
+        let sourceReadHandle = sourcePipe.fileHandleForReading
+        let sourceWriteHandle = sourcePipe.fileHandleForWriting
+        let reader = ProcessOutputReader(fileHandle: sourceReadHandle)
+        defer {
+            reader.close()
+            try? sourceWriteHandle.close()
+        }
+
+        try setNonBlocking(sourceReadHandle.fileDescriptor)
+        let expectedOutput = Array("captured-output".utf8)
+        try sourceWriteHandle.write(contentsOf: Data(expectedOutput))
+
+        #expect(reader.drain() == .continueReading)
+        #expect(reader.snapshot == expectedOutput)
+
+        reader.close()
+        try sourceWriteHandle.close()
+
+        // Represents a queued readability handler running after the original
+        // descriptor has been closed and its numeric value may have been reused.
+        let replacementPipe = Pipe()
+        let replacementReadHandle = replacementPipe.fileHandleForReading
+        let replacementWriteHandle = replacementPipe.fileHandleForWriting
+        defer {
+            try? replacementReadHandle.close()
+            try? replacementWriteHandle.close()
+        }
+
+        try replacementWriteHandle.write(contentsOf: Data("unrelated-output".utf8))
+        try replacementWriteHandle.close()
+
+        #expect(reader.drain() == .finished)
+
+        #expect(reader.snapshot == expectedOutput)
+    }
+
+    private func setNonBlocking(_ fileDescriptor: Int32) throws {
+        let flags = fcntl(fileDescriptor, F_GETFL)
+        try #require(flags != -1)
+        try #require(fcntl(fileDescriptor, F_SETFL, flags | O_NONBLOCK) != -1)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the process execution hang reported in #272 when a child process exits but a long-lived descendant keeps stdout/stderr pipe file descriptors open.

## Changes

- Make `ProcessExecutor` complete based on the immediate child process termination instead of waiting for pipe EOF.
- Introduce `ProcessOutputReader`, which owns each non-blocking `FileHandle` and manages its readability notifications and closure.
- Serialize read, append, and close operations through a single locked state so queued readability callbacks cannot access a closed or reused file descriptor.
- Track EOF explicitly, stop readability notifications when observation finishes, and perform one final non-blocking drain at process termination.
- Preserve ordered `streamOutput` delivery and wait for all scheduled callbacks before returning from `execute`.
- Retry interrupted `fcntl` calls and fail before starting the process if a pipe cannot be configured for non-blocking reads.
- Flush Scipio log output after each line so CI pipe output appears promptly.
- Add regression coverage for inherited pipe handles, stream delivery completion, EOF handling, and stale drains after closure.

## Root Cause

The Foundation.Process-based executor waited for stdout/stderr streams to reach EOF after `waitUntilExit()`. On fresh CI environments, build tools can spawn long-lived descendants that inherit the write end of those pipes, so EOF may never arrive even after the immediate child exits.

Completing at immediate-child termination requires a final drain without waiting for EOF. The reader therefore uses non-blocking descriptors and synchronizes draining with closure so a queued readability callback cannot race with descriptor closure or reuse.

## Validation

- `swift test --filter ProcessOutputReaderTests`
- `swift test --filter ProcessExecutorTests`
- `swift test`
- Confirmed by @r-plus https://github.com/giginet/Scipio/issues/272#issuecomment-4524278316
