### PR TITLE
Strip top-level SwiftPM traits from dump-package JSON before decoding

### DIFF
--- a/Sources/ScipioKit/Resolver/ManifestLoader.swift
+++ b/Sources/ScipioKit/Resolver/ManifestLoader.swift
@@ -44,8 +44,24 @@ struct ManifestLoader: @unchecked Sendable {
             throw Error.utf8EncodingFailed
         }
 
-        let manifest = try jsonDecoder.decode(Manifest.self, from: manifestData)
-        return manifest
+        return try decodeManifest(from: manifestData)
+    }
+
+    // PackageManifestKit 0.2.0 expects Manifest.traits as [String]?, but SwiftPM 6.1+
+    // dump-package emits trait objects. Since Scipio does not read top-level traits,
+    // decode directly and, only on failure, drop the field and retry. Remove once
+    // PackageManifestKit models Manifest.traits as [TraitDescription]?.
+    private func decodeManifest(from data: Data) throws -> Manifest {
+        do {
+            return try jsonDecoder.decode(Manifest.self, from: data)
+        } catch {
+            guard var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  object["traits"] != nil else {
+                throw error
+            }
+            object["traits"] = nil
+            return try jsonDecoder.decode(Manifest.self, from: JSONSerialization.data(withJSONObject: object))
+        }
     }
 
     enum Error: LocalizedError {

--- a/Tests/ScipioKitTests/ManifestLoaderTests.swift
+++ b/Tests/ScipioKitTests/ManifestLoaderTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable @_spi(Internals) import ScipioKit
+
+struct ManifestLoaderTests {
+    // A minimal dump-package payload whose top-level `traits` is the SwiftPM 6.1
+    // object form. PackageManifestKit models Manifest.traits as [String]?, so this
+    // fails to decode unless ManifestLoader strips the field first.
+    private static let manifestWithObjectFormTraits = """
+    {
+      "name": "MyFramework",
+      "toolsVersion": { "_version": "6.1.0" },
+      "dependencies": [],
+      "products": [],
+      "targets": [],
+      "packageKind": { "root": ["/tmp/MyFramework"] },
+      "traits": [
+        { "name": "default", "enabledTraits": ["Foo"] },
+        { "name": "Foo", "description": "bar", "enabledTraits": [] }
+      ]
+    }
+    """
+
+    // Same manifest without a `traits` key: exercises the strip no-op path.
+    private static let manifestWithoutTraits = """
+    {
+      "name": "MyFramework",
+      "toolsVersion": { "_version": "6.1.0" },
+      "dependencies": [],
+      "products": [],
+      "targets": [],
+      "packageKind": { "root": ["/tmp/MyFramework"] }
+    }
+    """
+
+    @Test
+    func decodesManifestDeclaringObjectFormTraits() async throws {
+        let executor = StubbableExecutor { arguments in
+            StubbableExecutorResult(arguments: arguments, success: Self.manifestWithObjectFormTraits)
+        }
+        let loader = ManifestLoader(executor: executor)
+
+        let manifest = try await loader.loadManifest(for: URL(filePath: "/tmp/MyFramework"))
+
+        #expect(manifest.name == "MyFramework")
+    }
+
+    @Test
+    func decodesManifestWithoutTraits() async throws {
+        let executor = StubbableExecutor { arguments in
+            StubbableExecutorResult(arguments: arguments, success: Self.manifestWithoutTraits)
+        }
+        let loader = ManifestLoader(executor: executor)
+
+        let manifest = try await loader.loadManifest(for: URL(filePath: "/tmp/MyFramework"))
+
+        #expect(manifest.name == "MyFramework")
+    }
+}


### PR DESCRIPTION
## Summary

`ManifestLoader` decodes `swift package dump-package` output into
`PackageManifestKit.Manifest`. Since SwiftPM 6.1, `dump-package` emits package
traits as objects:

```json
"traits" : [
  { "name" : "default", "enabledTraits" : ["FoundationURL"] },
  { "name" : "FoundationURL", "description" : "...", "enabledTraits" : [] }
]
```

but `PackageManifestKit` 0.2.0 models `Manifest.traits` as `[String]?`, so any
manifest that declares traits (e.g. swift-http-types 1.6.0) fails to decode,
aborting the build:

```
DecodingError.typeMismatch: expected String, found dictionary. Path: traits[0]
```

Scipio never reads top-level `Manifest.traits`, so this PR strips that field from
the `dump-package` JSON before decoding.

## Note

Stopgap until the root fix in PackageManifestKit (model `traits` as
`[TraitDescription]?`) ships and the dependency is bumped.
