### PR TITLE
Package system-library targets as header-only frameworks

### DIFF
--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -128,11 +128,14 @@ private final class BuildProductsResolver {
         let targetsToBuild = try targetsToBuild()
         let products = try targetsToBuild.flatMap(resolveBuildProduct(from:))
 
-        return try DependencyGraph<BuildProduct>.resolve(
+        // Resolve the full set first so every child ID stays resolvable; `filter` reconnects
+        // parents to children, preserving the build order of the remaining products.
+        let graph = try DependencyGraph<BuildProduct>.resolve(
             Set(products),
             id: \.target.name,
             childIDs: { $0.target.dependencies.flatMap(\.moduleNames) }
         )
+        return graph.filter { $0.target.underlying.type.isFrameworkProducible }
     }
 
     private func targetsToBuild() throws -> [ResolvedModule] {

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -72,6 +72,18 @@ extension DescriptionPackage {
     }
 }
 
+extension PackageManifestKit.Target.TargetKind {
+    /// Whether Scipio can produce an XCFramework for this target kind.
+    var isFrameworkProducible: Bool {
+        switch self {
+        case .regular, .binary, .system:
+            true
+        case .executable, .test, .plugin, .macro:
+            false
+        }
+    }
+}
+
 struct BuildProduct: Hashable, Sendable {
     var package: ResolvedPackage
     var target: ResolvedModule

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -83,6 +83,11 @@ extension PackageManifestKit.Target.TargetKind {
         }
     }
 
+    /// Whether the produced framework is linkable: a system-library framework
+    /// is header-only and resolves through the SDK instead.
+    var isFrameworkLinkable: Bool {
+        isFrameworkProducible && self != .system
+    }
 }
 
 struct BuildProduct: Hashable, Sendable {

--- a/Sources/ScipioKit/DescriptionPackage.swift
+++ b/Sources/ScipioKit/DescriptionPackage.swift
@@ -82,6 +82,7 @@ extension PackageManifestKit.Target.TargetKind {
             false
         }
     }
+
 }
 
 struct BuildProduct: Hashable, Sendable {
@@ -126,16 +127,16 @@ private final class BuildProductsResolver {
 
     func resolveBuildProductDependencyGraph() throws -> DependencyGraph<BuildProduct> {
         let targetsToBuild = try targetsToBuild()
-        let products = try targetsToBuild.flatMap(resolveBuildProduct(from:))
+        let products = try Set(targetsToBuild.flatMap(resolveBuildProduct(from:)))
 
-        // Resolve the full set first so every child ID stays resolvable; `filter` reconnects
-        // parents to children, preserving the build order of the remaining products.
-        let graph = try DependencyGraph<BuildProduct>.resolve(
-            Set(products),
+        // Non-producible targets are pruned from the resolution with their subtrees,
+        // so edges into them are dropped here as well.
+        let productNames = Set(products.map(\.target.name))
+        return try DependencyGraph<BuildProduct>.resolve(
+            products,
             id: \.target.name,
-            childIDs: { $0.target.dependencies.flatMap(\.moduleNames) }
+            childIDs: { $0.target.dependencies.flatMap(\.moduleNames).filter(productNames.contains) }
         )
-        return graph.filter { $0.target.underlying.type.isFrameworkProducible }
     }
 
     private func targetsToBuild() throws -> [ResolvedModule] {
@@ -155,21 +156,22 @@ private final class BuildProductsResolver {
     }
 
     private func resolveBuildProduct(from rootTarget: ResolvedModule) throws -> Set<BuildProduct> {
-        let dependencyProducts = Set(try rootTarget.recursiveModuleDependencies()
-            .flatMap(buildProducts(from:)))
-
         switch descriptionPackage.mode {
         case .createPackage:
             // In create mode, rootTarget should be built
-            let rootTargetProducts = try buildProducts(from: rootTarget)
-            return rootTargetProducts.union(dependencyProducts)
+            return try buildProducts(from: rootTarget)
         case .prepareDependencies:
             // In prepare mode, rootTarget is just a container. So it should be skipped.
-            return dependencyProducts
+            return Set(try rootTarget.dependencies.flatMap(\.modules).flatMap(buildProducts(from:)))
         }
     }
 
     private func buildProducts(from target: ResolvedModule) throws -> Set<BuildProduct> {
+        // A target that produces no framework is pruned with its whole subtree:
+        // its dependencies serve no product a consumer can link.
+        guard target.underlying.type.isFrameworkProducible else {
+            return []
+        }
         guard let package = descriptionPackage.graph.package(for: target) else {
             return []
         }
@@ -180,7 +182,7 @@ private final class BuildProductsResolver {
             return buildProducts
         }
 
-        let dependencyProducts = try target.recursiveDependencies().compactMap(\.module).flatMap(buildProducts(from:))
+        let dependencyProducts = try target.dependencies.flatMap(\.modules).flatMap(buildProducts(from:))
 
         let buildProducts = Set([rootTargetProduct] + dependencyProducts)
         buildProductsCache.updateValue(buildProducts, forKey: rootTargetProduct)

--- a/Sources/ScipioKit/Producer/FrameworkProducer.swift
+++ b/Sources/ScipioKit/Producer/FrameworkProducer.swift
@@ -339,7 +339,7 @@ struct FrameworkProducer {
     }
 
     private enum TargetBuildResult {
-        case interrupted(builtTargets: OrderedSet<CacheSystem.CacheTarget>, error: any Error)
+        case interrupted(builtTargets: OrderedSet<CacheSystem.CacheTarget>, error: any Swift.Error)
         case completed(builtTargets: OrderedSet<CacheSystem.CacheTarget>)
     }
 
@@ -373,8 +373,14 @@ struct FrameworkProducer {
             )
             try binaryExtractor.extract(of: product.target, overwrite: overwrite)
             logger.info("✅ Copy \(product.target.c99name).xcframework", metadata: .color(.green))
+        case .system:
+            try await packageSystemLibrary(product, buildOptions: buildOptions, outputDir: outputDir)
         default:
-            fatalError("Unexpected target type \(product.target.underlying.type)")
+            // Unreachable while the build-product graph only carries producible kinds.
+            throw Error.unsupportedTargetType(
+                targetName: product.target.name,
+                type: product.target.underlying.type
+            )
         }
 
         return []
@@ -476,6 +482,37 @@ struct FrameworkProducer {
                 await group.waitForAll()
             }
         }
+    }
+}
+
+extension FrameworkProducer {
+    enum Error: LocalizedError {
+        case unsupportedTargetType(targetName: String, type: Target.TargetKind)
+
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedTargetType(let targetName, let type):
+                return "Cannot produce an XCFramework for \(targetName): unsupported target type \(type.rawValue)"
+            }
+        }
+    }
+
+    fileprivate func packageSystemLibrary(
+        _ product: BuildProduct,
+        buildOptions: BuildOptions,
+        outputDir: URL
+    ) async throws {
+        let packager = SystemLibraryPackager(
+            descriptionPackage: descriptionPackage,
+            buildOptions: buildOptions,
+            keepPublicHeadersStructure: { [baseBuildOptions, buildOptionsMatrix] targetName in
+                (buildOptionsMatrix[targetName] ?? baseBuildOptions).keepPublicHeadersStructure
+            },
+            fileSystem: fileSystem
+        )
+        try await packager.createXCFramework(buildProduct: product,
+                                             outputDirectory: outputDir,
+                                             overwrite: overwrite)
     }
 }
 

--- a/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
+++ b/Sources/ScipioKit/Producer/InfoPlistGenerator.swift
@@ -12,6 +12,39 @@ struct InfoPlistGenerator {
         try fileSystem.writeFileContents(path, string: body)
     }
 
+    /// Generates an Info.plist for framework bundles assembled without a build step,
+    /// so all values are concrete instead of build-setting placeholders.
+    func generateForFramework(name: String, bundleIdentifier: String, at path: URL) throws {
+        try fileSystem.writeFileContents(path, string: frameworkBody(name: name, bundleIdentifier: bundleIdentifier))
+    }
+
+    private func frameworkBody(name: String, bundleIdentifier: String) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleDevelopmentRegion</key>
+            <string>en</string>
+            <key>CFBundleExecutable</key>
+            <string>\(name)</string>
+            <key>CFBundleIdentifier</key>
+            <string>\(bundleIdentifier)</string>
+            <key>CFBundleInfoDictionaryVersion</key>
+            <string>6.0</string>
+            <key>CFBundleName</key>
+            <string>\(name)</string>
+            <key>CFBundlePackageType</key>
+            <string>FMWK</string>
+            <key>CFBundleShortVersionString</key>
+            <string>1.0</string>
+            <key>CFBundleVersion</key>
+            <string>1</string>
+        </dict>
+        </plist>
+        """
+    }
+
     private var resourceBundleBody: String {
         """
         <?xml version="1.0" encoding="UTF-8"?>

--- a/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
+++ b/Sources/ScipioKit/Producer/PIF/CHeaderIncludeRewriter.swift
@@ -28,12 +28,24 @@ struct CHeaderIncludeRewriter {
         var ambiguousPaths: Set<String> = []
 
         for module in modules {
-            guard case let .clang(includeDir, publicHeaders) = module.resolvedModuleType else {
+            let includeDir: URL
+            let publicHeaders: [URL]
+            let keepsStructure: Bool
+            switch module.resolvedModuleType {
+            case .clang(let clangIncludeDir, let clangPublicHeaders):
+                includeDir = clangIncludeDir
+                publicHeaders = clangPublicHeaders
+                keepsStructure = keepPublicHeadersStructure(module)
+            case .system(let moduleDir, let systemHeaders, _):
+                // System-library headers always land with their module-map-relative layout preserved.
+                includeDir = moduleDir
+                publicHeaders = systemHeaders
+                keepsStructure = true
+            default:
                 continue
             }
             // `-F` resolves the framework bundle name, not the C99 modulemap name.
             let moduleName = module.name.packageNamed()
-            let keepsStructure = keepPublicHeadersStructure(module)
             var base = includeDir.standardizedFileURL.path(percentEncoded: false)
             if base.hasSuffix("/") && base != "/" {
                 base.removeLast()

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -183,7 +183,7 @@ struct FrameworkModuleMapGenerator {
         }
         // Line-anchored so declarations below leading comment lines convert too; nested
         // submodules are indented and stay untouched.
-        let moduleDeclaration = /^module/.anchorsMatchLineEndings()
+        let moduleDeclaration = /^module\b/.anchorsMatchLineEndings()
         return contents.replacing(moduleDeclaration, with: "framework module")
     }
 }

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -151,8 +151,9 @@ struct FrameworkModuleMapGenerator {
 
     private func generateLinkSection(context: Context) -> [String] {
         context.resolvedTarget.dependencies
-            .compactMap(\.module?.c99name)
-            .map { "    link framework \"\($0)\"" }
+            .compactMap(\.module)
+            .filter { $0.underlying.type.isFrameworkLinkable }
+            .map { "    link framework \"\($0.c99name)\"" }
     }
 
     private func generateModuleMapFile(

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -176,12 +176,10 @@ struct FrameworkModuleMapGenerator {
         guard let contents = String(bytes: rawData, encoding: .utf8) else {
             throw Error.unableToLoadCustomModuleMap(customModuleMap)
         }
-        // TODO: Use modern regex
-        let regex = try NSRegularExpression(pattern: "^module", options: [])
-        let replaced = regex.stringByReplacingMatches(in: contents,
-                                                      range: NSRange(location: 0, length: contents.utf16.count),
-                                                      withTemplate: "framework module")
-        return replaced
+        // Line-anchored so declarations below leading comment lines convert too; nested
+        // submodules are indented and stay untouched.
+        let moduleDeclaration = /^module/.anchorsMatchLineEndings()
+        return contents.replacing(moduleDeclaration, with: "framework module")
     }
 }
 

--- a/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/FrameworkModuleMapGenerator.swift
@@ -56,6 +56,11 @@ struct FrameworkModuleMapGenerator {
             case .none:
                 return nil
             }
+        } else if case let .system(_, _, moduleMapPath) = resolvedTarget.resolvedModuleType {
+            // A system-library module ships its own module map; only the framework conversion applies.
+            let path = try constructGeneratedModuleMapPath(context: context)
+            try generateModuleMapFile(context: context, moduleMapType: .custom(moduleMapPath), outputPath: path)
+            return path
         } else {
             let path = try constructGeneratedModuleMapPath(context: context)
             try generateModuleMapFile(context: context, moduleMapType: nil, outputPath: path)

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -136,12 +136,13 @@ struct PIFGenerator {
                 .append("-Wl,-make_mergeable")
             fallthrough
         case .dynamic:
-            guard let resolvedTarget = allModules.first(where: { $0.c99name == target.c99Name }),
-                  let recursiveDependencies = try? resolvedTarget.recursiveDependencies() else {
+            guard let resolvedTarget = allModules.first(where: { $0.c99name == target.c99Name }) else {
                 break
             }
 
-            let moduleDependenciesPerPlatforms = categorizeModuleDependenciesByPlatform(recursiveDependencies)
+            let moduleDependenciesPerPlatforms = categorizeModuleDependenciesByPlatform(
+                resolvedTarget.recursiveFrameworkLinkableDependencies()
+            )
 
             for (platforms, dependencies) in moduleDependenciesPerPlatforms {
                 let flags = dependencies.flatMap {
@@ -174,10 +175,6 @@ struct PIFGenerator {
     ) -> [[PIFKit.Platform]?: [ResolvedModule]] {
         dependencies.reduce(into: [:]) { partialResult, dependency in
             guard case .module(let module, let conditions) = dependency else {
-                return
-            }
-            // System-library modules build no product, so there is no framework to link.
-            guard module.underlying.type != .system else {
                 return
             }
             if conditions.isEmpty {

--- a/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
+++ b/Sources/ScipioKit/Producer/PIF/PIFGenerator.swift
@@ -176,6 +176,10 @@ struct PIFGenerator {
             guard case .module(let module, let conditions) = dependency else {
                 return
             }
+            // System-library modules build no product, so there is no framework to link.
+            guard module.underlying.type != .system else {
+                return
+            }
             if conditions.isEmpty {
                 partialResult[nil, default: []].append(module)
                 return

--- a/Sources/ScipioKit/Producer/SystemLibraryPackager.swift
+++ b/Sources/ScipioKit/Producer/SystemLibraryPackager.swift
@@ -117,15 +117,7 @@ struct SystemLibraryPackager: Compiler {
     ) async throws {
         let stubBinaryPath = try await buildStubBinary(for: target, sdk: sdk)
         let infoPlistPath = try generateInfoPlist(for: target, sdk: sdk)
-        let frameworkModuleMapGenerator = FrameworkModuleMapGenerator(
-            packageLocator: descriptionPackage,
-            fileSystem: fileSystem
-        )
-        let frameworkModuleMapPath = try frameworkModuleMapGenerator.generate(
-            resolvedTarget: target,
-            sdk: sdk,
-            keepPublicHeadersStructure: true
-        )
+        let frameworkModuleMapPath = try generateFrameworkModuleMap(for: target, sdk: sdk)
 
         let frameworkOutputDir = descriptionPackage.assembledFrameworksDirectory(
             buildConfiguration: buildOptions.buildConfiguration,
@@ -225,6 +217,27 @@ struct SystemLibraryPackager: Compiler {
             ]
         )
         return binaryPath
+    }
+
+    /// Custom module map contents take precedence over the shipped module map,
+    /// matching the compiled-target path.
+    private func generateFrameworkModuleMap(for target: ResolvedModule, sdk: SDK) throws -> URL? {
+        if let customModuleMapContents = buildOptions.customFrameworkModuleMapContents {
+            logger.info("📝 Using custom modulemap for \(target.name)(\(sdk.displayName))")
+            let moduleMapPath = try descriptionPackage.generatedModuleMapPath(of: target, sdk: sdk)
+            try fileSystem.createDirectory(moduleMapPath.parentDirectory, recursive: true)
+            try fileSystem.writeFileContents(moduleMapPath, data: customModuleMapContents)
+            return moduleMapPath
+        }
+        let generator = FrameworkModuleMapGenerator(
+            packageLocator: descriptionPackage,
+            fileSystem: fileSystem
+        )
+        return try generator.generate(
+            resolvedTarget: target,
+            sdk: sdk,
+            keepPublicHeadersStructure: true
+        )
     }
 
     /// There is no build step to fill in Info.plist variables, so the file is generated with

--- a/Sources/ScipioKit/Producer/SystemLibraryPackager.swift
+++ b/Sources/ScipioKit/Producer/SystemLibraryPackager.swift
@@ -1,0 +1,255 @@
+import Foundation
+import PackageManifestKit
+import ScipioKitCore
+
+/// A packager to produce XCFrameworks for system-library targets.
+///
+/// System-library targets carry a module map and optional headers and have nothing to compile;
+/// SwiftPM exposes them to importers through header search paths, which prebuilt-framework
+/// consumers do not get. Packaging them as header-only frameworks (headers, a framework module
+/// map, and a stub binary XCFramework creation requires) makes `import` of such modules resolve
+/// through the framework search consumers already have.
+struct SystemLibraryPackager: Compiler {
+    enum Error: LocalizedError {
+        case unexpectedModuleType(targetName: String)
+        case moduleMapNotFound(targetName: String, expectedPath: URL)
+
+        var errorDescription: String? {
+            switch self {
+            case .unexpectedModuleType(let targetName):
+                return """
+                System library target \(targetName) was resolved without system-library support. \
+                The restored resolved packages cache is stale: please clear it and retry.
+                """
+            case .moduleMapNotFound(let targetName, let expectedPath):
+                return "System library target \(targetName) has no module map at \(expectedPath.path(percentEncoded: false))"
+            }
+        }
+    }
+
+    let descriptionPackage: DescriptionPackage
+    private let buildOptions: BuildOptions
+    /// Resolves whether a target keeps its public-header directory structure in the produced
+    /// framework; the caller owns the per-target override rules.
+    private let keepPublicHeadersStructure: @Sendable (_ targetName: String) -> Bool
+    private let fileSystem: any FileSystem
+    private let executor: any Executor
+
+    init(
+        descriptionPackage: DescriptionPackage,
+        buildOptions: BuildOptions,
+        keepPublicHeadersStructure: @escaping @Sendable (_ targetName: String) -> Bool,
+        fileSystem: any FileSystem = LocalFileSystem.default,
+        executor: any Executor = ProcessExecutor(errorDecoder: StandardOutputDecoder())
+    ) {
+        self.descriptionPackage = descriptionPackage
+        self.buildOptions = buildOptions
+        self.keepPublicHeadersStructure = keepPublicHeadersStructure
+        self.fileSystem = fileSystem
+        self.executor = executor
+    }
+
+    func createXCFramework(buildProduct: BuildProduct, outputDirectory: URL, overwrite: Bool) async throws {
+        let target = buildProduct.target
+
+        guard case let .system(includeDir, publicHeaders, moduleMapPath) = target.resolvedModuleType else {
+            throw Error.unexpectedModuleType(targetName: target.name)
+        }
+        guard fileSystem.exists(moduleMapPath) else {
+            throw Error.moduleMapNotFound(targetName: target.name, expectedPath: moduleMapPath)
+        }
+        if target.underlying.pkgConfig != nil {
+            logger.warning(
+                "⚠️ \(target.name) declares pkgConfig; pkg-config flags are not carried into the prebuilt framework",
+                metadata: .color(.yellow)
+            )
+        }
+
+        let sdks = buildOptions.sdks
+        let sdkNames = sdks.map(\.displayName).joined(separator: ", ")
+        logger.info("📦 Packaging \(target.name) for \(sdkNames)")
+
+        // System-library headers compile in each importer's context; rewrite against their union.
+        let headerIncludeRewriter = CHeaderIncludeRewriter(
+            modules: try modulesVisibleToImporters(of: target),
+            keepPublicHeadersStructure: { keepPublicHeadersStructure($0.name) }
+        )
+
+        for sdk in sdks {
+            try await assembleFramework(
+                for: target,
+                sdk: sdk,
+                includeDir: includeDir,
+                publicHeaders: publicHeaders,
+                headerIncludeRewriter: headerIncludeRewriter
+            )
+        }
+
+        logger.info("🚀 Combining into XCFramework...")
+
+        let xcFrameworkName = target.xcFrameworkName
+        let outputXCFrameworkPath = outputDirectory.appending(component: xcFrameworkName)
+        if fileSystem.exists(outputXCFrameworkPath) && overwrite {
+            logger.info("💥 Delete \(xcFrameworkName)", metadata: .color(.red))
+            try fileSystem.removeFileTree(outputXCFrameworkPath)
+        }
+
+        let xcBuildClient = XCBuildClient(
+            buildProduct: buildProduct,
+            buildOptions: buildOptions,
+            configuration: buildOptions.buildConfiguration,
+            packageLocator: descriptionPackage
+        )
+        try await xcBuildClient.createXCFramework(
+            sdks: Set(sdks),
+            debugSymbols: nil,
+            outputPath: outputXCFrameworkPath
+        )
+    }
+
+    /// Assembles the header-only framework bundle for one SDK.
+    private func assembleFramework(
+        for target: ResolvedModule,
+        sdk: SDK,
+        includeDir: URL,
+        publicHeaders: [URL],
+        headerIncludeRewriter: CHeaderIncludeRewriter
+    ) async throws {
+        let stubBinaryPath = try await buildStubBinary(for: target, sdk: sdk)
+        let infoPlistPath = try generateInfoPlist(for: target, sdk: sdk)
+        let frameworkModuleMapGenerator = FrameworkModuleMapGenerator(
+            packageLocator: descriptionPackage,
+            fileSystem: fileSystem
+        )
+        let frameworkModuleMapPath = try frameworkModuleMapGenerator.generate(
+            resolvedTarget: target,
+            sdk: sdk,
+            keepPublicHeadersStructure: true
+        )
+
+        let frameworkOutputDir = descriptionPackage.assembledFrameworksDirectory(
+            buildConfiguration: buildOptions.buildConfiguration,
+            sdk: sdk
+        )
+        let frameworkName = target.name.packageNamed()
+        let components = FrameworkComponents(
+            isVersionedBundle: false,
+            frameworkName: frameworkName,
+            frameworkPath: frameworkOutputDir.appending(component: "\(frameworkName).framework"),
+            binaryPath: stubBinaryPath,
+            infoPlistPath: infoPlistPath,
+            swiftModulesPath: nil,
+            includeDir: includeDir,
+            publicHeaderPaths: Set(publicHeaders),
+            bridgingHeaderPath: nil,
+            modulemapPath: frameworkModuleMapPath,
+            resourceBundlePath: nil
+        )
+
+        // The module-map-relative layout must survive regardless of keepPublicHeadersStructure.
+        let assembler = FrameworkBundleAssembler(
+            frameworkComponents: components,
+            keepPublicHeadersStructure: true,
+            outputDirectory: frameworkOutputDir,
+            fileSystem: fileSystem,
+            headerIncludeRewriter: headerIncludeRewriter
+        )
+        try assembler.assemble()
+    }
+
+    /// The dependency closure of every module that transitively depends on this one: exactly
+    /// the compile contexts SwiftPM would have compiled these headers in.
+    private func modulesVisibleToImporters(of target: ResolvedModule) throws -> [ResolvedModule] {
+        // Keyed by name to avoid hashing whole module value trees.
+        var visibleModulesByName: [String: ResolvedModule] = [target.name: target]
+        for module in descriptionPackage.graph.allModules {
+            let closure = try module.recursiveModuleDependencies()
+            guard closure.contains(where: { $0.name == target.name }) else { continue }
+            visibleModulesByName[module.name] = module
+            for dependency in closure {
+                visibleModulesByName[dependency.name] = dependency
+            }
+        }
+        return Array(visibleModulesByName.values)
+    }
+
+    private func workingDirectory(for target: ResolvedModule, sdk: SDK) -> URL {
+        descriptionPackage.workspaceDirectory
+            .appending(components: "SystemLibraryFrameworks", target.name, sdk.settingValue)
+    }
+
+    /// Builds the stub binary the framework carries. XCFramework creation requires a binary and
+    /// reads the slice's platform from it, so the stub is compiled per SDK for its standard
+    /// architectures and merged into one static archive.
+    private func buildStubBinary(for target: ResolvedModule, sdk: SDK) async throws -> URL {
+        let workingDirectory = workingDirectory(for: target, sdk: sdk)
+        try fileSystem.createDirectory(workingDirectory, recursive: true)
+
+        // One module-scoped symbol keeps the archive non-empty; an unscoped name would collide
+        // when several stub frameworks are linked into the same binary.
+        let sourcePath = workingDirectory.appending(component: "stub.c")
+        try fileSystem.writeFileContents(
+            sourcePath,
+            string: "char _scipio_system_library_stub_\(target.c99name) = 0;\n"
+        )
+
+        var objectPaths: [URL] = []
+        for architecture in sdk.stubBinaryArchitectures {
+            let objectPath = workingDirectory.appending(component: "stub_\(architecture).o")
+            try await executor.execute([
+                "/usr/bin/xcrun",
+                "--sdk", sdk.settingValue,
+                "clang",
+                "-arch", architecture,
+                "-c", sourcePath.path(percentEncoded: false),
+                "-o", objectPath.path(percentEncoded: false),
+            ])
+            objectPaths.append(objectPath)
+        }
+
+        let binaryPath = workingDirectory.appending(component: target.name.packageNamed())
+        try await executor.execute(
+            [
+                "/usr/bin/xcrun",
+                "--sdk", sdk.settingValue,
+                "libtool",
+                "-static",
+            ]
+            + objectPaths.map { $0.path(percentEncoded: false) }
+            + [
+                "-o", binaryPath.path(percentEncoded: false),
+            ]
+        )
+        return binaryPath
+    }
+
+    /// There is no build step to fill in Info.plist variables, so the file is generated with
+    /// concrete values.
+    private func generateInfoPlist(for target: ResolvedModule, sdk: SDK) throws -> URL {
+        let infoPlistPath = workingDirectory(for: target, sdk: sdk).appending(component: "Info.plist")
+        let generator = InfoPlistGenerator(fileSystem: fileSystem)
+        try generator.generateForFramework(
+            name: target.name.packageNamed(),
+            bundleIdentifier: target.name.spm_mangledToBundleIdentifier(),
+            at: infoPlistPath
+        )
+        return infoPlistPath
+    }
+}
+
+extension SDK {
+    /// The standard architectures the stub binary is compiled for. Extra slices are harmless:
+    /// consumers pick the library by platform and link only the matching architecture.
+    fileprivate var stubBinaryArchitectures: [String] {
+        switch self {
+        case .macOS, .macCatalyst:
+            ["arm64", "x86_64"]
+        case .iOS, .tvOS, .visionOS:
+            ["arm64"]
+        case .iOSSimulator, .tvOSSimulator, .watchOSSimulator, .visionOSSimulator:
+            ["arm64", "x86_64"]
+        case .watchOS:
+            ["arm64", "arm64_32", "armv7k"]
+        }
+    }
+}

--- a/Sources/ScipioKit/Producer/SystemLibraryPackager.swift
+++ b/Sources/ScipioKit/Producer/SystemLibraryPackager.swift
@@ -196,14 +196,18 @@ struct SystemLibraryPackager: Compiler {
         var objectPaths: [URL] = []
         for architecture in sdk.stubBinaryArchitectures {
             let objectPath = workingDirectory.appending(component: "stub_\(architecture).o")
-            try await executor.execute([
-                "/usr/bin/xcrun",
-                "--sdk", sdk.settingValue,
-                "clang",
-                "-arch", architecture,
-                "-c", sourcePath.path(percentEncoded: false),
-                "-o", objectPath.path(percentEncoded: false),
-            ])
+            try await executor.execute(
+                [
+                    "/usr/bin/xcrun",
+                    "--sdk", sdk.stubBinarySDKName,
+                    "clang",
+                ]
+                + sdk.stubBinaryPlatformArguments(architecture: architecture)
+                + [
+                    "-c", sourcePath.path(percentEncoded: false),
+                    "-o", objectPath.path(percentEncoded: false),
+                ]
+            )
             objectPaths.append(objectPath)
         }
 
@@ -211,7 +215,7 @@ struct SystemLibraryPackager: Compiler {
         try await executor.execute(
             [
                 "/usr/bin/xcrun",
-                "--sdk", sdk.settingValue,
+                "--sdk", sdk.stubBinarySDKName,
                 "libtool",
                 "-static",
             ]
@@ -250,6 +254,27 @@ extension SDK {
             ["arm64", "x86_64"]
         case .watchOS:
             ["arm64", "arm64_32", "armv7k"]
+        }
+    }
+
+    // Mac Catalyst has no SDK of its own: the stub compiles against the macOS SDK there.
+    fileprivate var stubBinarySDKName: String {
+        switch self {
+        case .macCatalyst:
+            SDK.macOS.settingValue
+        default:
+            settingValue
+        }
+    }
+
+    // For Mac Catalyst the platform cannot be inferred from the SDK, so the full target
+    // triple marks the slice; XCFramework creation reads the platform from the binary.
+    fileprivate func stubBinaryPlatformArguments(architecture: String) -> [String] {
+        switch self {
+        case .macCatalyst:
+            ["-target", "\(architecture)-apple-ios-macabi"]
+        default:
+            ["-arch", architecture]
         }
     }
 }

--- a/Sources/ScipioKit/Producer/SystemLibraryPackager.swift
+++ b/Sources/ScipioKit/Producer/SystemLibraryPackager.swift
@@ -157,8 +157,8 @@ struct SystemLibraryPackager: Compiler {
         try assembler.assemble()
     }
 
-    /// The dependency closure of every module that transitively depends on this one: exactly
-    /// the compile contexts SwiftPM would have compiled these headers in.
+    // The dependency closure of every module that transitively depends on this one: exactly
+    // the compile contexts SwiftPM would have compiled these headers in.
     private func modulesVisibleToImporters(of target: ResolvedModule) throws -> [ResolvedModule] {
         // Keyed by name to avoid hashing whole module value trees.
         var visibleModulesByName: [String: ResolvedModule] = [target.name: target]

--- a/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
+++ b/Sources/ScipioKit/Resolver/ModuleTypeResolver.swift
@@ -23,6 +23,11 @@ extension PackageResolver {
                     target,
                     dependencyPackage: dependencyPackage
                 )
+            case .system:
+                resolveModuleTypeForSystemLibraryTarget(
+                    target,
+                    dependencyPackage: dependencyPackage
+                )
             default:
                 resolveModuleTypeForLibraryTarget(
                     target,
@@ -52,6 +57,32 @@ extension PackageResolver {
             }()
 
             return .binary(artifactType)
+        }
+
+        private func resolveModuleTypeForSystemLibraryTarget(
+            _ target: Target,
+            dependencyPackage: DependencyPackage
+        ) -> ResolvedModuleType {
+            assert(target.type == .system)
+
+            // SwiftPM expects module.modulemap at the module root and resolves its header paths
+            // against it, so the module directory itself is the include root.
+            let moduleFullPath = resolveTargetFullPath(of: target, dependencyPackage: dependencyPackage)
+                .standardizedFileURL
+            // Sorted because the enumeration order is unspecified: keeps the resolution
+            // result, and thus the serialized snapshot, deterministic.
+            let publicHeaders = FileManager.default
+                .enumerator(at: moduleFullPath, includingPropertiesForKeys: nil)?
+                .compactMap { $0 as? URL }
+                .filter { headerExtensions.contains($0.pathExtension) }
+                .sorted { $0.path(percentEncoded: false) < $1.path(percentEncoded: false) } ?? []
+
+            // Module map existence is validated at packaging time, with a proper error.
+            return .system(
+                includeDir: moduleFullPath,
+                publicHeaders: publicHeaders,
+                moduleMapPath: moduleFullPath.appending(component: "module.modulemap")
+            )
         }
 
         private func resolveModuleTypeForLibraryTarget(

--- a/Sources/ScipioKit/Resolver/PackageResolver.swift
+++ b/Sources/ScipioKit/Resolver/PackageResolver.swift
@@ -107,7 +107,25 @@ actor PackageResolver {
             }
         )
 
+        if Self.containsStaleSystemModule(in: allModules) {
+            logger.warning(
+                "⚠️ Discarding a resolved packages cache written without system-library support",
+                metadata: .color(.yellow)
+            )
+            return nil
+        }
+
         return (allPackages: allPackages, allModules: allModules)
+    }
+
+    /// Caches written before system-library support carry a wrong module type for system
+    /// modules; packaging from them would produce empty frameworks.
+    static func containsStaleSystemModule(in modules: some Collection<ResolvedModule>) -> Bool {
+        modules.contains { module in
+            guard module.underlying.type == .system else { return false }
+            if case .system = module.resolvedModuleType { return false }
+            return true
+        }
     }
 
     /// Resolve a manifest into a concrete ResolvedPackage with modules and products.

--- a/Sources/ScipioKit/Resolver/PackageResolver.swift
+++ b/Sources/ScipioKit/Resolver/PackageResolver.swift
@@ -118,8 +118,8 @@ actor PackageResolver {
         return (allPackages: allPackages, allModules: allModules)
     }
 
-    /// Caches written before system-library support carry a wrong module type for system
-    /// modules; packaging from them would produce empty frameworks.
+    // Whether any system module was resolved without system-library support: caches written
+    // before it carry a wrong module type, and packaging from them would produce empty frameworks.
     static func containsStaleSystemModule(in modules: some Collection<ResolvedModule>) -> Bool {
         modules.contains { module in
             guard module.underlying.type == .system else { return false }

--- a/Sources/ScipioKit/Resolver/ResolvedModels+Extensions.swift
+++ b/Sources/ScipioKit/Resolver/ResolvedModels+Extensions.swift
@@ -37,6 +37,32 @@ extension ResolvedModule {
         try topologicalSort(self.dependencies) { $0.dependencies }
     }
 
+    /// The dependencies to link as frameworks. The walk mirrors the build-product
+    /// pruning: modules reachable only through non-producible targets build no
+    /// framework, and system-library modules are packaged but resolve through the SDK.
+    func recursiveFrameworkLinkableDependencies() -> [Dependency] {
+        var visitedModuleNames = Set<String>()
+        var linkable: [Dependency] = []
+
+        func visit(_ dependencies: [Dependency]) {
+            for dependency in dependencies {
+                switch dependency {
+                case .product:
+                    visit(dependency.dependencies)
+                case .module(let module, _):
+                    guard visitedModuleNames.insert(module.name).inserted else { continue }
+                    guard module.underlying.type.isFrameworkProducible else { continue }
+                    if module.underlying.type.isFrameworkLinkable {
+                        linkable.append(dependency)
+                    }
+                    visit(module.dependencies)
+                }
+            }
+        }
+
+        visit(dependencies)
+        return linkable
+    }
 }
 
 extension ResolvedModule.Dependency {

--- a/Sources/ScipioKit/Resolver/ResolvedModels+Extensions.swift
+++ b/Sources/ScipioKit/Resolver/ResolvedModels+Extensions.swift
@@ -36,6 +36,7 @@ extension ResolvedModule {
     func recursiveDependencies() throws -> [Dependency] {
         try topologicalSort(self.dependencies) { $0.dependencies }
     }
+
 }
 
 extension ResolvedModule.Dependency {
@@ -62,12 +63,15 @@ extension ResolvedModule.Dependency {
         }
     }
 
-    var moduleNames: [String] {
-        let moduleNames = switch self {
-        case .module(let module, _): [module.name]
-        case .product(let product, _): product.modules.map(\.name)
+    var modules: [ResolvedModule] {
+        switch self {
+        case .module(let module, _): [module]
+        case .product(let product, _): product.modules
         }
-        return moduleNames
+    }
+
+    var moduleNames: [String] {
+        modules.map(\.name)
     }
 }
 

--- a/Sources/ScipioKitCore/ResolvedModels.swift
+++ b/Sources/ScipioKitCore/ResolvedModels.swift
@@ -188,6 +188,10 @@ public enum ResolvedModuleType: Hashable, Codable, Sendable {
     /// A Swift module (compiled from Swift source).
     case swift
 
+    /// A system-library module: a module map with optional headers, nothing to compile.
+    /// `includeDir` is the module directory itself; the module map addresses headers relative to it.
+    case system(includeDir: URL, publicHeaders: [URL], moduleMapPath: URL)
+
     /// Returns the include directory for Clang modules, or `nil` for other module types.
     public var includeDir: URL? {
         switch self {

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -132,7 +132,11 @@ struct DescriptionPackageTests {
         }
         let expectedModuleDirectory = rootPath.appending(components: "Sources", "SysShim").standardizedFileURL
         #expect(includeDir.path(percentEncoded: false) == expectedModuleDirectory.path(percentEncoded: false))
-        #expect(publicHeaders.map(\.lastPathComponent) == ["shim.h"])
+        // Recursive discovery in path-sorted order: the nested header comes first.
+        #expect(publicHeaders.map { $0.path(percentEncoded: false) } == [
+            expectedModuleDirectory.appending(components: "nested", "extra.h").path(percentEncoded: false),
+            expectedModuleDirectory.appending(component: "shim.h").path(percentEncoded: false),
+        ])
         #expect(moduleMapPath.path(percentEncoded: false) ==
                 expectedModuleDirectory.appending(component: "module.modulemap").path(percentEncoded: false))
     }

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -162,6 +162,39 @@ struct DescriptionPackageTests {
     }
 
     @Test
+    func frameworkLinkableDependencies() async throws {
+        let rootPath = fixturePath.appendingPathComponent("PackageWithExecutableTargetDependency")
+        let package = try await DescriptionPackage(
+            packageDirectory: rootPath,
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: false
+        )
+
+        let myLib = try #require(package.graph.rootPackage.targets.first { $0.name == "MyLib" })
+
+        // The executable and everything reachable only through it build no
+        // framework, so nothing is linkable.
+        #expect(myLib.recursiveFrameworkLinkableDependencies().isEmpty)
+    }
+
+    @Test
+    func frameworkLinkableDependenciesSkipSystemModules() async throws {
+        let rootPath = fixturePath.appendingPathComponent("PackageWithSystemLibraryTarget")
+        let package = try await DescriptionPackage(
+            packageDirectory: rootPath,
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: false
+        )
+
+        let mainLib = try #require(package.graph.rootPackage.targets.first { $0.name == "MainLib" })
+
+        // The system-library module is packaged but resolves through the SDK.
+        #expect(mainLib.recursiveFrameworkLinkableDependencies().flatMap(\.moduleNames) == ["CoreLib"])
+    }
+
+    @Test
     func frameworkProducibleTargetKinds() {
         #expect(Target.TargetKind.regular.isFrameworkProducible)
         #expect(Target.TargetKind.binary.isFrameworkProducible)
@@ -170,6 +203,12 @@ struct DescriptionPackageTests {
         #expect(!Target.TargetKind.test.isFrameworkProducible)
         #expect(!Target.TargetKind.plugin.isFrameworkProducible)
         #expect(!Target.TargetKind.macro.isFrameworkProducible)
+
+        // Producible but header-only: nothing to link.
+        #expect(Target.TargetKind.regular.isFrameworkLinkable)
+        #expect(Target.TargetKind.binary.isFrameworkLinkable)
+        #expect(!Target.TargetKind.system.isFrameworkLinkable)
+        #expect(!Target.TargetKind.executable.isFrameworkLinkable)
     }
 
     @Test

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -154,11 +154,11 @@ struct DescriptionPackageTests {
         let graph = try package.resolveBuildProductDependencyGraph()
             .map { $0.target.name }
 
-        // HelperTool is dropped, and MyLib is reconnected to its transitive
-        // library dependency so the build order survives the removal.
-        #expect(graph.allNodes.map(\.value).sorted() == ["MyLib", "ToolSupport"])
+        // HelperTool produces no framework, so it is pruned together with
+        // ToolSupport, which is reachable only through it.
+        #expect(graph.allNodes.map(\.value) == ["MyLib"])
         let myLibNode = try #require(graph.rootNodes.first { $0.value == "MyLib" })
-        #expect(myLibNode.children.map(\.value) == ["ToolSupport"])
+        #expect(myLibNode.children.isEmpty)
     }
 
     @Test

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -1,5 +1,7 @@
 import Foundation
 import Testing
+import PackageManifestKit
+import ScipioKitCore
 @testable import ScipioKit
 
 private let fixturePath = URL(fileURLWithPath: #filePath)
@@ -108,5 +110,60 @@ struct DescriptionPackageTests {
             Set(try package.resolveBuildProductDependencyGraph().allNodes.map(\.value.target.name)) ==
             ["SomeBinary"]
         )
+    }
+
+    @Test
+    func systemLibraryBuildProductsInCreateMode() async throws {
+        let rootPath = fixturePath.appendingPathComponent("PackageWithSystemLibraryTarget")
+        let package = try await DescriptionPackage(
+            packageDirectory: rootPath,
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: false
+        )
+
+        let graph = try package.resolveBuildProductDependencyGraph()
+        #expect(graph.allNodes.map(\.value.target.name).sorted() == ["CoreLib", "MainLib", "SysShim"])
+
+        let sysShim = try #require(graph.allNodes.map(\.value.target).first { $0.name == "SysShim" })
+        guard case let .system(includeDir, publicHeaders, moduleMapPath) = sysShim.resolvedModuleType else {
+            Issue.record("SysShim should be resolved as a system module, got \(sysShim.resolvedModuleType)")
+            return
+        }
+        let expectedModuleDirectory = rootPath.appending(components: "Sources", "SysShim").standardizedFileURL
+        #expect(includeDir.path(percentEncoded: false) == expectedModuleDirectory.path(percentEncoded: false))
+        #expect(publicHeaders.map(\.lastPathComponent) == ["shim.h"])
+        #expect(moduleMapPath.path(percentEncoded: false) ==
+                expectedModuleDirectory.appending(component: "module.modulemap").path(percentEncoded: false))
+    }
+
+    @Test
+    func frameworkProducibleTargetKinds() {
+        #expect(Target.TargetKind.regular.isFrameworkProducible)
+        #expect(Target.TargetKind.binary.isFrameworkProducible)
+        #expect(Target.TargetKind.system.isFrameworkProducible)
+        #expect(!Target.TargetKind.executable.isFrameworkProducible)
+        #expect(!Target.TargetKind.test.isFrameworkProducible)
+        #expect(!Target.TargetKind.plugin.isFrameworkProducible)
+        #expect(!Target.TargetKind.macro.isFrameworkProducible)
+    }
+
+    @Test
+    func staleSystemModuleDetection() async throws {
+        let rootPath = fixturePath.appendingPathComponent("PackageWithSystemLibraryTarget")
+        let package = try await DescriptionPackage(
+            packageDirectory: rootPath,
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: false
+        )
+
+        let modules = package.graph.allModules
+        #expect(!PackageResolver.containsStaleSystemModule(in: modules))
+
+        // A cache written without system-library support carries the old clang fallback type.
+        var staleModule = try #require(modules.first { $0.name == "SysShim" })
+        staleModule.resolvedModuleType = .clang(includeDir: staleModule.localPackageURL, publicHeaders: [])
+        #expect(PackageResolver.containsStaleSystemModule(in: [staleModule]))
     }
 }

--- a/Tests/ScipioKitTests/DescriptionPackageTests.swift
+++ b/Tests/ScipioKitTests/DescriptionPackageTests.swift
@@ -142,6 +142,26 @@ struct DescriptionPackageTests {
     }
 
     @Test
+    func executableTargetIsExcludedFromBuildProducts() async throws {
+        let rootPath = fixturePath.appendingPathComponent("PackageWithExecutableTargetDependency")
+        let package = try await DescriptionPackage(
+            packageDirectory: rootPath,
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: false
+        )
+
+        let graph = try package.resolveBuildProductDependencyGraph()
+            .map { $0.target.name }
+
+        // HelperTool is dropped, and MyLib is reconnected to its transitive
+        // library dependency so the build order survives the removal.
+        #expect(graph.allNodes.map(\.value).sorted() == ["MyLib", "ToolSupport"])
+        let myLibNode = try #require(graph.rootNodes.first { $0.value == "MyLib" })
+        #expect(myLibNode.children.map(\.value) == ["ToolSupport"])
+    }
+
+    @Test
     func frameworkProducibleTargetKinds() {
         #expect(Target.TargetKind.regular.isFrameworkProducible)
         #expect(Target.TargetKind.binary.isFrameworkProducible)

--- a/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
+++ b/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import ScipioKit
+@testable import ScipioKitCore
 import Testing
 
 private let fixturesPath = URL(fileURLWithPath: #filePath)
@@ -116,11 +117,42 @@ framework module SysShim {
         #expect(generatedModuleMapContents == expectedModuleMapContents)
     }
 
+    @Test
+    func generate_skipsNonFrameworkDependenciesInLinkSection() async throws {
+        let outputDirectory = temporaryDirectory.appending(component: #function)
+        defer { try? fileSystem.removeFileTree(outputDirectory) }
+
+        let executable = try ResolvedGraphFixtures.resolvedModule(
+            name: "HelperTool",
+            targetType: "executable"
+        )
+        let library = try ResolvedGraphFixtures.resolvedModule(name: "RealLib")
+        let target = try ResolvedGraphFixtures.resolvedModule(
+            name: "MyTarget",
+            dependencies: [
+                .module(executable, conditions: []),
+                .module(library, conditions: []),
+            ]
+        )
+
+        let generatedModuleMapContents = try await generateModuleMap(
+            for: clangPackageWithUmbrellaDirectoryPath,
+            moduleName: "MyTarget",
+            keepPublicHeadersStructure: false,
+            outputDirectory: outputDirectory,
+            resolvedTarget: target
+        )
+
+        #expect(generatedModuleMapContents.contains("link framework \"RealLib\""))
+        #expect(!generatedModuleMapContents.contains("link framework \"HelperTool\""))
+    }
+
     private func generateModuleMap(
         for packageDirectory: URL,
         moduleName: String,
         keepPublicHeadersStructure: Bool,
-        outputDirectory: URL
+        outputDirectory: URL,
+        resolvedTarget overrideResolvedTarget: ResolvedModule? = nil
     ) async throws -> String {
         let packageLocator = PackageLocatorMock(packageDirectory: outputDirectory)
         let generator = FrameworkModuleMapGenerator(
@@ -128,14 +160,20 @@ framework module SysShim {
             fileSystem: fileSystem
         )
 
-        let descriptionPackage = try await DescriptionPackage(
-            packageDirectory: packageDirectory,
-            mode: .createPackage,
-            resolvedPackagesCachePolicies: [],
-            onlyUseVersionsFromResolvedFile: false
-        )
+        let resolvedTarget: ResolvedModule
+        if let overrideResolvedTarget {
+            resolvedTarget = overrideResolvedTarget
+        } else {
+            let descriptionPackage = try await DescriptionPackage(
+                packageDirectory: packageDirectory,
+                mode: .createPackage,
+                resolvedPackagesCachePolicies: [],
+                onlyUseVersionsFromResolvedFile: false
+            )
+            resolvedTarget = try #require(descriptionPackage.graph.module(for: moduleName))
+        }
         let generatedModuleMapPath = try generator.generate(
-            resolvedTarget: #require(descriptionPackage.graph.module(for: moduleName)),
+            resolvedTarget: resolvedTarget,
             sdk: SDK.macOS,
             keepPublicHeadersStructure: keepPublicHeadersStructure
         )

--- a/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
+++ b/Tests/ScipioKitTests/FrameworkModuleMapGeneratorTests.swift
@@ -8,6 +8,7 @@ private let fixturesPath = URL(fileURLWithPath: #filePath)
     .appendingPathComponent("Fixtures")
 private let clangPackageWithUmbrellaDirectoryPath = fixturesPath.appendingPathComponent("ClangPackageWithUmbrellaDirectory")
 private let clangPackageWithRelativePublicHeadersPath = fixturesPath.appendingPathComponent("ClangPackageWithRelativePublicHeadersPath")
+private let packageWithSystemLibraryTargetPath = fixturesPath.appendingPathComponent("PackageWithSystemLibraryTarget")
 
 private struct PackageLocatorMock: PackageLocator {
     let packageDirectory: URL
@@ -86,6 +87,29 @@ framework module MyTarget {
         let expectedModuleMapContents = """
 framework module ClangPackageWithRelativePublicHeadersPath {
     header "ClangPackageWithRelativePublicHeadersPath/add.h"
+    export *
+}
+"""
+        #expect(generatedModuleMapContents == expectedModuleMapContents)
+    }
+
+    @Test
+    func generate_systemLibraryTarget() async throws {
+        let outputDirectory = temporaryDirectory.appending(component: #function)
+        defer { try? fileSystem.removeFileTree(outputDirectory) }
+
+        let generatedModuleMapContents = try await generateModuleMap(
+            for: packageWithSystemLibraryTargetPath,
+            moduleName: "SysShim",
+            keepPublicHeadersStructure: true,
+            outputDirectory: outputDirectory
+        )
+        // The shipped module map is converted to a framework module; the declaration is found
+        // even below leading comment lines, which stay in place.
+        let expectedModuleMapContents = """
+// A leading comment: the framework conversion must still find the declaration below.
+framework module SysShim {
+    header "shim.h"
     export *
 }
 """

--- a/Tests/ScipioKitTests/InfoPlistGeneratorTests.swift
+++ b/Tests/ScipioKitTests/InfoPlistGeneratorTests.swift
@@ -38,4 +38,44 @@ struct InfoPlistGeneratorTests {
         </plist>
         """)
     }
+
+    @Test(.temporaryDirectory)
+    func generateForFramework() throws {
+        let generator = InfoPlistGenerator(fileSystem: fileSystem)
+        let temporaryPath = TemporaryDirectory.url.appending(component: "Info.plist")
+
+        try generator.generateForFramework(
+            name: "MyFramework",
+            bundleIdentifier: "MyFramework",
+            at: temporaryPath
+        )
+
+        let infoPlistBodyData = try fileSystem.readFileContents(temporaryPath)
+        let infoPlistBody = try #require(String(data: infoPlistBodyData, encoding: .utf8))
+
+        #expect(infoPlistBody == """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleDevelopmentRegion</key>
+            <string>en</string>
+            <key>CFBundleExecutable</key>
+            <string>MyFramework</string>
+            <key>CFBundleIdentifier</key>
+            <string>MyFramework</string>
+            <key>CFBundleInfoDictionaryVersion</key>
+            <string>6.0</string>
+            <key>CFBundleName</key>
+            <string>MyFramework</string>
+            <key>CFBundlePackageType</key>
+            <string>FMWK</string>
+            <key>CFBundleShortVersionString</key>
+            <string>1.0</string>
+            <key>CFBundleVersion</key>
+            <string>1</string>
+        </dict>
+        </plist>
+        """)
+    }
 }

--- a/Tests/ScipioKitTests/ResolvedPackagesSnapshotTests.swift
+++ b/Tests/ScipioKitTests/ResolvedPackagesSnapshotTests.swift
@@ -38,6 +38,30 @@ struct ResolvedPackagesSnapshotTests {
         #expect(restoredRoot.dependencies == originalRoot.dependencies)
     }
 
+    @Test("A system-library module type round-trips through the snapshot")
+    func roundTripPreservesSystemModuleType() throws {
+        let moduleDirectory = URL(filePath: "/tmp/example-package/Sources/SysShim")
+        let systemModuleType = ResolvedModuleType.system(
+            includeDir: moduleDirectory,
+            publicHeaders: [moduleDirectory.appending(component: "shim.h")],
+            moduleMapPath: moduleDirectory.appending(component: "module.modulemap")
+        )
+        let systemModule = try ResolvedGraphFixtures.resolvedModule(
+            name: "SysShim",
+            targetType: "system",
+            resolvedModuleType: systemModuleType
+        )
+        let original = [try ResolvedGraphFixtures.package(targets: [systemModule])]
+
+        let data = try jsonEncoder.encode(ResolvedPackagesSnapshot(resolvedPackages: original))
+        let restored = try jsonDecoder.decode(ResolvedPackagesSnapshot.self, from: data).restoreResolvedPackages()
+
+        let restoredModule = try #require(restored.first?.targets.first)
+        #expect(restoredModule.resolvedModuleType == systemModuleType)
+        // A restored system module must pass the staleness gate that guards cache reuse.
+        #expect(!PackageResolver.containsStaleSystemModule(in: [restoredModule]))
+    }
+
     @Test("Restoring produces one value per identity")
     func restoreProducesOneValuePerIdentity() throws {
         let original = [try ResolvedGraphFixtures.diamondChainPackage(depth: 12)]

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     ],
     targets: [
         // A library target may depend on an executable target; no framework can be
-        // produced for the executable, so it must stay out of the build graph while
-        // its own library dependencies stay in.
+        // produced for the executable, so it is pruned from the build graph together
+        // with the dependencies only it reaches.
         .target(name: "MyLib", dependencies: ["HelperTool"]),
         .executableTarget(name: "HelperTool", dependencies: ["ToolSupport"]),
         .target(name: "ToolSupport"),

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "PackageWithExecutableTargetDependency",
+    platforms: [.macOS(.v12)],
+    products: [
+        .library(
+            name: "MyLib",
+            targets: ["MyLib"]
+        ),
+    ],
+    targets: [
+        // A library target may depend on an executable target; no framework can be
+        // produced for the executable, so it must stay out of the build graph while
+        // its own library dependencies stay in.
+        .target(name: "MyLib", dependencies: ["HelperTool"]),
+        .executableTarget(name: "HelperTool", dependencies: ["ToolSupport"]),
+        .target(name: "ToolSupport"),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Sources/HelperTool/main.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Sources/HelperTool/main.swift
@@ -1,0 +1,3 @@
+import ToolSupport
+
+_ = toolSupportValue()

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Sources/MyLib/MyLib.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Sources/MyLib/MyLib.swift
@@ -1,0 +1,3 @@
+public func myLibValue() -> Int {
+    0
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Sources/ToolSupport/ToolSupport.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithExecutableTargetDependency/Sources/ToolSupport/ToolSupport.swift
@@ -1,0 +1,3 @@
+public func toolSupportValue() -> Int {
+    0
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithStandaloneExecutableTarget/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithStandaloneExecutableTarget/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "PackageWithStandaloneExecutableTarget",
+    platforms: [.macOS(.v12)],
+    products: [
+        .library(
+            name: "MyLib",
+            targets: ["MyLib"]
+        ),
+    ],
+    targets: [
+        // The executable produces no framework, so it is pruned from the build
+        // graph; standalone because the xcbuild path cannot link an executable
+        // product against the renamed module frameworks of its dependencies.
+        .target(name: "MyLib", dependencies: ["HelperTool"]),
+        .executableTarget(name: "HelperTool"),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithStandaloneExecutableTarget/Sources/HelperTool/main.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithStandaloneExecutableTarget/Sources/HelperTool/main.swift
@@ -1,0 +1,1 @@
+print("helper")

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithStandaloneExecutableTarget/Sources/MyLib/MyLib.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithStandaloneExecutableTarget/Sources/MyLib/MyLib.swift
@@ -1,0 +1,3 @@
+public func myLibValue() -> Int {
+    0
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Package.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.7
+import PackageDescription
+
+let package = Package(
+    name: "PackageWithSystemLibraryTarget",
+    platforms: [.iOS(.v12)],
+    products: [
+        .library(
+            name: "MainLib",
+            targets: ["MainLib"]
+        ),
+    ],
+    targets: [
+        .target(name: "CoreLib"),
+        .systemLibrary(name: "SysShim"),
+        .target(
+            name: "MainLib",
+            // The system-library header includes CoreLib's header, so importers carry both.
+            dependencies: ["CoreLib", "SysShim"]
+        ),
+    ]
+)

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/CoreLib/core_impl.c
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/CoreLib/core_impl.c
@@ -1,0 +1,5 @@
+#include <core/core.h>
+
+core_value_t core_value(void) {
+    return 42;
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/CoreLib/include/core/core.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/CoreLib/include/core/core.h
@@ -1,0 +1,8 @@
+#ifndef CORE_CORE_H
+#define CORE_CORE_H
+
+#include <core/core_types.h>
+
+core_value_t core_value(void);
+
+#endif /* CORE_CORE_H */

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/CoreLib/include/core/core_types.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/CoreLib/include/core/core_types.h
@@ -1,0 +1,6 @@
+#ifndef CORE_CORE_TYPES_H
+#define CORE_CORE_TYPES_H
+
+typedef int core_value_t;
+
+#endif /* CORE_CORE_TYPES_H */

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/MainLib/MainLib.swift
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/MainLib/MainLib.swift
@@ -1,0 +1,5 @@
+import SysShim
+
+public func mainLibValue() -> sys_shim_value_t {
+    sys_shim_value_t(0)
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/SysShim/module.modulemap
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/SysShim/module.modulemap
@@ -1,0 +1,5 @@
+// A leading comment: the framework conversion must still find the declaration below.
+module SysShim {
+    header "shim.h"
+    export *
+}

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/SysShim/nested/extra.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/SysShim/nested/extra.h
@@ -1,0 +1,7 @@
+#ifndef SYS_SHIM_EXTRA_H
+#define SYS_SHIM_EXTRA_H
+
+// Lives in a subdirectory: header discovery must recurse and stay order-stable.
+typedef int sys_shim_extra_t;
+
+#endif /* SYS_SHIM_EXTRA_H */

--- a/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/SysShim/shim.h
+++ b/Tests/ScipioKitTests/Resources/Fixtures/PackageWithSystemLibraryTarget/Sources/SysShim/shim.h
@@ -1,0 +1,9 @@
+#ifndef SYS_SHIM_H
+#define SYS_SHIM_H
+
+// Cross-module include, resolved by the importers' search paths in source builds.
+#include <core/core.h>
+
+typedef core_value_t sys_shim_value_t;
+
+#endif /* SYS_SHIM_H */

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -17,6 +17,7 @@ private let clangPackageWithCustomModuleMapPath = fixturePath.appendingPathCompo
 private let clangPackageWithUmbrellaDirectoryPath = fixturePath.appendingPathComponent("ClangPackageWithUmbrellaDirectory")
 private let clangPackageWithInterdependentHeadersPath = fixturePath.appendingPathComponent("ClangPackageWithInterdependentHeaders")
 private let packageWithSystemLibraryTargetPath = fixturePath.appendingPathComponent("PackageWithSystemLibraryTarget")
+private let packageWithStandaloneExecutableTargetPath = fixturePath.appendingPathComponent("PackageWithStandaloneExecutableTarget")
 
 private struct InfoPlist: Decodable {
     var bundleVersion: String
@@ -373,6 +374,33 @@ final class RunnerTests: XCTestCase {
         XCTAssertEqual(
             compile.status, 0,
             "Consumer should compile using only -F (framework search). Output:\n\(compile.output)"
+        )
+    }
+
+    func testBuildPackageWithStandaloneExecutableTarget() async throws {
+        let runner = Runner(
+            mode: .createPackage,
+            options: .init(
+                // Dynamic linking so a stray -framework flag for the pruned executable
+                // dependency fails this test at link time.
+                baseBuildOptions: .init(frameworkType: .dynamic),
+                shouldOnlyUseVersionsFromResolvedFile: true
+            )
+        )
+        do {
+            try await runner.run(packageDirectory: packageWithStandaloneExecutableTargetPath,
+                                 frameworkOutputDir: .custom(frameworkOutputDir))
+        } catch {
+            XCTFail("Build should be succeeded. \(error.localizedDescription)")
+        }
+
+        XCTAssertTrue(
+            fileManager.fileExists(atPath: frameworkOutputDir.appendingPathComponent("MyLib.xcframework").path),
+            "MyLib.xcframework should be produced"
+        )
+        XCTAssertFalse(
+            fileManager.fileExists(atPath: frameworkOutputDir.appendingPathComponent("HelperTool.xcframework").path),
+            "HelperTool.xcframework should not be produced for a pruned executable target"
         )
     }
 

--- a/Tests/ScipioKitTests/RunnerTests.swift
+++ b/Tests/ScipioKitTests/RunnerTests.swift
@@ -16,6 +16,7 @@ private let clangPackageWithSymbolicLinkHeadersPath = fixturePath.appendingPathC
 private let clangPackageWithCustomModuleMapPath = fixturePath.appendingPathComponent("ClangPackageWithCustomModuleMap")
 private let clangPackageWithUmbrellaDirectoryPath = fixturePath.appendingPathComponent("ClangPackageWithUmbrellaDirectory")
 private let clangPackageWithInterdependentHeadersPath = fixturePath.appendingPathComponent("ClangPackageWithInterdependentHeaders")
+private let packageWithSystemLibraryTargetPath = fixturePath.appendingPathComponent("PackageWithSystemLibraryTarget")
 
 private struct InfoPlist: Decodable {
     var bundleVersion: String
@@ -257,6 +258,117 @@ final class RunnerTests: XCTestCase {
             "-F", coreLibSlice.path,
             "-fsyntax-only",
             "-x", "c", consumerSource.path,
+        ])
+        XCTAssertEqual(
+            compile.status, 0,
+            "Consumer should compile using only -F (framework search). Output:\n\(compile.output)"
+        )
+    }
+
+    func testBuildPackageWithSystemLibraryTarget() async throws {
+        let runner = Runner(
+            mode: .createPackage,
+            options: .init(
+                // Dynamic linking (explicitly, not by default) so a missing system-module skip in
+                // PIFGenerator's linker-flag injection fails this test with `framework not found`.
+                baseBuildOptions: .init(
+                    isSimulatorSupported: true,
+                    frameworkType: .dynamic,
+                    keepPublicHeadersStructure: true
+                ),
+                shouldOnlyUseVersionsFromResolvedFile: true
+            )
+        )
+        do {
+            try await runner.run(packageDirectory: packageWithSystemLibraryTargetPath,
+                                 frameworkOutputDir: .custom(frameworkOutputDir))
+        } catch {
+            XCTFail("Build should be succeeded. \(error.localizedDescription)")
+        }
+
+        for xcFrameworkName in ["MainLib.xcframework", "CoreLib.xcframework", "SysShim.xcframework"] {
+            XCTAssertTrue(
+                fileManager.fileExists(atPath: frameworkOutputDir.appendingPathComponent(xcFrameworkName).path),
+                "\(xcFrameworkName) should be produced"
+            )
+        }
+
+        let sysShimFramework = frameworkOutputDir
+            .appendingPathComponent("SysShim.xcframework")
+            .appendingPathComponent("ios-arm64")
+            .appendingPathComponent("SysShim.framework")
+
+        XCTAssertTrue(
+            fileManager.fileExists(atPath: sysShimFramework.appendingPathComponent("SysShim").path),
+            "The framework should contain the stub binary"
+        )
+        XCTAssertTrue(
+            fileManager.fileExists(atPath: sysShimFramework.appendingPathComponent("Info.plist").path),
+            "The framework should contain a generated Info.plist"
+        )
+
+        // The simulator stub merges one object per architecture into a single archive.
+        let simulatorStubPath = frameworkOutputDir
+            .appendingPathComponent("SysShim.xcframework")
+            .appendingPathComponent("ios-arm64_x86_64-simulator")
+            .appendingPathComponent("SysShim.framework/SysShim")
+            .path
+        let lipoInfo = try runProcess("/usr/bin/xcrun", ["lipo", "-info", simulatorStubPath])
+        XCTAssertEqual(lipoInfo.status, 0, "The simulator slice should contain a stub binary")
+        XCTAssertTrue(
+            lipoInfo.output.contains("x86_64") && lipoInfo.output.contains("arm64"),
+            "The simulator stub should cover both architectures, got:\n\(lipoInfo.output)"
+        )
+
+        let moduleMapPath = sysShimFramework.appendingPathComponent("Modules/module.modulemap").path
+        let moduleMapContents = try XCTUnwrap(
+            fileManager.contents(atPath: moduleMapPath).flatMap { String(decoding: $0, as: UTF8.self) }
+        )
+        XCTAssertTrue(
+            moduleMapContents.contains("framework module SysShim"),
+            "The module map should declare a framework module, got:\n\(moduleMapContents)"
+        )
+
+        let shimHeaderPath = sysShimFramework.appendingPathComponent("Headers/shim.h").path
+        let shimHeaderContents = try XCTUnwrap(
+            fileManager.contents(atPath: shimHeaderPath).flatMap { String(decoding: $0, as: UTF8.self) }
+        )
+        XCTAssertTrue(
+            shimHeaderContents.contains("#include <CoreLib/core/core.h>"),
+            "Angle-bracket include should be rewritten to framework form, got:\n\(shimHeaderContents)"
+        )
+        XCTAssertFalse(
+            shimHeaderContents.contains("#include <core/core.h>"),
+            "Original non-framework include should be gone"
+        )
+
+        // Importing the Swift module that itself imports the system-library module must resolve
+        // with only -F: the consumer-side `missing required module` failure this PR removes.
+        let sdkPath = try runProcess("/usr/bin/xcrun", ["--sdk", "iphoneos", "--show-sdk-path"])
+        XCTAssertEqual(sdkPath.status, 0, "Should resolve the iphoneos SDK path")
+
+        let consumerSource = tempDir.appendingPathComponent("system_library_consumer.swift")
+        try """
+        import MainLib
+        import SysShim
+
+        func consumerValue() -> sys_shim_value_t {
+            mainLibValue()
+        }
+
+        """.write(to: consumerSource, atomically: true, encoding: .utf8)
+        defer { try? fileManager.removeItem(at: consumerSource) }
+
+        let frameworkSearchPaths = ["MainLib", "CoreLib", "SysShim"].flatMap { name in
+            ["-F", frameworkOutputDir.appendingPathComponent("\(name).xcframework/ios-arm64").path]
+        }
+        let compile = try runProcess("/usr/bin/xcrun", [
+            "--sdk", "iphoneos", "swiftc",
+            "-typecheck",
+            "-target", "arm64-apple-ios12.0",
+            "-sdk", sdkPath.output.trimmingCharacters(in: .whitespacesAndNewlines),
+        ] + frameworkSearchPaths + [
+            consumerSource.path,
         ])
         XCTAssertEqual(
             compile.status, 0,

--- a/Tests/ScipioKitTests/SystemLibraryPackagerTests.swift
+++ b/Tests/ScipioKitTests/SystemLibraryPackagerTests.swift
@@ -25,7 +25,8 @@ struct SystemLibraryPackagerTests {
 
     private func makePackager(
         packageDirectory: URL,
-        sdks: Set<SDK>
+        sdks: Set<SDK>,
+        customFrameworkModuleMapContents: Data? = nil
     ) async throws -> (packager: SystemLibraryPackager, buildProducts: [String: BuildProduct]) {
         let descriptionPackage = try await DescriptionPackage(
             packageDirectory: packageDirectory,
@@ -42,7 +43,7 @@ struct SystemLibraryPackagerTests {
             extraBuildParameters: nil,
             enableLibraryEvolution: false,
             keepPublicHeadersStructure: false,
-            customFrameworkModuleMapContents: nil,
+            customFrameworkModuleMapContents: customFrameworkModuleMapContents,
             stripStaticDWARFSymbols: false
         )
         let packager = SystemLibraryPackager(
@@ -80,6 +81,39 @@ struct SystemLibraryPackagerTests {
         )
         #expect(fileManager.fileExists(atPath: catalystFramework.appendingPathComponent("SysShim").path))
         #expect(fileManager.fileExists(atPath: catalystFramework.appendingPathComponent("Modules/module.modulemap").path))
+    }
+
+    @Test
+    func honorsCustomFrameworkModuleMapContents() async throws {
+        let packageDirectory = try makeTemporaryFixture(named: "PackageWithSystemLibraryTarget")
+        defer { try? fileManager.removeItem(at: packageDirectory.deletingLastPathComponent()) }
+        let customContents = """
+        framework module SysShim {
+            header "shim.h"
+            export *
+        }
+        """
+        let (packager, buildProducts) = try await makePackager(
+            packageDirectory: packageDirectory,
+            sdks: [.iOS],
+            customFrameworkModuleMapContents: Data(customContents.utf8)
+        )
+        let sysShim = try #require(buildProducts["SysShim"])
+
+        let outputDirectory = packageDirectory.appendingPathComponent("XCFrameworks")
+        try await packager.createXCFramework(
+            buildProduct: sysShim,
+            outputDirectory: outputDirectory,
+            overwrite: false
+        )
+
+        let moduleMapPath = outputDirectory.appendingPathComponent(
+            "SysShim.xcframework/ios-arm64/SysShim.framework/Modules/module.modulemap"
+        )
+        let shippedContents = try #require(
+            fileManager.contents(atPath: moduleMapPath.path).map { String(decoding: $0, as: UTF8.self) }
+        )
+        #expect(shippedContents == customContents)
     }
 
     @Test

--- a/Tests/ScipioKitTests/SystemLibraryPackagerTests.swift
+++ b/Tests/ScipioKitTests/SystemLibraryPackagerTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import ScipioKit
+
+private let fixturePath = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .appendingPathComponent("Resources")
+    .appendingPathComponent("Fixtures")
+
+struct SystemLibraryPackagerTests {
+    private let fileManager: FileManager = .default
+
+    /// Copies the fixture into a temporary directory: tests mutate the package
+    /// contents and share nothing with the in-place fixture builds.
+    private func makeTemporaryFixture(named name: String) throws -> URL {
+        let destinationRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("SystemLibraryPackagerTests")
+            .appendingPathComponent(UUID().uuidString)
+        try fileManager.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
+        let destination = destinationRoot.appendingPathComponent(name)
+        try fileManager.copyItem(at: fixturePath.appendingPathComponent(name), to: destination)
+        try? fileManager.removeItem(at: destination.appendingPathComponent(".build"))
+        return destination
+    }
+
+    private func makePackager(
+        packageDirectory: URL,
+        sdks: Set<SDK>
+    ) async throws -> (packager: SystemLibraryPackager, buildProducts: [String: BuildProduct]) {
+        let descriptionPackage = try await DescriptionPackage(
+            packageDirectory: packageDirectory,
+            mode: .createPackage,
+            resolvedPackagesCachePolicies: [],
+            onlyUseVersionsFromResolvedFile: false
+        )
+        let buildOptions = BuildOptions(
+            buildConfiguration: .release,
+            isDebugSymbolsEmbedded: false,
+            frameworkType: .static,
+            sdks: sdks,
+            extraFlags: nil,
+            extraBuildParameters: nil,
+            enableLibraryEvolution: false,
+            keepPublicHeadersStructure: false,
+            customFrameworkModuleMapContents: nil,
+            stripStaticDWARFSymbols: false
+        )
+        let packager = SystemLibraryPackager(
+            descriptionPackage: descriptionPackage,
+            buildOptions: buildOptions,
+            keepPublicHeadersStructure: { _ in false }
+        )
+        let buildProducts = try descriptionPackage.resolveBuildProductDependencyGraph()
+            .allNodes
+            .reduce(into: [String: BuildProduct]()) { $0[$1.value.target.name] = $1.value }
+        return (packager, buildProducts)
+    }
+
+    @Test
+    func packagesMacCatalystSlice() async throws {
+        let packageDirectory = try makeTemporaryFixture(named: "PackageWithSystemLibraryTarget")
+        defer { try? fileManager.removeItem(at: packageDirectory.deletingLastPathComponent()) }
+        let (packager, buildProducts) = try await makePackager(
+            packageDirectory: packageDirectory,
+            sdks: [.macCatalyst]
+        )
+        let sysShim = try #require(buildProducts["SysShim"])
+
+        let outputDirectory = packageDirectory.appendingPathComponent("XCFrameworks")
+        try await packager.createXCFramework(
+            buildProduct: sysShim,
+            outputDirectory: outputDirectory,
+            overwrite: false
+        )
+
+        // The slice must be identified as Mac Catalyst, not macOS: the stub is
+        // compiled against the macOS SDK but marked with the macabi target triple.
+        let catalystFramework = outputDirectory.appendingPathComponent(
+            "SysShim.xcframework/ios-arm64_x86_64-maccatalyst/SysShim.framework"
+        )
+        #expect(fileManager.fileExists(atPath: catalystFramework.appendingPathComponent("SysShim").path))
+        #expect(fileManager.fileExists(atPath: catalystFramework.appendingPathComponent("Modules/module.modulemap").path))
+    }
+
+    @Test
+    func throwsWhenModuleMapIsMissing() async throws {
+        let packageDirectory = try makeTemporaryFixture(named: "PackageWithSystemLibraryTarget")
+        defer { try? fileManager.removeItem(at: packageDirectory.deletingLastPathComponent()) }
+        let (packager, buildProducts) = try await makePackager(
+            packageDirectory: packageDirectory,
+            sdks: [.iOS]
+        )
+        let sysShim = try #require(buildProducts["SysShim"])
+
+        try fileManager.removeItem(
+            at: packageDirectory.appendingPathComponent("Sources/SysShim/module.modulemap")
+        )
+
+        await #expect {
+            try await packager.createXCFramework(
+                buildProduct: sysShim,
+                outputDirectory: packageDirectory.appendingPathComponent("XCFrameworks"),
+                overwrite: false
+            )
+        } throws: { error in
+            guard case SystemLibraryPackager.Error.moduleMapNotFound = error else { return false }
+            return true
+        }
+    }
+
+    @Test
+    func throwsForNonSystemModuleType() async throws {
+        let packageDirectory = try makeTemporaryFixture(named: "PackageWithSystemLibraryTarget")
+        defer { try? fileManager.removeItem(at: packageDirectory.deletingLastPathComponent()) }
+        let (packager, buildProducts) = try await makePackager(
+            packageDirectory: packageDirectory,
+            sdks: [.iOS]
+        )
+        let coreLib = try #require(buildProducts["CoreLib"])
+
+        await #expect {
+            try await packager.createXCFramework(
+                buildProduct: coreLib,
+                outputDirectory: packageDirectory.appendingPathComponent("XCFrameworks"),
+                overwrite: false
+            )
+        } throws: { error in
+            guard case SystemLibraryPackager.Error.unexpectedModuleType = error else { return false }
+            return true
+        }
+    }
+}

--- a/Tests/ScipioKitTests/TestUtilities/ResolvedGraphFixtures.swift
+++ b/Tests/ScipioKitTests/TestUtilities/ResolvedGraphFixtures.swift
@@ -26,7 +26,7 @@ enum ResolvedGraphFixtures {
         )
     }
 
-    static func target(name: String) throws -> Target {
+    static func target(name: String, type: String = "regular") throws -> Target {
         try decode(
             Target.self,
             fromObject: [
@@ -36,7 +36,7 @@ enum ResolvedGraphFixtures {
                 "exclude": [Any](),
                 "dependencies": [Any](),
                 "settings": [Any](),
-                "type": "regular",
+                "type": type,
             ]
         )
     }
@@ -68,12 +68,13 @@ enum ResolvedGraphFixtures {
 
     static func resolvedModule(
         name: String,
+        targetType: String = "regular",
         packageID: PackageID? = nil,
         dependencies: [ResolvedModule.Dependency] = [],
         resolvedModuleType: ResolvedModuleType = .swift
     ) throws -> ResolvedModule {
         ResolvedModule(
-            underlying: try target(name: name),
+            underlying: try target(name: name, type: targetType),
             dependencies: dependencies,
             localPackageURL: URL(filePath: "/tmp/example-package"),
             packageID: packageID ?? Self.packageID(),


### PR DESCRIPTION
## Summary

SwiftPM's `.systemLibrary` targets carry a module map and optional headers and have nothing to compile:

```
Sources/SysShim/
├── module.modulemap
└── shim.h              // #include <core/core.h>
```

SwiftPM exposes such modules to importers through injected search paths, which only resolve while the package sources are on disk. Prebuilt-framework consumers only get `-F`, so today the producer dies with `fatalError("Unexpected target type")`, and even if it skipped the target, `import SysShim` in consumers would fail with `missing required module 'SysShim'`.

This PR packages system-library targets as header-only frameworks, so the module resolves through the framework search paths consumers already have:

```
SysShim.xcframework/ios-arm64/SysShim.framework/
├── SysShim                    // stub binary; XCFramework creation requires one
├── Headers/shim.h             // #include <CoreLib/core/core.h>, rewritten by #278
├── Modules/module.modulemap   // framework module SysShim { ... }
└── Info.plist
```

## Behavior

- `pkgConfig` declarations log a warning instead of failing: shim-style modules still resolve through the SDK and autolinking.
- Linking dynamic frameworks no longer injects `-framework` for dependencies that produce no linkable framework: system modules resolve through the SDK, and non-producible targets build no product. Generated module maps' `link framework` sections follow the same rule.
- Targets that cannot produce a framework (executables, macros, plugins, tests) are pruned from the build-product graph together with dependencies reachable only through them. Such graphs previously crashed with `fatalError("Unexpected target type")`.
- Resolved-packages caches written before system-library support are discarded on restore.
- Discovery is through importer edges; a system-library target reachable only as a product member stays out of scope, unchanged from current behavior.

## Testing

- Unit tests cover the resolution shape, module map conversion below leading comments, cache staleness, the snapshot round-trip, and the generated Info.plist.
- An end-to-end test compiles a consumer importing the system-library module against the produced frameworks using only `-F`: the `missing required module` failure this PR removes.
- Unit tests cover the graph pruning and the linkable-dependency walk; an end-to-end test builds a dynamic framework whose library depends on an executable target. Custom module map contents are covered for system-library targets.

