### PR TITLE
Rewrite C header includes for framework consumers

### DIFF
--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -53,7 +53,11 @@ struct FrameworkProducer {
     }
 
     private func overriddenBuildOption(for buildProduct: BuildProduct) -> BuildOptions {
-        buildOptionsMatrix[buildProduct.target.name] ?? baseBuildOptions
+        overriddenBuildOption(forTargetNamed: buildProduct.target.name)
+    }
+
+    private func overriddenBuildOption(forTargetNamed targetName: String) -> BuildOptions {
+        buildOptionsMatrix[targetName] ?? baseBuildOptions
     }
 
     func clean() async throws {
@@ -353,7 +357,10 @@ struct FrameworkProducer {
             let compiler = PIFCompiler(
                 descriptionPackage: descriptionPackage,
                 buildOptions: buildOptions,
-                buildOptionsMatrix: buildOptionsMatrix
+                buildOptionsMatrix: buildOptionsMatrix,
+                keepPublicHeadersStructure: { [baseBuildOptions, buildOptionsMatrix] targetName in
+                    (buildOptionsMatrix[targetName] ?? baseBuildOptions).keepPublicHeadersStructure
+                }
             )
             try await compiler.createXCFramework(buildProduct: product,
                                                  outputDirectory: outputDir,

--- a/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
+++ b/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
@@ -18,16 +18,18 @@ import ScipioKitCore
 struct CHeaderIncludeRewriter {
     /// Source include path to framework include path, e.g. `"core/core.h" -> "CoreLib/core/core.h"`.
     private let replacementsByHeaderPath: [String: String]
+    private let fileSystem: any FileSystem
 
-    init(replacementsByHeaderPath: [String: String]) {
+    init(replacementsByHeaderPath: [String: String], fileSystem: some FileSystem = LocalFileSystem.default) {
         self.replacementsByHeaderPath = replacementsByHeaderPath
+        self.fileSystem = fileSystem
     }
 
     /// Builds the table from a target and its visible dependency closure.
     init(
         modules: some Sequence<ResolvedModule>,
         keepPublicHeadersStructure: (ResolvedModule) -> Bool,
-        fileSystem: any FileSystem = LocalFileSystem.default
+        fileSystem: some FileSystem = LocalFileSystem.default
     ) {
         var table: [String: String] = [:]
         var ambiguousPaths: Set<String> = []
@@ -75,37 +77,165 @@ struct CHeaderIncludeRewriter {
             table[path] = nil
         }
         self.replacementsByHeaderPath = table
+        self.fileSystem = fileSystem
     }
 
     var isEmpty: Bool { replacementsByHeaderPath.isEmpty }
 
-    // Angle includes only; quoted includes keep their source-relative semantics.
+    /// Where the header being rewritten comes from and how it lands inside the framework,
+    /// so quoted includes can be checked against the copied layout.
+    struct IncluderContext {
+        var sourceFile: URL
+        var includeDir: URL?
+        var keepsPublicHeadersStructure: Bool
+    }
+
+    private enum CaptureGroup {
+        static let directive = "directive"
+        static let anglePath = "anglePath"
+        static let quotedPath = "quotedPath"
+    }
+
     private static let includeRegex = try! NSRegularExpression(
-        pattern: #"^(\s*#\s*(?:include|import)\s*)<([^>]+)>"#
+        pattern: #"^(?<\#(CaptureGroup.directive)>\s*#\s*(?:include|import)\s*)"#
+            + #"(?:<(?<\#(CaptureGroup.anglePath)>[^>]+)>|"(?<\#(CaptureGroup.quotedPath)>[^"]+)")"#
     )
 
     /// Leaves system, ambiguous, and out-of-closure includes unchanged.
-    func rewrite(_ contents: String) -> String {
+    ///
+    /// Quoted includes mirror the compiler's lookup order: a file reachable relative to the
+    /// including header wins, but only as long as the copy into the framework preserves that
+    /// relation; flattened layouts break subdirectory relations, so such includes are rewritten
+    /// to the framework form like an angle include, looked up by the candidate's canonical
+    /// include-dir-relative path so `./` and `../` spellings rewrite too.
+    func rewrite(_ contents: String, includer: IncluderContext? = nil) -> String {
         guard !replacementsByHeaderPath.isEmpty else { return contents }
 
         let lines = contents.components(separatedBy: "\n")
         let rewritten = lines.map { line -> String in
             let range = NSRange(line.startIndex..<line.endIndex, in: line)
             guard let match = Self.includeRegex.firstMatch(in: line, range: range),
-                  let directiveRange = Range(match.range(at: 1), in: line),
-                  let pathRange = Range(match.range(at: 2), in: line) else {
+                  let directiveRange = Range(match.range(withName: CaptureGroup.directive), in: line) else {
+                return line
+            }
+
+            let pathRange: Range<String.Index>
+            let isQuoted: Bool
+            if let angleRange = Range(match.range(withName: CaptureGroup.anglePath), in: line) {
+                pathRange = angleRange
+                isQuoted = false
+            } else if let quotedRange = Range(match.range(withName: CaptureGroup.quotedPath), in: line) {
+                pathRange = quotedRange
+                isQuoted = true
+            } else {
                 return line
             }
 
             let path = String(line[pathRange])
-            guard let replacement = replacementsByHeaderPath[path] else {
+            let replacement: String?
+            if isQuoted, let includer {
+                replacement = quotedIncludeReplacement(for: path, from: includer)
+            } else {
+                replacement = searchPathReplacement(for: path)
+            }
+            guard let replacement else {
                 return line
             }
 
             let directive = line[directiveRange]
-            let trailing = line[pathRange.upperBound...] // includes the closing `>` and any comment
-            return "\(directive)<\(replacement)\(trailing)"
+            // Skip the original closing `>` or `"`; both are a single character.
+            let trailing = line[line.index(after: pathRange.upperBound)...]
+            return "\(directive)<\(replacement)>\(trailing)"
         }
         return rewritten.joined(separator: "\n")
+    }
+
+    /// Decides the framework path a quoted include is rewritten to; nil keeps the line.
+    ///
+    /// A candidate reachable relative to the including header wins the compiler's quoted lookup:
+    /// it stays untouched while the copy preserves that relation, and is otherwise rewritten via
+    /// the candidate's canonical include-dir-relative path, which also covers `./` and `../`
+    /// spellings. An include with no relative candidate could only have resolved through the
+    /// search paths, so it is looked up as written.
+    private func quotedIncludeReplacement(for path: String, from includer: IncluderContext) -> String? {
+        let candidate = includer.sourceFile.deletingLastPathComponent()
+            .appending(path: path)
+            .standardizedFileURL
+        guard fileSystem.exists(candidate) else {
+            return searchPathReplacement(for: path)
+        }
+
+        // A candidate outside the include dir is never copied; rewriting to some other module's
+        // same-named header would silently change which contents get included.
+        guard let base = includer.includeDir.map(Self.trimmedBasePath(of:)),
+              candidate.path(percentEncoded: false).hasPrefix(base + "/") else {
+            return nil
+        }
+
+        if quotedIncludeResolvesAfterCopy(path, candidate: candidate, from: includer) {
+            return nil
+        }
+
+        let canonicalKey = String(candidate.path(percentEncoded: false).dropFirst(base.count + 1))
+        return replacementsByHeaderPath[canonicalKey]
+    }
+
+    /// Whether a quoted include keeps resolving relative to its includer after both land in the
+    /// framework: the candidate must land at the offset the include names, with `.` and `..`
+    /// segments folded; escaping the framework's header root can never resolve.
+    private func quotedIncludeResolvesAfterCopy(_ path: String, candidate: URL, from includer: IncluderContext) -> Bool {
+        let includerDestination = FrameworkBundleAssembler.headerDestinationComponents(
+            header: includer.sourceFile,
+            includeDir: includer.includeDir,
+            keepPublicHeadersStructure: includer.keepsPublicHeadersStructure
+        )
+        // Includes use the symlink path; copied headers land at the resolved path, and symlinks
+        // duplicating a real header are not copied at all, so their landed path never matches.
+        let landedCandidate = fileSystem.isSymlink(candidate) ? candidate.resolvingSymlinksInPath() : candidate
+        let candidateDestination = FrameworkBundleAssembler.headerDestinationComponents(
+            header: landedCandidate,
+            includeDir: includer.includeDir,
+            keepPublicHeadersStructure: includer.keepsPublicHeadersStructure
+        )
+        let named = includerDestination.dropLast() + path.split(separator: "/").map(String.init)
+        guard let resolved = Self.foldingDotSegments(named) else {
+            return false
+        }
+        return resolved == candidateDestination
+    }
+
+    /// Table lookup for an include that resolves through the search paths: each root interprets
+    /// the path relative to itself, so the canonical table key has `.`/`..` segments folded.
+    /// Absolute paths never resolve through the table.
+    private func searchPathReplacement(for path: String) -> String? {
+        guard !path.hasPrefix("/") else { return nil }
+        guard let key = Self.foldingDotSegments(path.split(separator: "/").map(String.init)) else {
+            return nil
+        }
+        return replacementsByHeaderPath[key.joined(separator: "/")]
+    }
+
+    private static func trimmedBasePath(of directory: URL) -> String {
+        var base = directory.standardizedFileURL.path(percentEncoded: false)
+        if base.hasSuffix("/") && base != "/" {
+            base.removeLast()
+        }
+        return base
+    }
+
+    /// Folds `.` and `..` path components; nil when `..` escapes the root.
+    private static func foldingDotSegments(_ components: some Sequence<String>) -> [String]? {
+        var result: [String] = []
+        for component in components {
+            switch component {
+            case ".":
+                continue
+            case "..":
+                guard result.popLast() != nil else { return nil }
+            default:
+                result.append(component)
+            }
+        }
+        return result
     }
 }

--- a/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
+++ b/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
@@ -1,20 +1,13 @@
 import Foundation
 import ScipioKitCore
 
-/// Rewrites angle-bracket C header includes into framework-relative form.
+/// Rewrites C header includes resolved through SwiftPM header search paths into framework form.
 ///
-/// C packages address their own and their dependencies' public headers relative to the include
-/// directory, e.g. `#include <core/core.h>`, and SwiftPM builds resolve that form through the
-/// `-I` / `HEADER_SEARCH_PATHS` entries they inject. Consumers of the prebuilt XCFrameworks only
-/// get `-F` (framework search), which answers `<ModuleName/...>`, so such includes no longer
-/// resolve. While copying a module's public headers into its framework, we rewrite includes that
-/// point at that module or one of its visible dependencies from `<core/core.h>` to
-/// `<CoreLib/core/core.h>`. Consumers then need no extra wiring.
+/// SwiftPM packages commonly include public headers as `<core/core.h>` and rely on injected
+/// `-I` / `HEADER_SEARCH_PATHS`. Prebuilt framework consumers only get `-F`, which resolves
+/// `<ModuleName/...>`, so copied headers need framework-relative includes.
 ///
-/// The rewrite target is the header's path **as it actually lands inside the owning framework**,
-/// which depends on that module's `keepPublicHeadersStructure`: with it on, the nested layout
-/// (`core/core.h`) is preserved; with it off, headers are flattened to their file name (`core.h`).
-/// The replacement therefore encodes that final path, not the original source-relative path.
+/// Replacement paths match where headers land in their framework, including flattened layouts.
 struct CHeaderIncludeRewriter {
     /// Source include path to framework include path, e.g. `"core/core.h" -> "CoreLib/core/core.h"`.
     private let replacementsByHeaderPath: [String: String]
@@ -83,8 +76,7 @@ struct CHeaderIncludeRewriter {
 
     var isEmpty: Bool { replacementsByHeaderPath.isEmpty }
 
-    /// Where the header being rewritten comes from and how it lands inside the framework,
-    /// so quoted includes can be checked against the copied layout.
+    /// Source and copy-layout context for quoted include resolution.
     struct IncluderContext {
         var sourceFile: URL
         var includeDir: URL?
@@ -92,12 +84,6 @@ struct CHeaderIncludeRewriter {
     }
 
     /// Leaves system, ambiguous, and out-of-closure includes unchanged.
-    ///
-    /// Quoted includes mirror the compiler's lookup order: a file reachable relative to the
-    /// including header wins, but only as long as the copy into the framework preserves that
-    /// relation; flattened layouts break subdirectory relations, so such includes are rewritten
-    /// to the framework form like an angle include, looked up by the candidate's canonical
-    /// include-dir-relative path so `./` and `../` spellings rewrite too.
     func rewrite(_ contents: String, includer: IncluderContext? = nil) -> String {
         guard !replacementsByHeaderPath.isEmpty else { return contents }
 
@@ -132,20 +118,17 @@ struct CHeaderIncludeRewriter {
                 return line
             }
 
-            // Skip the original closing `>` or `"`; both are a single character.
             let trailing = line[line.index(after: pathSubstring.endIndex)...]
             return "\(match.output.directive)<\(replacement)>\(trailing)"
         }
         return rewritten.joined(separator: "\n")
     }
 
-    /// Decides the framework path a quoted include is rewritten to; nil keeps the line.
+    /// Returns the framework include path for a quoted include, or nil when it should stay quoted.
     ///
-    /// A candidate reachable relative to the including header wins the compiler's quoted lookup:
-    /// it stays untouched while the copy preserves that relation, and is otherwise rewritten via
-    /// the candidate's canonical include-dir-relative path, which also covers `./` and `../`
-    /// spellings. An include with no relative candidate could only have resolved through the
-    /// search paths, so it is looked up as written.
+    /// Quoted includes first try the includer's directory. They stay quoted only if that same
+    /// relation still exists after the headers are copied into the framework; otherwise they are
+    /// rewritten through the candidate's canonical include-dir-relative path.
     private func quotedIncludeReplacement(for path: String, from includer: IncluderContext) -> String? {
         let candidate = includer.sourceFile.deletingLastPathComponent()
             .appending(path: path)
@@ -154,8 +137,7 @@ struct CHeaderIncludeRewriter {
             return searchPathReplacement(for: path)
         }
 
-        // A candidate outside the include dir is never copied; rewriting to some other module's
-        // same-named header would silently change which contents get included.
+        // Do not replace a private relative include with a public header that merely shares a name.
         guard let base = includer.includeDir.map(Self.trimmedBasePath(of:)),
               candidate.path(percentEncoded: false).hasPrefix(base + "/") else {
             return nil
@@ -169,17 +151,14 @@ struct CHeaderIncludeRewriter {
         return replacementsByHeaderPath[canonicalKey]
     }
 
-    /// Whether a quoted include keeps resolving relative to its includer after both land in the
-    /// framework: the candidate must land at the offset the include names, with `.` and `..`
-    /// segments folded; escaping the framework's header root can never resolve.
+    /// Whether the quoted path still reaches the same candidate in the copied framework layout.
     private func quotedIncludeResolvesAfterCopy(_ path: String, candidate: URL, from includer: IncluderContext) -> Bool {
         let includerDestination = FrameworkBundleAssembler.headerDestinationComponents(
             header: includer.sourceFile,
             includeDir: includer.includeDir,
             keepPublicHeadersStructure: includer.keepsPublicHeadersStructure
         )
-        // Includes use the symlink path; copied headers land at the resolved path, and symlinks
-        // duplicating a real header are not copied at all, so their landed path never matches.
+        // Copied headers land at resolved symlink paths.
         let landedCandidate = fileSystem.isSymlink(candidate) ? candidate.resolvingSymlinksInPath() : candidate
         let candidateDestination = FrameworkBundleAssembler.headerDestinationComponents(
             header: landedCandidate,
@@ -193,9 +172,7 @@ struct CHeaderIncludeRewriter {
         return resolved == candidateDestination
     }
 
-    /// Table lookup for an include that resolves through the search paths: each root interprets
-    /// the path relative to itself, so the canonical table key has `.`/`..` segments folded.
-    /// Absolute paths never resolve through the table.
+    /// Table lookup for an include resolved relative to a header search path root.
     private func searchPathReplacement(for path: String) -> String? {
         guard !path.hasPrefix("/") else { return nil }
         guard let key = Self.foldingDotSegments(path.split(separator: "/").map(String.init)) else {

--- a/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
+++ b/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
@@ -1,0 +1,111 @@
+import Foundation
+import ScipioKitCore
+
+/// Rewrites angle-bracket C header includes into framework-relative form.
+///
+/// C packages address their own and their dependencies' public headers relative to the include
+/// directory, e.g. `#include <core/core.h>`, and SwiftPM builds resolve that form through the
+/// `-I` / `HEADER_SEARCH_PATHS` entries they inject. Consumers of the prebuilt XCFrameworks only
+/// get `-F` (framework search), which answers `<ModuleName/...>`, so such includes no longer
+/// resolve. While copying a module's public headers into its framework, we rewrite includes that
+/// point at that module or one of its visible dependencies from `<core/core.h>` to
+/// `<CoreLib/core/core.h>`. Consumers then need no extra wiring.
+///
+/// The rewrite target is the header's path **as it actually lands inside the owning framework**,
+/// which depends on that module's `keepPublicHeadersStructure`: with it on, the nested layout
+/// (`core/core.h`) is preserved; with it off, headers are flattened to their file name (`core.h`).
+/// The replacement therefore encodes that final path, not the original source-relative path.
+struct CHeaderIncludeRewriter {
+    /// Source include path to framework include path, e.g. `"core/core.h" -> "CoreLib/core/core.h"`.
+    private let replacementsByHeaderPath: [String: String]
+
+    init(replacementsByHeaderPath: [String: String]) {
+        self.replacementsByHeaderPath = replacementsByHeaderPath
+    }
+
+    /// Builds the table from a target and its visible dependency closure.
+    init(
+        modules: some Sequence<ResolvedModule>,
+        keepPublicHeadersStructure: (ResolvedModule) -> Bool,
+        fileSystem: any FileSystem = LocalFileSystem.default
+    ) {
+        var table: [String: String] = [:]
+        var ambiguousPaths: Set<String> = []
+
+        for module in modules {
+            guard case let .clang(includeDir, publicHeaders) = module.resolvedModuleType else {
+                continue
+            }
+            // `-F` resolves the framework bundle name, not the C99 modulemap name.
+            let moduleName = module.name.packageNamed()
+            let keepsStructure = keepPublicHeadersStructure(module)
+            var base = includeDir.standardizedFileURL.path(percentEncoded: false)
+            if base.hasSuffix("/") && base != "/" {
+                base.removeLast()
+            }
+
+            for header in publicHeaders {
+                let headerPath = header.standardizedFileURL.path(percentEncoded: false)
+                guard headerPath.hasPrefix(base + "/") else { continue }
+                let sourceRelativePath = String(headerPath.dropFirst(base.count + 1))
+                guard !sourceRelativePath.isEmpty else { continue }
+
+                // Includes use the symlink path; copied headers land at the resolved path.
+                let landedHeader = fileSystem.isSymlink(header) ? header.resolvingSymlinksInPath() : header
+                let inFrameworkPath = FrameworkBundleAssembler.headerDestinationComponents(
+                    header: landedHeader,
+                    includeDir: includeDir,
+                    keepPublicHeadersStructure: keepsStructure
+                ).joined(separator: "/")
+                let replacement = "\(moduleName)/\(inFrameworkPath)"
+
+                if let existing = table[sourceRelativePath], existing != replacement {
+                    // Do not guess when two modules provide the same include path.
+                    ambiguousPaths.insert(sourceRelativePath)
+                    logger.warning(
+                        "Public header \(sourceRelativePath) is provided by multiple modules; leaving its includes unrewritten"
+                    )
+                } else {
+                    table[sourceRelativePath] = replacement
+                }
+            }
+        }
+
+        for path in ambiguousPaths {
+            table[path] = nil
+        }
+        self.replacementsByHeaderPath = table
+    }
+
+    var isEmpty: Bool { replacementsByHeaderPath.isEmpty }
+
+    // Angle includes only; quoted includes keep their source-relative semantics.
+    private static let includeRegex = try! NSRegularExpression(
+        pattern: #"^(\s*#\s*(?:include|import)\s*)<([^>]+)>"#
+    )
+
+    /// Leaves system, ambiguous, and out-of-closure includes unchanged.
+    func rewrite(_ contents: String) -> String {
+        guard !replacementsByHeaderPath.isEmpty else { return contents }
+
+        let lines = contents.components(separatedBy: "\n")
+        let rewritten = lines.map { line -> String in
+            let range = NSRange(line.startIndex..<line.endIndex, in: line)
+            guard let match = Self.includeRegex.firstMatch(in: line, range: range),
+                  let directiveRange = Range(match.range(at: 1), in: line),
+                  let pathRange = Range(match.range(at: 2), in: line) else {
+                return line
+            }
+
+            let path = String(line[pathRange])
+            guard let replacement = replacementsByHeaderPath[path] else {
+                return line
+            }
+
+            let directive = line[directiveRange]
+            let trailing = line[pathRange.upperBound...] // includes the closing `>` and any comment
+            return "\(directive)<\(replacement)\(trailing)"
+        }
+        return rewritten.joined(separator: "\n")
+    }
+}

--- a/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
+++ b/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
@@ -65,7 +65,8 @@ struct CHeaderIncludeRewriter {
                     // Do not guess when two modules provide the same include path.
                     ambiguousPaths.insert(sourceRelativePath)
                     logger.warning(
-                        "Public header \(sourceRelativePath) is provided by multiple modules; leaving its includes unrewritten"
+                        "⚠️ Public header \(sourceRelativePath) is provided by multiple modules; leaving its includes unrewritten",
+                        metadata: .color(.yellow)
                     )
                 } else {
                     table[sourceRelativePath] = replacement

--- a/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
+++ b/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
@@ -91,17 +91,6 @@ struct CHeaderIncludeRewriter {
         var keepsPublicHeadersStructure: Bool
     }
 
-    private enum CaptureGroup {
-        static let directive = "directive"
-        static let anglePath = "anglePath"
-        static let quotedPath = "quotedPath"
-    }
-
-    private static let includeRegex = try! NSRegularExpression(
-        pattern: #"^(?<\#(CaptureGroup.directive)>\s*#\s*(?:include|import)\s*)"#
-            + #"(?:<(?<\#(CaptureGroup.anglePath)>[^>]+)>|"(?<\#(CaptureGroup.quotedPath)>[^"]+)")"#
-    )
-
     /// Leaves system, ambiguous, and out-of-closure includes unchanged.
     ///
     /// Quoted includes mirror the compiler's lookup order: a file reachable relative to the
@@ -112,27 +101,27 @@ struct CHeaderIncludeRewriter {
     func rewrite(_ contents: String, includer: IncluderContext? = nil) -> String {
         guard !replacementsByHeaderPath.isEmpty else { return contents }
 
+        let regex = /^(?<directive>\s*#\s*(?:include|import)\s*)(?:<(?<anglePath>[^>]+)>|"(?<quotedPath>[^"]+)")/
+
         let lines = contents.components(separatedBy: "\n")
         let rewritten = lines.map { line -> String in
-            let range = NSRange(line.startIndex..<line.endIndex, in: line)
-            guard let match = Self.includeRegex.firstMatch(in: line, range: range),
-                  let directiveRange = Range(match.range(withName: CaptureGroup.directive), in: line) else {
+            guard let match = line.firstMatch(of: regex) else {
                 return line
             }
 
-            let pathRange: Range<String.Index>
+            let pathSubstring: Substring
             let isQuoted: Bool
-            if let angleRange = Range(match.range(withName: CaptureGroup.anglePath), in: line) {
-                pathRange = angleRange
+            if let anglePath = match.output.anglePath {
+                pathSubstring = anglePath
                 isQuoted = false
-            } else if let quotedRange = Range(match.range(withName: CaptureGroup.quotedPath), in: line) {
-                pathRange = quotedRange
+            } else if let quotedPath = match.output.quotedPath {
+                pathSubstring = quotedPath
                 isQuoted = true
             } else {
                 return line
             }
 
-            let path = String(line[pathRange])
+            let path = String(pathSubstring)
             let replacement: String?
             if isQuoted, let includer {
                 replacement = quotedIncludeReplacement(for: path, from: includer)
@@ -143,10 +132,9 @@ struct CHeaderIncludeRewriter {
                 return line
             }
 
-            let directive = line[directiveRange]
             // Skip the original closing `>` or `"`; both are a single character.
-            let trailing = line[line.index(after: pathRange.upperBound)...]
-            return "\(directive)<\(replacement)>\(trailing)"
+            let trailing = line[line.index(after: pathSubstring.endIndex)...]
+            return "\(match.output.directive)<\(replacement)>\(trailing)"
         }
         return rewritten.joined(separator: "\n")
     }

--- a/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
@@ -7,6 +7,7 @@ struct FrameworkBundleAssembler {
     private let keepPublicHeadersStructure: Bool
     private let outputDirectory: URL
     private let fileSystem: any FileSystem
+    private let headerIncludeRewriter: CHeaderIncludeRewriter?
 
     private var frameworkBundlePath: URL {
         outputDirectory.appending(component: "\(frameworkComponents.frameworkName).framework")
@@ -16,12 +17,14 @@ struct FrameworkBundleAssembler {
         frameworkComponents: FrameworkComponents,
         keepPublicHeadersStructure: Bool,
         outputDirectory: URL,
-        fileSystem: some FileSystem
+        fileSystem: some FileSystem,
+        headerIncludeRewriter: CHeaderIncludeRewriter? = nil
     ) {
         self.frameworkComponents = frameworkComponents
         self.keepPublicHeadersStructure = keepPublicHeadersStructure
         self.outputDirectory = outputDirectory
         self.fileSystem = fileSystem
+        self.headerIncludeRewriter = headerIncludeRewriter
     }
 
     @discardableResult
@@ -80,46 +83,65 @@ struct FrameworkBundleAssembler {
         try fileSystem.createDirectory(headerDir)
 
         for header in headers {
-            if keepPublicHeadersStructure, let includeDir = frameworkComponents.includeDir {
-                try copyHeaderKeepingStructure(
-                    header: header,
-                    includeDir: includeDir,
-                    into: headerDir
-                )
-            } else {
-                try fileSystem.copy(
-                    from: header,
-                    to: headerDir.appending(component: header.lastPathComponent)
+            let destinationComponents = Self.headerDestinationComponents(
+                header: header,
+                includeDir: frameworkComponents.includeDir,
+                keepPublicHeadersStructure: keepPublicHeadersStructure
+            )
+            let destination = headerDir.appending(components: destinationComponents)
+            if destinationComponents.count > 1 {
+                try fileSystem.createDirectory(
+                    destination.deletingLastPathComponent(),
+                    recursive: true
                 )
             }
+            try copyHeader(from: header, to: destination)
         }
     }
 
-    private func copyHeaderKeepingStructure(
+    /// Path components below `Headers/`; shared with `CHeaderIncludeRewriter`.
+    static func headerDestinationComponents(
         header: URL,
-        includeDir: URL,
-        into headerDir: URL
-    ) throws {
-        let subdirectoryComponents: [String] = if header.dirname.hasPrefix(includeDir.path(percentEncoded: false)) {
-            header.dirname.dropFirst(includeDir.path(percentEncoded: false).count)
-                .split(separator: "/")
-                .map(String.init)
-        } else {
-            []
+        includeDir: URL?,
+        keepPublicHeadersStructure: Bool
+    ) -> [String] {
+        guard keepPublicHeadersStructure, let includeDir else {
+            return [header.lastPathComponent]
+        }
+        var base = includeDir.standardizedFileURL.path(percentEncoded: false)
+        if base.hasSuffix("/") && base != "/" {
+            base.removeLast()
+        }
+        let parent = header.dirname
+        guard parent == base || parent.hasPrefix(base + "/") else {
+            return [header.lastPathComponent]
+        }
+        let subdirectoryComponents = parent.dropFirst(base.count)
+            .split(separator: "/")
+            .map(String.init)
+        return subdirectoryComponents + [header.lastPathComponent]
+    }
+
+    /// Copies a public header, rewriting textual headers when a rewriter is configured.
+    private func copyHeader(from source: URL, to destination: URL) throws {
+        // `fileSystem.copy` refuses to overwrite, but `writeFileContents` does not: check upfront so
+        // headers flattened to a colliding name keep failing loudly on either path.
+        guard !fileSystem.exists(destination) else {
+            throw FileSystemError.alreadyExistsAtDestination(path: destination)
         }
 
-        if !subdirectoryComponents.isEmpty {
-            try fileSystem.createDirectory(
-                headerDir.appending(components: subdirectoryComponents),
-                recursive: true
-            )
+        guard let headerIncludeRewriter, !headerIncludeRewriter.isEmpty else {
+            try fileSystem.copy(from: source, to: destination)
+            return
         }
-        try fileSystem.copy(
-            from: header,
-            to: headerDir
-                .appending(components: subdirectoryComponents)
-                .appending(component: header.lastPathComponent)
-        )
+
+        let rawData = try fileSystem.readFileContents(source)
+        guard let contents = String(bytes: rawData, encoding: .utf8) else {
+            try fileSystem.copy(from: source, to: destination)
+            return
+        }
+
+        try fileSystem.writeFileContents(destination, string: headerIncludeRewriter.rewrite(contents))
     }
 
     private func copyModules() throws {

--- a/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkBundleAssembler.swift
@@ -141,7 +141,17 @@ struct FrameworkBundleAssembler {
             return
         }
 
-        try fileSystem.writeFileContents(destination, string: headerIncludeRewriter.rewrite(contents))
+        try fileSystem.writeFileContents(
+            destination,
+            string: headerIncludeRewriter.rewrite(
+                contents,
+                includer: .init(
+                    sourceFile: source,
+                    includeDir: frameworkComponents.includeDir,
+                    keepsPublicHeadersStructure: keepPublicHeadersStructure
+                )
+            )
+        )
     }
 
     private func copyModules() throws {

--- a/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFCompiler.swift
@@ -3,6 +3,9 @@ import Foundation
 struct PIFCompiler: Compiler {
     let descriptionPackage: DescriptionPackage
     private let buildOptions: BuildOptions
+    /// Resolves whether a target keeps its public-header directory structure in the produced
+    /// framework; the caller owns the per-target override rules.
+    private let keepPublicHeadersStructure: @Sendable (_ targetName: String) -> Bool
     private let fileSystem: any FileSystem
     private let executor: any Executor
     private let buildOptionsMatrix: [String: BuildOptions]
@@ -13,12 +16,14 @@ struct PIFCompiler: Compiler {
         descriptionPackage: DescriptionPackage,
         buildOptions: BuildOptions,
         buildOptionsMatrix: [String: BuildOptions],
+        keepPublicHeadersStructure: @escaping @Sendable (_ targetName: String) -> Bool,
         fileSystem: any FileSystem = LocalFileSystem.default,
         executor: any Executor = ProcessExecutor()
     ) {
         self.descriptionPackage = descriptionPackage
         self.buildOptions = buildOptions
         self.buildOptionsMatrix = buildOptionsMatrix
+        self.keepPublicHeadersStructure = keepPublicHeadersStructure
         self.fileSystem = fileSystem
         self.executor = executor
         self.buildParametersGenerator = .init(buildOptions: buildOptions, fileSystem: fileSystem, executor: executor)
@@ -45,11 +50,20 @@ struct PIFCompiler: Compiler {
         // Build frameworks for each SDK
         logger.info("📦 Building \(target.name) for \(sdkNames)")
 
+        // Scope the include rewrite to this target and its visible dependency closure so headers of
+        // unrelated packages can never match (e.g. a generic `config.h`).
+        let rewriterModules = try [buildProduct.target] + buildProduct.target.recursiveModuleDependencies()
+        let headerIncludeRewriter = CHeaderIncludeRewriter(
+            modules: rewriterModules,
+            keepPublicHeadersStructure: { keepPublicHeadersStructure($0.name) }
+        )
+
         let xcBuildClient: XCBuildClient = .init(
             buildProduct: buildProduct,
             buildOptions: buildOptions,
             configuration: buildOptions.buildConfiguration,
-            packageLocator: descriptionPackage
+            packageLocator: descriptionPackage,
+            headerIncludeRewriter: headerIncludeRewriter
         )
 
         let debugSymbolStripper = DWARFSymbolStripper(executor: executor)

--- a/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
+++ b/Sources/ScipioKit/Producer/PIF/XCBuildClient.swift
@@ -20,6 +20,7 @@ struct XCBuildClient {
     private let packageLocator: any PackageLocator
     private let fileSystem: any FileSystem
     private let executor: any Executor
+    private let headerIncludeRewriter: CHeaderIncludeRewriter?
 
     init(
         buildProduct: BuildProduct,
@@ -27,7 +28,8 @@ struct XCBuildClient {
         configuration: BuildConfiguration,
         packageLocator: some PackageLocator,
         fileSystem: any FileSystem = LocalFileSystem.default,
-        executor: some Executor = ProcessExecutor(errorDecoder: StandardOutputDecoder())
+        executor: some Executor = ProcessExecutor(errorDecoder: StandardOutputDecoder()),
+        headerIncludeRewriter: CHeaderIncludeRewriter? = nil
     ) {
         self.buildProduct = buildProduct
         self.buildOptions = buildOptions
@@ -35,6 +37,7 @@ struct XCBuildClient {
         self.packageLocator = packageLocator
         self.fileSystem = fileSystem
         self.executor = executor
+        self.headerIncludeRewriter = headerIncludeRewriter
     }
 
     private func fetchXCBuildPath() async throws -> URL {
@@ -115,7 +118,8 @@ struct XCBuildClient {
             frameworkComponents: components,
             keepPublicHeadersStructure: buildOptions.keepPublicHeadersStructure,
             outputDirectory: frameworkOutputDir,
-            fileSystem: fileSystem
+            fileSystem: fileSystem,
+            headerIncludeRewriter: headerIncludeRewriter
         )
 
         return try assembler.assemble()

--- a/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
+++ b/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
@@ -8,7 +8,7 @@ extension PackageResolver {
         let rootPackageDirectory: URL
 
         let clangFileTypes = ["c", "m", "mm", "cc", "cpp", "cxx"]
-        let headerExtensions = ["h", "hh", "hpp", "h++", "hp", "hxx", "H", "ipp", "def"]
+        let headerExtensions = ["h", "hh", "hpp", "h++", "hp", "hxx", "H", "ipp", "def", "inl"]
         let asmFileTypes = ["s", "S"]
         let swiftFileType = "swift"
 

--- a/Tests/ScipioKitTests/CHeaderIncludeRewriterTests.swift
+++ b/Tests/ScipioKitTests/CHeaderIncludeRewriterTests.swift
@@ -38,7 +38,6 @@ struct CHeaderIncludeRewriterTests {
 
     @Test("Quoted includes rewrite unless the copied layout still resolves them")
     func rewritesQuotedIncludesAgainstCopiedLayout() throws {
-        // Without an includer the search-path fallback is the only possible resolution.
         #expect(rewriter.rewrite("#include \"dep/foo.h\"") == "#include <DepModule/dep/foo.h>")
         #expect(rewriter.rewrite("#import \"dep/foo.h\" // keep me") == "#import <DepModule/dep/foo.h> // keep me")
 
@@ -56,7 +55,6 @@ struct CHeaderIncludeRewriterTests {
             try Data().write(to: file)
         }
 
-        // With the structure kept, the relative relation survives the copy and the include stays.
         let keepingStructure = CHeaderIncludeRewriter.IncluderContext(
             sourceFile: includer,
             includeDir: includeDir,
@@ -67,8 +65,6 @@ struct CHeaderIncludeRewriterTests {
             "#include \"dep/foo.h\""
         )
 
-        // Flattening moves the candidate next to the includer, breaking the subdirectory
-        // relation: the include must be rewritten to the framework form.
         let flattening = CHeaderIncludeRewriter.IncluderContext(
             sourceFile: includer,
             includeDir: includeDir,
@@ -79,7 +75,6 @@ struct CHeaderIncludeRewriterTests {
             "#include <DepModule/dep/foo.h>"
         )
 
-        // A bare sibling stays next to the includer in both layouts and survives flattening.
         let siblingRewriter = CHeaderIncludeRewriter(
             replacementsByHeaderPath: ["sibling.h": "DepModule/sibling.h"]
         )
@@ -88,7 +83,6 @@ struct CHeaderIncludeRewriterTests {
             "#include \"sibling.h\""
         )
 
-        // With no relative candidate on disk, only the search paths could have resolved it.
         let outside = CHeaderIncludeRewriter.IncluderContext(
             sourceFile: includeDir.appending(components: "dep", "other.h"),
             includeDir: includeDir,
@@ -99,8 +93,6 @@ struct CHeaderIncludeRewriterTests {
             "#include <DepModule/dep/foo.h>"
         )
 
-        // A symlinked candidate lands at its resolved path (or, duplicating a real header, is
-        // not copied at all), so the include must be rewritten to the table's landed path.
         let linkedCandidate = includeDir.appending(component: "link.h")
         try FileManager.default.createSymbolicLink(at: linkedCandidate, withDestinationURL: sibling)
         let symlinkRewriter = CHeaderIncludeRewriter(
@@ -132,7 +124,6 @@ struct CHeaderIncludeRewriterTests {
             replacementsByHeaderPath: ["foo.h": "DepModule/foo.h"]
         )
 
-        // Flattening breaks the `..` relation; the canonical key "foo.h" finds the landed path.
         let flattening = CHeaderIncludeRewriter.IncluderContext(
             sourceFile: includer,
             includeDir: includeDir,
@@ -143,7 +134,6 @@ struct CHeaderIncludeRewriterTests {
             "#include <DepModule/foo.h>"
         )
 
-        // With the structure kept, `../foo.h` still resolves inside Headers/ and stays.
         let keepingStructure = CHeaderIncludeRewriter.IncluderContext(
             sourceFile: includer,
             includeDir: includeDir,
@@ -154,14 +144,11 @@ struct CHeaderIncludeRewriterTests {
             "#include \"../foo.h\""
         )
 
-        // A candidate escaping the include dir is never copied: rewriting cannot help.
         #expect(
             dotRewriter.rewrite("#include \"../../escape.h\"", includer: keepingStructure) ==
             "#include \"../../escape.h\""
         )
 
-        // No includer-relative candidate: the search paths fold dot segments while resolving,
-        // so the canonical key must be used for the table lookup as well.
         #expect(
             dotRewriter.rewrite("#include \"./foo.h\"", includer: keepingStructure) ==
             "#include <DepModule/foo.h>"
@@ -169,7 +156,6 @@ struct CHeaderIncludeRewriterTests {
         #expect(rewriter.rewrite("#include \"./dep/foo.h\"") == "#include <DepModule/dep/foo.h>")
         #expect(rewriter.rewrite("#include <./dep/foo.h>") == "#include <DepModule/dep/foo.h>")
 
-        // Absolute includes never resolve through the search paths' relative roots.
         #expect(rewriter.rewrite("#include \"/dep/foo.h\"") == "#include \"/dep/foo.h\"")
     }
 
@@ -238,7 +224,6 @@ struct CHeaderIncludeRewriterTests {
 
         let rewriter = CHeaderIncludeRewriter(modules: [someLib], keepPublicHeadersStructure: { _ in true })
 
-        // The collector deduplicates this symlink against its real header.
         #expect(rewriter.rewrite("#include <some_lib_dupe.h>") == "#include <some_lib/some_lib.h>")
         #expect(rewriter.rewrite("#include <a.h>") == "#include <some_lib/a.h>")
         #expect(rewriter.rewrite("#include <some_lib.h>") == "#include <some_lib/some_lib.h>")

--- a/Tests/ScipioKitTests/CHeaderIncludeRewriterTests.swift
+++ b/Tests/ScipioKitTests/CHeaderIncludeRewriterTests.swift
@@ -25,15 +25,152 @@ struct CHeaderIncludeRewriterTests {
         #expect(rewriter.rewrite("#include<dep/foo.h>") == "#include<DepModule/dep/foo.h>")
     }
 
-    @Test("Leaves unknown, quoted, and empty-table includes untouched")
+    @Test("Leaves unknown and empty-table includes untouched")
     func leavesNonMatchingIncludesUntouched() {
         #expect(rewriter.rewrite("#include <stdio.h>") == "#include <stdio.h>")
         #expect(rewriter.rewrite("#include <other/unknown.h>") == "#include <other/unknown.h>")
-        #expect(rewriter.rewrite("#include \"dep/foo.h\"") == "#include \"dep/foo.h\"")
+        #expect(rewriter.rewrite("#include \"other/unknown.h\"") == "#include \"other/unknown.h\"")
 
         let empty = CHeaderIncludeRewriter(replacementsByHeaderPath: [:])
         #expect(empty.isEmpty)
         #expect(empty.rewrite("#include <dep/foo.h>") == "#include <dep/foo.h>")
+    }
+
+    @Test("Quoted includes rewrite unless the copied layout still resolves them")
+    func rewritesQuotedIncludesAgainstCopiedLayout() throws {
+        // Without an includer the search-path fallback is the only possible resolution.
+        #expect(rewriter.rewrite("#include \"dep/foo.h\"") == "#include <DepModule/dep/foo.h>")
+        #expect(rewriter.rewrite("#import \"dep/foo.h\" // keep me") == "#import <DepModule/dep/foo.h> // keep me")
+
+        let includeDir = FileManager.default.temporaryDirectory
+            .appending(components: "CHeaderIncludeRewriterTests", UUID().uuidString, "include")
+        defer { try? FileManager.default.removeItem(at: includeDir.deletingLastPathComponent()) }
+        let includer = includeDir.appending(component: "root.h")
+        let sibling = includeDir.appending(component: "sibling.h")
+        let nested = includeDir.appending(components: "dep", "foo.h")
+        try FileManager.default.createDirectory(
+            at: nested.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        for file in [includer, sibling, nested] {
+            try Data().write(to: file)
+        }
+
+        // With the structure kept, the relative relation survives the copy and the include stays.
+        let keepingStructure = CHeaderIncludeRewriter.IncluderContext(
+            sourceFile: includer,
+            includeDir: includeDir,
+            keepsPublicHeadersStructure: true
+        )
+        #expect(
+            rewriter.rewrite("#include \"dep/foo.h\"", includer: keepingStructure) ==
+            "#include \"dep/foo.h\""
+        )
+
+        // Flattening moves the candidate next to the includer, breaking the subdirectory
+        // relation: the include must be rewritten to the framework form.
+        let flattening = CHeaderIncludeRewriter.IncluderContext(
+            sourceFile: includer,
+            includeDir: includeDir,
+            keepsPublicHeadersStructure: false
+        )
+        #expect(
+            rewriter.rewrite("#include \"dep/foo.h\"", includer: flattening) ==
+            "#include <DepModule/dep/foo.h>"
+        )
+
+        // A bare sibling stays next to the includer in both layouts and survives flattening.
+        let siblingRewriter = CHeaderIncludeRewriter(
+            replacementsByHeaderPath: ["sibling.h": "DepModule/sibling.h"]
+        )
+        #expect(
+            siblingRewriter.rewrite("#include \"sibling.h\"", includer: flattening) ==
+            "#include \"sibling.h\""
+        )
+
+        // With no relative candidate on disk, only the search paths could have resolved it.
+        let outside = CHeaderIncludeRewriter.IncluderContext(
+            sourceFile: includeDir.appending(components: "dep", "other.h"),
+            includeDir: includeDir,
+            keepsPublicHeadersStructure: true
+        )
+        #expect(
+            rewriter.rewrite("#include \"dep/foo.h\"", includer: outside) ==
+            "#include <DepModule/dep/foo.h>"
+        )
+
+        // A symlinked candidate lands at its resolved path (or, duplicating a real header, is
+        // not copied at all), so the include must be rewritten to the table's landed path.
+        let linkedCandidate = includeDir.appending(component: "link.h")
+        try FileManager.default.createSymbolicLink(at: linkedCandidate, withDestinationURL: sibling)
+        let symlinkRewriter = CHeaderIncludeRewriter(
+            replacementsByHeaderPath: ["link.h": "DepModule/sibling.h"]
+        )
+        #expect(
+            symlinkRewriter.rewrite("#include \"link.h\"", includer: flattening) ==
+            "#include <DepModule/sibling.h>"
+        )
+    }
+
+    @Test("Dot-segment quoted includes rewrite via the candidate's canonical path")
+    func rewritesDotSegmentQuotedIncludes() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appending(components: "CHeaderIncludeRewriterTests", UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let includeDir = root.appending(component: "include")
+        let includer = includeDir.appending(components: "sub", "root.h")
+        let candidate = includeDir.appending(component: "foo.h")
+        let escapee = root.appending(component: "escape.h")
+        try FileManager.default.createDirectory(
+            at: includer.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        for file in [includer, candidate, escapee] {
+            try Data().write(to: file)
+        }
+        let dotRewriter = CHeaderIncludeRewriter(
+            replacementsByHeaderPath: ["foo.h": "DepModule/foo.h"]
+        )
+
+        // Flattening breaks the `..` relation; the canonical key "foo.h" finds the landed path.
+        let flattening = CHeaderIncludeRewriter.IncluderContext(
+            sourceFile: includer,
+            includeDir: includeDir,
+            keepsPublicHeadersStructure: false
+        )
+        #expect(
+            dotRewriter.rewrite("#include \"../foo.h\"", includer: flattening) ==
+            "#include <DepModule/foo.h>"
+        )
+
+        // With the structure kept, `../foo.h` still resolves inside Headers/ and stays.
+        let keepingStructure = CHeaderIncludeRewriter.IncluderContext(
+            sourceFile: includer,
+            includeDir: includeDir,
+            keepsPublicHeadersStructure: true
+        )
+        #expect(
+            dotRewriter.rewrite("#include \"../foo.h\"", includer: keepingStructure) ==
+            "#include \"../foo.h\""
+        )
+
+        // A candidate escaping the include dir is never copied: rewriting cannot help.
+        #expect(
+            dotRewriter.rewrite("#include \"../../escape.h\"", includer: keepingStructure) ==
+            "#include \"../../escape.h\""
+        )
+
+        // No includer-relative candidate: the search paths fold dot segments while resolving,
+        // so the canonical key must be used for the table lookup as well.
+        #expect(
+            dotRewriter.rewrite("#include \"./foo.h\"", includer: keepingStructure) ==
+            "#include <DepModule/foo.h>"
+        )
+        #expect(rewriter.rewrite("#include \"./dep/foo.h\"") == "#include <DepModule/dep/foo.h>")
+        #expect(rewriter.rewrite("#include <./dep/foo.h>") == "#include <DepModule/dep/foo.h>")
+
+        // Absolute includes never resolve through the search paths' relative roots.
+        #expect(rewriter.rewrite("#include \"/dep/foo.h\"") == "#include \"/dep/foo.h\"")
     }
 
     @Test("Only matching lines change while preserving line endings")

--- a/Tests/ScipioKitTests/CHeaderIncludeRewriterTests.swift
+++ b/Tests/ScipioKitTests/CHeaderIncludeRewriterTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import ScipioKit
+
+private let fixturePath = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .appendingPathComponent("Resources")
+    .appendingPathComponent("Fixtures")
+
+struct CHeaderIncludeRewriterTests {
+    private let rewriter = CHeaderIncludeRewriter(
+        replacementsByHeaderPath: [
+            "dep/foo.h": "DepModule/dep/foo.h",
+            "core/nested/types.h": "CoreLib/core/nested/types.h",
+        ]
+    )
+
+    @Test("Rewrites include and import directives to framework form")
+    func rewritesAngleBracketIncludesToFrameworkForm() {
+        #expect(rewriter.rewrite("#include <dep/foo.h>") == "#include <DepModule/dep/foo.h>")
+        #expect(rewriter.rewrite("#import <dep/foo.h>") == "#import <DepModule/dep/foo.h>")
+        #expect(rewriter.rewrite("#include <core/nested/types.h>") == "#include <CoreLib/core/nested/types.h>")
+        let spacedInclude = "  #  include   <dep/foo.h> // keep me"
+        #expect(rewriter.rewrite(spacedInclude) == "  #  include   <DepModule/dep/foo.h> // keep me")
+        #expect(rewriter.rewrite("#include<dep/foo.h>") == "#include<DepModule/dep/foo.h>")
+    }
+
+    @Test("Leaves unknown, quoted, and empty-table includes untouched")
+    func leavesNonMatchingIncludesUntouched() {
+        #expect(rewriter.rewrite("#include <stdio.h>") == "#include <stdio.h>")
+        #expect(rewriter.rewrite("#include <other/unknown.h>") == "#include <other/unknown.h>")
+        #expect(rewriter.rewrite("#include \"dep/foo.h\"") == "#include \"dep/foo.h\"")
+
+        let empty = CHeaderIncludeRewriter(replacementsByHeaderPath: [:])
+        #expect(empty.isEmpty)
+        #expect(empty.rewrite("#include <dep/foo.h>") == "#include <dep/foo.h>")
+    }
+
+    @Test("Only matching lines change while preserving line endings")
+    func rewritesOnlyMatchingLinesPreservingOtherContents() {
+        let input = """
+        #include <dep/foo.h>
+        #include <stdio.h>
+        int answer(void) { return 42; }
+        #include "relative.h"
+        """
+        let expected = """
+        #include <DepModule/dep/foo.h>
+        #include <stdio.h>
+        int answer(void) { return 42; }
+        #include "relative.h"
+        """
+        #expect(rewriter.rewrite(input) == expected)
+        let crlfInput = "#include <dep/foo.h>\r\nint x;\r\n"
+        #expect(rewriter.rewrite(crlfInput) == "#include <DepModule/dep/foo.h>\r\nint x;\r\n")
+    }
+
+    @Test("Replacement uses the header layout produced in the framework")
+    func buildsReplacementFromModuleHeaderLayout() async throws {
+        let package = try await DescriptionPackage(
+            packageDirectory: fixturePath.appendingPathComponent("ClangPackageWithInterdependentHeaders"),
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: false
+        )
+        let coreLib = try #require(package.graph.allModules.first { $0.name == "CoreLib" })
+
+        let keepingStructure = CHeaderIncludeRewriter(modules: [coreLib], keepPublicHeadersStructure: { _ in true })
+        #expect(keepingStructure.rewrite("#include <core/core.h>") == "#include <CoreLib/core/core.h>")
+
+        let flattening = CHeaderIncludeRewriter(modules: [coreLib], keepPublicHeadersStructure: { _ in false })
+        #expect(flattening.rewrite("#include <core/core.h>") == "#include <CoreLib/core.h>")
+    }
+
+    @Test("Ambiguous header paths are left unrewritten")
+    func leavesAmbiguousHeaderPathsUnrewritten() async throws {
+        let package = try await DescriptionPackage(
+            packageDirectory: fixturePath.appendingPathComponent("ClangPackageWithConflictingHeaders"),
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: false
+        )
+        let consumer = try #require(package.graph.allModules.first { $0.name == "Consumer" })
+        let closure = try [consumer] + consumer.recursiveModuleDependencies()
+
+        let rewriter = CHeaderIncludeRewriter(modules: closure, keepPublicHeadersStructure: { _ in false })
+
+        #expect(rewriter.rewrite("#include <shared.h>") == "#include <shared.h>")
+        #expect(rewriter.rewrite("#include <consumer.h>") == "#include <Consumer/consumer.h>")
+    }
+
+    @Test("Symlinked headers rewrite to their landed framework path")
+    func resolvesSymlinkedHeadersToTheirLandedPath() async throws {
+        let package = try await DescriptionPackage(
+            packageDirectory: fixturePath.appendingPathComponent("ClangPackageWithSymbolicLinkHeaders"),
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: false
+        )
+        let someLib = try #require(package.graph.allModules.first { $0.name == "some_lib" })
+
+        let rewriter = CHeaderIncludeRewriter(modules: [someLib], keepPublicHeadersStructure: { _ in true })
+
+        // The collector deduplicates this symlink against its real header.
+        #expect(rewriter.rewrite("#include <some_lib_dupe.h>") == "#include <some_lib/some_lib.h>")
+        #expect(rewriter.rewrite("#include <a.h>") == "#include <some_lib/a.h>")
+        #expect(rewriter.rewrite("#include <some_lib.h>") == "#include <some_lib/some_lib.h>")
+    }
+}

--- a/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
+++ b/Tests/ScipioKitTests/FrameworkBundleAssemblerTests.swift
@@ -42,6 +42,53 @@ struct FrameworkBundleAssemblerTests {
         #expect(Set(try fileSystem.getDirectoryContents(frameworkHeadersPath.appending(component: "bar"))) == ["bar.h"])
     }
 
+    @Test("Flattened header name collisions fail loudly when rewriting")
+    func copyHeaders_flattened_name_collision_fails() throws {
+        let outputDirectory = temporaryDirectory.appending(component: #function)
+        let includeDir = temporaryDirectory.appending(components: "\(#function)-src", "include")
+        defer {
+            try? fileSystem.removeFileTree(outputDirectory)
+            try? fileSystem.removeFileTree(includeDir.parentDirectory)
+        }
+
+        for subdirectory in ["foo", "bar"] {
+            try fileSystem.writeFileContents(
+                includeDir.appending(components: subdirectory, "common.h"),
+                string: "// \(subdirectory)\n"
+            )
+        }
+
+        let fixture = fixturesPath.appendingPathComponent("FrameworkBundleAssemblerTests")
+        let frameworkComponents = FrameworkComponents(
+            isVersionedBundle: false,
+            frameworkName: "Foo",
+            frameworkPath: fixture.appending(component: "Foo.framework"),
+            binaryPath: fixture.appending(components: "Foo.framework", "Foo"),
+            infoPlistPath: fixture.appending(components: "Foo.framework", "Info.plist"),
+            includeDir: includeDir,
+            publicHeaderPaths: [
+                includeDir.appending(components: "foo", "common.h"),
+                includeDir.appending(components: "bar", "common.h"),
+            ]
+        )
+        let assembler = FrameworkBundleAssembler(
+            frameworkComponents: frameworkComponents,
+            keepPublicHeadersStructure: false,
+            outputDirectory: outputDirectory,
+            fileSystem: fileSystem,
+            headerIncludeRewriter: CHeaderIncludeRewriter(replacementsByHeaderPath: ["unrelated.h": "Foo/unrelated.h"])
+        )
+
+        let error = #expect(throws: FileSystemError.self) {
+            try assembler.assemble()
+        }
+        guard case .alreadyExistsAtDestination(let path)? = error else {
+            Issue.record("Expected alreadyExistsAtDestination, got \(String(describing: error))")
+            return
+        }
+        #expect(path.lastPathComponent == "common.h")
+    }
+
     private func assembleFramework(keepPublicHeadersStructure: Bool, outputDirectory: URL) throws {
         let fixture = fixturesPath.appendingPathComponent("FrameworkBundleAssemblerTests")
         let frameworkComponents = FrameworkComponents(

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "ClangPackageWithConflictingHeaders",
+    platforms: [.iOS(.v12)],
+    products: [
+        .library(
+            name: "Consumer",
+            targets: ["Consumer"]
+        ),
+    ],
+    targets: [
+        .target(name: "LibA"),
+        .target(name: "LibB"),
+        .target(
+            name: "Consumer",
+            dependencies: ["LibA", "LibB"]
+        ),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/Consumer/consumer.c
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/Consumer/consumer.c
@@ -1,0 +1,5 @@
+#include <consumer.h>
+
+int consumer_value(void) {
+    return 0;
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/Consumer/include/consumer.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/Consumer/include/consumer.h
@@ -1,0 +1,6 @@
+#ifndef CONSUMER_CONSUMER_H
+#define CONSUMER_CONSUMER_H
+
+int consumer_value(void);
+
+#endif /* CONSUMER_CONSUMER_H */

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/LibA/a.c
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/LibA/a.c
@@ -1,0 +1,5 @@
+#include <shared.h>
+
+int liba_value(void) {
+    return 1;
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/LibA/include/shared.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/LibA/include/shared.h
@@ -1,0 +1,6 @@
+#ifndef LIBA_SHARED_H
+#define LIBA_SHARED_H
+
+int liba_value(void);
+
+#endif /* LIBA_SHARED_H */

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/LibB/b.c
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/LibB/b.c
@@ -1,0 +1,5 @@
+#include <shared.h>
+
+int libb_value(void) {
+    return 2;
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/LibB/include/shared.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithConflictingHeaders/Sources/LibB/include/shared.h
@@ -1,0 +1,6 @@
+#ifndef LIBB_SHARED_H
+#define LIBB_SHARED_H
+
+int libb_value(void);
+
+#endif /* LIBB_SHARED_H */

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "ClangPackageWithInterdependentHeaders",
+    platforms: [.iOS(.v12)],
+    products: [
+        .library(
+            name: "Feature",
+            targets: ["Feature"]
+        ),
+    ],
+    targets: [
+        .target(name: "CoreLib"),
+        .target(
+            name: "Feature",
+            dependencies: ["CoreLib"]
+        ),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/core_impl.c
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/core_impl.c
@@ -1,0 +1,5 @@
+#include <core/core.h>
+
+int core_answer(void) {
+    return 42;
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core.h
@@ -1,0 +1,9 @@
+#ifndef CORE_CORE_H
+#define CORE_CORE_H
+
+// Same-module public header include.
+#include <core/core_types.h>
+
+core_answer_t core_answer(void);
+
+#endif /* CORE_CORE_H */

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core.h
@@ -3,6 +3,8 @@
 
 // Same-module public header include.
 #include <core/core_types.h>
+// Inline-implementation file: textually included, must ship with the framework.
+#include <core/core_inline.inl>
 
 core_answer_t core_answer(void);
 

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core.h
@@ -5,6 +5,9 @@
 #include <core/core_types.h>
 // Inline-implementation file: textually included, must ship with the framework.
 #include <core/core_inline.inl>
+// Quoted include in the search-path style: no such file exists next to this header,
+// so only the -I entries SwiftPM injects can resolve it in source builds.
+#include "core/core_quoted.h"
 
 core_answer_t core_answer(void);
 

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core_inline.inl
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core_inline.inl
@@ -1,0 +1,8 @@
+#ifndef CORE_CORE_INLINE_INL
+#define CORE_CORE_INLINE_INL
+
+static inline core_answer_t core_default_answer(void) {
+    return (core_answer_t)42;
+}
+
+#endif /* CORE_CORE_INLINE_INL */

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core_quoted.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core_quoted.h
@@ -1,0 +1,6 @@
+#ifndef CORE_CORE_QUOTED_H
+#define CORE_CORE_QUOTED_H
+
+int core_quoted_answer(void);
+
+#endif /* CORE_CORE_QUOTED_H */

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core_types.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/CoreLib/include/core/core_types.h
@@ -1,0 +1,6 @@
+#ifndef CORE_CORE_TYPES_H
+#define CORE_CORE_TYPES_H
+
+typedef int core_answer_t;
+
+#endif /* CORE_CORE_TYPES_H */

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/Feature/feature.c
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/Feature/feature.c
@@ -1,0 +1,5 @@
+#include <feature.h>
+
+int feature_value(void) {
+    return core_answer() + 1;
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/Feature/include/feature.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/ClangPackageWithInterdependentHeaders/Sources/Feature/include/feature.h
@@ -1,0 +1,9 @@
+#ifndef FEATURE_FEATURE_H
+#define FEATURE_FEATURE_H
+
+// Cross-module include of a dependency's public header.
+#include <core/core.h>
+
+int feature_value(void);
+
+#endif /* FEATURE_FEATURE_H */

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -15,6 +15,7 @@ private let clangPackagePath = fixturePath.appendingPathComponent("ClangPackage"
 private let clangPackageWithSymbolicLinkHeadersPath = fixturePath.appendingPathComponent("ClangPackageWithSymbolicLinkHeaders")
 private let clangPackageWithCustomModuleMapPath = fixturePath.appendingPathComponent("ClangPackageWithCustomModuleMap")
 private let clangPackageWithUmbrellaDirectoryPath = fixturePath.appendingPathComponent("ClangPackageWithUmbrellaDirectory")
+private let clangPackageWithInterdependentHeadersPath = fixturePath.appendingPathComponent("ClangPackageWithInterdependentHeaders")
 
 private struct InfoPlist: Decodable {
     var bundleVersion: String
@@ -156,6 +157,102 @@ final class RunnerTests: XCTestCase {
             XCTAssertFalse(fileManager.fileExists(atPath: versionFile.path),
                            "Should not create .\(library).version in create mode")
         }
+    }
+
+    func testBuildClangPackageRewritesInterdependentHeaderIncludes() async throws {
+        // Use keepPublicHeadersStructure so the nested `core/core.h` layout survives into the framework.
+        let runner = Runner(
+            mode: .createPackage,
+            options: .init(
+                baseBuildOptions: .init(isSimulatorSupported: false, keepPublicHeadersStructure: true),
+                shouldOnlyUseVersionsFromResolvedFile: true
+            )
+        )
+        do {
+            try await runner.run(packageDirectory: clangPackageWithInterdependentHeadersPath,
+                                 frameworkOutputDir: .custom(frameworkOutputDir))
+        } catch {
+            XCTFail("Build should be succeeded. \(error.localizedDescription)")
+        }
+
+        let featureSlice = frameworkOutputDir
+            .appendingPathComponent("Feature.xcframework")
+            .appendingPathComponent("ios-arm64")
+        let coreLibSlice = frameworkOutputDir
+            .appendingPathComponent("CoreLib.xcframework")
+            .appendingPathComponent("ios-arm64")
+
+        // `Feature`'s public header does `#include <core/core.h>`. In the prebuilt framework it must
+        // be rewritten to the framework-relative `<CoreLib/core/core.h>` so consumers resolve it via
+        // `-F` instead of a `-I` that only SwiftPM would inject.
+        let featureHeaderPath = featureSlice
+            .appendingPathComponent("Feature.framework")
+            .appendingPathComponent("Headers/feature.h")
+            .path
+        let headerContents = try XCTUnwrap(
+            fileManager.contents(atPath: featureHeaderPath).flatMap { String(decoding: $0, as: UTF8.self) }
+        )
+        XCTAssertTrue(
+            headerContents.contains("#include <CoreLib/core/core.h>"),
+            "Angle-bracket include should be rewritten to framework form, got:\n\(headerContents)"
+        )
+        XCTAssertFalse(
+            headerContents.contains("#include <core/core.h>"),
+            "Original non-framework include should be gone"
+        )
+
+        // The rewritten path must actually exist in the dependency framework, otherwise the include
+        // is still unresolvable under `-F`. Its same-module include of a sibling public header must
+        // be rewritten as well.
+        let coreHeaderPath = coreLibSlice
+            .appendingPathComponent("CoreLib.framework")
+            .appendingPathComponent("Headers/core/core.h")
+            .path
+        let coreHeaderContents = try XCTUnwrap(
+            fileManager.contents(atPath: coreHeaderPath).flatMap { String(decoding: $0, as: UTF8.self) },
+            "CoreLib framework should expose the header at the rewritten path"
+        )
+        XCTAssertTrue(
+            coreHeaderContents.contains("#include <CoreLib/core/core_types.h>"),
+            "Same-module include should be rewritten to framework form, got:\n\(coreHeaderContents)"
+        )
+
+        // Prove a consumer can compile against the produced frameworks using only framework search
+        // (`-F`), with none of the `-I` paths SwiftPM would otherwise inject.
+        let sdkPath = try runProcess("/usr/bin/xcrun", ["--sdk", "iphoneos", "--show-sdk-path"])
+        XCTAssertEqual(sdkPath.status, 0, "Should resolve the iphoneos SDK path")
+
+        let consumerSource = tempDir.appendingPathComponent("header_rewrite_consumer.c")
+        try "#include <Feature/feature.h>\n".write(to: consumerSource, atomically: true, encoding: .utf8)
+        defer { try? fileManager.removeItem(at: consumerSource) }
+
+        let compile = try runProcess("/usr/bin/xcrun", [
+            "--sdk", "iphoneos", "clang",
+            "-target", "arm64-apple-ios12.0",
+            "-isysroot", sdkPath.output.trimmingCharacters(in: .whitespacesAndNewlines),
+            "-F", featureSlice.path,
+            "-F", coreLibSlice.path,
+            "-fsyntax-only",
+            "-x", "c", consumerSource.path,
+        ])
+        XCTAssertEqual(
+            compile.status, 0,
+            "Consumer should compile using only -F (framework search). Output:\n\(compile.output)"
+        )
+    }
+
+    private func runProcess(_ launchPath: String, _ arguments: [String]) throws -> (status: Int32, output: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        // Drain the pipe before waiting: waiting first deadlocks once output exceeds the pipe buffer.
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(decoding: data, as: UTF8.self))
     }
 
     func testBuildClangPackageWithSymbolicLinkHeaders() async throws {

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -233,6 +233,13 @@ final class RunnerTests: XCTestCase {
             "Include of the inline-implementation file should be rewritten, got:\n\(coreHeaderContents)"
         )
 
+        // A quoted include that only the injected search paths could resolve is rewritten like
+        // an angle include; quoted lookup has no includer-relative candidate for it here.
+        XCTAssertTrue(
+            coreHeaderContents.contains("#include <CoreLib/core/core_quoted.h>"),
+            "Search-path style quoted include should be rewritten, got:\n\(coreHeaderContents)"
+        )
+
         // Prove a consumer can compile against the produced frameworks using only framework search
         // (`-F`), with none of the `-I` paths SwiftPM would otherwise inject.
         let sdkPath = try runProcess("/usr/bin/xcrun", ["--sdk", "iphoneos", "--show-sdk-path"])

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -217,6 +217,22 @@ final class RunnerTests: XCTestCase {
             "Same-module include should be rewritten to framework form, got:\n\(coreHeaderContents)"
         )
 
+        // Inline-implementation files are textual headers: they must ship with the framework
+        // and includes pointing at them must be rewritten like any other header.
+        XCTAssertTrue(
+            fileManager.fileExists(
+                atPath: coreLibSlice
+                    .appendingPathComponent("CoreLib.framework")
+                    .appendingPathComponent("Headers/core/core_inline.inl")
+                    .path
+            ),
+            "Inline-implementation file should be shipped with the framework"
+        )
+        XCTAssertTrue(
+            coreHeaderContents.contains("#include <CoreLib/core/core_inline.inl>"),
+            "Include of the inline-implementation file should be rewritten, got:\n\(coreHeaderContents)"
+        )
+
         // Prove a consumer can compile against the produced frameworks using only framework search
         // (`-F`), with none of the `-I` paths SwiftPM would otherwise inject.
         let sdkPath = try runProcess("/usr/bin/xcrun", ["--sdk", "iphoneos", "--show-sdk-path"])


### PR DESCRIPTION
## Summary

C packages address public headers relative to their include directory:

```c
#include <core/core.h>
```

SwiftPM resolves this form through the `-I` / `HEADER_SEARCH_PATHS` entries it injects. Consumers of the prebuilt XCFrameworks only get framework search paths (`-F`), which resolve the framework-relative form instead:

```c
#include <CoreLib/core/core.h>
```

So headers written in the SwiftPM form are unusable from the prebuilt frameworks.

This PR rewrites copied public headers from the first form to the second when an include points at the target itself or one of its visible dependencies. Replacement paths encode the header's final layout under `*.framework/Headers`, covering both `keepPublicHeadersStructure` and flattened headers.

## Behavior

- System headers, quoted includes, and paths outside the dependency closure are untouched.
- If multiple visible modules expose the same include path, Scipio logs a warning and leaves the include as-is rather than picking a module by iteration order.
- Headers with no matching includes round-trip byte-for-byte, so existing outputs are unaffected.

## Testing

- Unit tests cover the rewrite rules and table construction: nested vs flattened layout, ambiguous paths, and symlinked headers.
- An end-to-end test compiles a consumer against the produced frameworks using only `-F`, with none of the `-I` paths SwiftPM would inject, covering both cross-module and same-module includes.