### PR TITLE
Bump PackageManifestKit to 0.3 and decode manifest traits directly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git",
                  from: "5.0.2"),
         .package(url: "https://github.com/giginet/PackageManifestKit",
-                 from: "0.2.0"),
+                 from: "0.3.0"),
         .package(url: "https://github.com/mtj0928/swift-async-operations.git",
                  from: "0.5.0"),
     ],

--- a/Sources/ScipioKit/Resolver/ManifestLoader.swift
+++ b/Sources/ScipioKit/Resolver/ManifestLoader.swift
@@ -44,24 +44,7 @@ struct ManifestLoader: @unchecked Sendable {
             throw Error.utf8EncodingFailed
         }
 
-        return try decodeManifest(from: manifestData)
-    }
-
-    // PackageManifestKit 0.2.0 expects Manifest.traits as [String]?, but SwiftPM 6.1+
-    // dump-package emits trait objects. Since Scipio does not read top-level traits,
-    // decode directly and, only on failure, drop the field and retry. Remove once
-    // PackageManifestKit models Manifest.traits as [TraitDescription]?.
-    private func decodeManifest(from data: Data) throws -> Manifest {
-        do {
-            return try jsonDecoder.decode(Manifest.self, from: data)
-        } catch {
-            guard var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  object["traits"] != nil else {
-                throw error
-            }
-            object["traits"] = nil
-            return try jsonDecoder.decode(Manifest.self, from: JSONSerialization.data(withJSONObject: object))
-        }
+        return try jsonDecoder.decode(Manifest.self, from: manifestData)
     }
 
     enum Error: LocalizedError {

--- a/Tests/ScipioKitTests/ManifestLoaderTests.swift
+++ b/Tests/ScipioKitTests/ManifestLoaderTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 struct ManifestLoaderTests {
     // A minimal dump-package payload whose top-level `traits` is the SwiftPM 6.1
-    // object form. PackageManifestKit models Manifest.traits as [String]?, so this
-    // fails to decode unless ManifestLoader strips the field first.
+    // object form, decoded via PackageManifestKit's TraitDescription model.
     private static let manifestWithObjectFormTraits = """
     {
       "name": "MyFramework",
@@ -21,7 +20,7 @@ struct ManifestLoaderTests {
     }
     """
 
-    // Same manifest without a `traits` key: exercises the strip no-op path.
+    // Same manifest without a `traits` key.
     private static let manifestWithoutTraits = """
     {
       "name": "MyFramework",
@@ -43,6 +42,10 @@ struct ManifestLoaderTests {
         let manifest = try await loader.loadManifest(for: URL(filePath: "/tmp/MyFramework"))
 
         #expect(manifest.name == "MyFramework")
+        let traits = try #require(manifest.traits)
+        #expect(traits.map(\.name) == ["default", "Foo"])
+        #expect(traits[0].enabledTraits == ["Foo"])
+        #expect(traits[1].description == "bar")
     }
 
     @Test


### PR DESCRIPTION
## Summary

PackageManifestKit 0.3.0 models `Manifest.traits` as `[TraitDescription]?` (giginet/PackageManifestKit#3), so the strip-and-retry workaround introduced in #277 is no longer needed: manifests declaring SwiftPM 6.1 trait objects now decode directly.

The version floor moves to 0.3.0, since decoding such manifests requires the new model.

## Testing

- The existing traits test now asserts the decoded `TraitDescription` values field by field, instead of only tolerating the key
- Full suite green locally